### PR TITLE
Refactor image loading and improve configuration defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@ OLLAMA_MODEL=llama3.1
 OLLAMA_EMBED_MODEL=nomic-embed-text
 
 # API Configuration
-RAG_BRAIN_HOST=0.0.0.0
+# Bind to localhost by default; use 0.0.0.0 only for authenticated deployments behind network controls
+RAG_BRAIN_HOST=127.0.0.1
 RAG_BRAIN_PORT=8000
 
 # Vector Store Configuration

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@ OLLAMA_MODEL=llama3.1
 OLLAMA_EMBED_MODEL=nomic-embed-text
 
 # API Configuration
-# Bind to localhost by default; use 0.0.0.0 only for authenticated deployments behind network controls
+# Bind to localhost by default. For containerized runs (Docker/Compose/K8s), set RAG_BRAIN_HOST=0.0.0.0
+# so the API is reachable from the host/UI container. Use 0.0.0.0 only for authenticated deployments behind network controls.
 RAG_BRAIN_HOST=127.0.0.1
 RAG_BRAIN_PORT=8000
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Requires Ollama running locally. Pull models before first use:
 ```bash
 ollama pull llama3.1        # default LLM
 ollama pull nomic-embed-text # optional, higher-quality embeddings
-ollama pull llava            # optional, for BMP image captioning
+ollama pull llava            # optional, for image captioning (BMP, PNG, TIF/TIFF, PGM)
 ```
 
 ## Running the Project
@@ -87,13 +87,13 @@ When adding new config fields, add to both `OpenStudioConfig` and the `load()` m
 Subclass `BaseLoader` (src/rag_brain/loaders.py), implement `load(path) -> List[Dict]`, then register the file extension in `DirectoryLoader.loaders`. Async support is free via `BaseLoader.aload()` which wraps `load()` with `asyncio.to_thread`.
 
 ### Supported file types (DirectoryLoader)
-`.txt`, `.md`, `.json`, `.tsv`, `.csv`, `.docx`, `.html`, `.pdf`, `.bmp`
+`.txt`, `.md`, `.json`, `.tsv`, `.csv`, `.docx`, `.html`, `.pdf`, `.bmp`, `.png`, `.tif`, `.tiff`, `.pgm`
 - **.txt, .md, .json, .tsv:** Text extraction via corresponding loaders
 - **.csv:** Each row becomes a document (uses text/content/body column if present)
 - **.docx:** Extracts paragraphs via `python-docx`
 - **.html:** Extracts visible text (skips script/style tags) via HTML parser
 - **.pdf:** Extracts text page-by-page using PyMuPDF (fitz) with pypdf fallback
-- **.bmp:** Uses Ollama VLM for visual captioning
+- **.bmp, .png, .tif, .tiff, .pgm:** Uses Ollama VLM for visual captioning (images normalised to PNG via Pillow before sending)
 
 ### Adding a new vector store
 Implement `_init_store()`, `add()`, and `search()` branches inside `OpenVectorStore` (src/rag_brain/main.py). Install the client as an optional extra in `setup.py`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,12 @@ repos:
           - types-requests
         args: [--ignore-missing-imports, --no-strict-optional]
 
-- repo: local
-  hooks:
-    - id: pytest-check
-      name: pytest
-      entry: pytest tests/ -x -q --no-header --override-ini="addopts="
-      language: system
-      pass_filenames: false
-      always_run: true
-      stages: [commit]
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: pytest
+        entry: pytest tests/ -x -q --no-header --override-ini="addopts="
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [commit]

--- a/QUICKREF.md
+++ b/QUICKREF.md
@@ -67,7 +67,7 @@ rag-brain-ui
 # CLI
 rag-brain "What is RAG?"
 rag-brain --ingest ./documents/
-rag-brain --query "test" --stream
+rag-brain "test" --stream
 ```
 
 ### Docker
@@ -123,7 +123,7 @@ nano .env
 ```bash
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=llama3.1
-RAG_BRAIN_HOST=0.0.0.0
+RAG_BRAIN_HOST=127.0.0.1
 RAG_BRAIN_PORT=8000
 LOG_LEVEL=INFO
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **A robust, general-purpose local RAG platform for humans and AI agents.**
 
-This project provides a fully open-source, local-first retrieval-augmented generation (RAG) system. It supports hybrid search (Vector + BM25), multimodal ingestion (BMP images), and is designed to serve as a central knowledge hub for both direct human interaction and automated agent orchestration.
+This project provides a fully open-source, local-first retrieval-augmented generation (RAG) system. It supports hybrid search (Vector + BM25), multimodal ingestion (BMP, PNG, TIF/TIFF, PGM images), and is designed to serve as a central knowledge hub for both direct human interaction and automated agent orchestration.
 
 ---
 
@@ -28,7 +28,7 @@ This project provides a fully open-source, local-first retrieval-augmented gener
 
 - **Local First:** Runs entirely on your hardware using Ollama and Sentence Transformers.
 - **Hybrid Search:** Combines semantic vector search with keyword-based BM25 for maximum precision.
-- **Multimodal Support:** Automatically captions and indexes BMP images via local Vision-Language Models (VLM).
+- **Multimodal Support:** Automatically captions and indexes BMP, PNG, TIF/TIFF, and PGM images via local Vision-Language Models (VLM).
 - **Rich Document Support:** Ingest PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, and plain text files.
 - **Agent Orchestration Ready:** Standardized FastAPI service with specialized tools for agentic reasoning and self-learning.
 - **Secure Ingestion:** Path traversal protection with configurable base directory via `RAG_INGEST_BASE`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project provides a fully open-source, local-first retrieval-augmented gener
 - **Local First:** Runs entirely on your hardware using Ollama and Sentence Transformers.
 - **Hybrid Search:** Combines semantic vector search with keyword-based BM25 for maximum precision.
 - **Multimodal Support:** Automatically captions and indexes BMP images via local Vision-Language Models (VLM).
-- **Rich Document Support:** Ingest PDF, DOCX, HTML, CSV, Markdown, JSON, and plain text files.
+- **Rich Document Support:** Ingest PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, and plain text files.
 - **Agent Orchestration Ready:** Standardized FastAPI service with specialized tools for agentic reasoning and self-learning.
 - **Secure Ingestion:** Path traversal protection with configurable base directory via `RAG_INGEST_BASE`.
 - **Async Ingestion:** High-performance asynchronous processing for directories and files.

--- a/SETUP.md
+++ b/SETUP.md
@@ -387,7 +387,7 @@ Copy the template and customize it:
 ```bash
 # config.yaml already exists in the repo root — edit it directly
 # Or copy it as a personal override
-cp config.yaml config.local.yaml
+cp config.yaml config.local.yaml  # pass --config config.local.yaml to the CLI
 ```
 
 Here are complete configurations for each tier:
@@ -464,8 +464,7 @@ rerank:
 ```yaml
 embedding:
   provider: ollama
-  model: nomic-embed-text
-  base_url: http://localhost:11434
+  model: nomic-embed-text  # Ollama uses the OLLAMA_HOST env var, not base_url
 
 llm:
   provider: ollama
@@ -518,7 +517,8 @@ OLLAMA_MODEL=llama3.1
 OLLAMA_EMBED_MODEL=nomic-embed-text
 
 # API server settings
-RAG_BRAIN_HOST=0.0.0.0
+# Bind to localhost by default; use 0.0.0.0 only for authenticated deployments behind network controls
+RAG_BRAIN_HOST=127.0.0.1
 RAG_BRAIN_PORT=8000
 
 # Where ChromaDB stores its data
@@ -568,7 +568,7 @@ curl http://localhost:8000/health
 
 Expected:
 ```json
-{"status": "ok"}
+{"status": "healthy", "brain_ready": true}
 ```
 
 ### Step 3: Ingest a test document
@@ -587,7 +587,7 @@ curl -X POST http://localhost:8000/ingest \
 
 Expected:
 ```json
-{"message": "Ingestion complete", "docs_added": 1}
+{"message": "Ingestion started for /tmp/test_doc.txt", "status": "processing"}
 ```
 
 ### Step 4: Run a test query
@@ -762,7 +762,7 @@ If the API service can't reach Ollama, check the `OLLAMA_HOST` environment varia
 | Start UI | `rag-brain-ui` or `make run-ui` |
 | Health check | `curl http://localhost:8000/health` |
 | Ingest a file | `rag-brain --ingest ./path/to/file` |
-| Run a query | `rag-brain --query "your question"` |
+| Run a query | `rag-brain "your question"` |
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -517,7 +517,7 @@ OLLAMA_MODEL=llama3.1
 OLLAMA_EMBED_MODEL=nomic-embed-text
 
 # API server settings
-# Bind to localhost by default; use 0.0.0.0 only for authenticated deployments behind network controls
+# Bind to localhost by default for local setups. For Docker/Compose deployments, set RAG_BRAIN_HOST=0.0.0.0 so the API is reachable from the host/other containers (only do this behind proper network/auth controls).
 RAG_BRAIN_HOST=127.0.0.1
 RAG_BRAIN_PORT=8000
 

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -17,7 +17,7 @@ The following features are already implemented:
 | **Embedding providers** | sentence-transformers (`all-MiniLM-L6-v2`), Ollama (`nomic-embed-text`), FastEmbed (`BAAI/bge-small-en-v1.5`) |
 | **LLM** | Ollama-backed LLM with streaming (llama3.1, qwen2.5, phi3, mistral) |
 | **Vector stores** | ChromaDB (default), Qdrant |
-| **Document formats** | PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, plain text, BMP images |
+| **Document formats** | PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, plain text, BMP/PNG/TIF/TIFF/PGM images |
 | **Multimodal** | BMP image ingestion with VLM auto-captioning (llava) |
 | **Agent interface** | FastAPI with 6 OpenAI-compatible tools |
 | **Evaluation** | RAGAS evaluation script (`scripts/evaluate.py`) |

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -17,7 +17,7 @@ The following features are already implemented:
 | **Embedding providers** | sentence-transformers (`all-MiniLM-L6-v2`), Ollama (`nomic-embed-text`), FastEmbed (`BAAI/bge-small-en-v1.5`) |
 | **LLM** | Ollama-backed LLM with streaming (llama3.1, qwen2.5, phi3, mistral) |
 | **Vector stores** | ChromaDB (default), Qdrant |
-| **Document formats** | PDF, DOCX, HTML, CSV, Markdown, JSON, plain text, BMP images |
+| **Document formats** | PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, plain text, BMP images |
 | **Multimodal** | BMP image ingestion with VLM auto-captioning (llava) |
 | **Agent interface** | FastAPI with 6 OpenAI-compatible tools |
 | **Evaluation** | RAGAS evaluation script (`scripts/evaluate.py`) |

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -195,7 +195,7 @@ async def delete_documents(request: DeleteRequest):
 
 def main():
     """Main entry point for rag-brain-api command."""
-    host = os.getenv("RAG_BRAIN_HOST", "127.0.0.1")
+    host = os.getenv("RAG_BRAIN_HOST", "0.0.0.0")
     port = int(os.getenv("RAG_BRAIN_PORT", "8000"))
     uvicorn.run(app, host=host, port=port)
 

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -195,7 +195,7 @@ async def delete_documents(request: DeleteRequest):
 
 def main():
     """Main entry point for rag-brain-api command."""
-    host = os.getenv("RAG_BRAIN_HOST", "0.0.0.0")
+    host = os.getenv("RAG_BRAIN_HOST", "127.0.0.1")
     port = int(os.getenv("RAG_BRAIN_PORT", "8000"))
     uvicorn.run(app, host=host, port=port)
 

--- a/src/rag_brain/loaders.py
+++ b/src/rag_brain/loaders.py
@@ -7,8 +7,6 @@ from pathlib import Path
 import logging
 from PIL import Image
 import io
-import base64
-
 logger = logging.getLogger("StudioBrainOpen.Loaders")
 
 class BaseLoader:
@@ -230,6 +228,7 @@ class ImageLoader(BaseLoader):
 
 # Backward-compatible alias kept for existing code that imports BMPLoader directly.
 BMPLoader = ImageLoader
+
 
 class PDFLoader(BaseLoader):
     """Loader for PDF files. Extracts text page-by-page using PyMuPDF (fitz) with pypdf fallback."""

--- a/src/rag_brain/loaders.py
+++ b/src/rag_brain/loaders.py
@@ -182,14 +182,14 @@ class ImageLoader(BaseLoader):
             self._pil = Image
         except ImportError:
             self._pil = None
-            logger.error("Pillow not installed. Image loading will fail.")
+            logger.warning("Pillow not installed. Image loading will be skipped.")
         try:
             import ollama
 
             self.ollama = ollama
         except ImportError:
             self.ollama = None
-            logger.error("ollama package not installed. Image loading will fail.")
+            logger.warning("ollama package not installed. Image loading will be skipped.")
 
     def load(self, path: str) -> List[Dict[str, Any]]:
         if self._pil is None or self.ollama is None:

--- a/src/rag_brain/loaders.py
+++ b/src/rag_brain/loaders.py
@@ -5,7 +5,6 @@ import asyncio
 from typing import List, Dict, Any, Optional
 from pathlib import Path
 import logging
-from PIL import Image
 import io
 logger = logging.getLogger("StudioBrainOpen.Loaders")
 
@@ -178,6 +177,13 @@ class ImageLoader(BaseLoader):
     def __init__(self, ollama_model: str = "llava"):
         self.ollama_model = ollama_model
         try:
+            from PIL import Image
+
+            self._pil = Image
+        except ImportError:
+            self._pil = None
+            logger.error("Pillow not installed. Image loading will fail.")
+        try:
             import ollama
 
             self.ollama = ollama
@@ -186,14 +192,14 @@ class ImageLoader(BaseLoader):
             logger.error("ollama package not installed. Image loading will fail.")
 
     def load(self, path: str) -> List[Dict[str, Any]]:
-        if self.ollama is None:
+        if self._pil is None or self.ollama is None:
             return []
 
         logger.info(f"🖼️ Processing image: {path} with {self.ollama_model}...")
 
         try:
             # Normalize to PNG bytes via Pillow for maximum VLM compatibility
-            img = Image.open(path).convert("RGB")
+            img = self._pil.open(path).convert("RGB")
             buf = io.BytesIO()
             img.save(buf, format="PNG")
             image_data = buf.getvalue()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -237,7 +237,8 @@ def test_search_uses_custom_top_k():
     api_module.brain.embedding = MagicMock()
     api_module.brain.embedding.embed_query.return_value = [0.0] * 384
     api_module.brain.vector_store.search.return_value = []
-    client.post("/search", json={"query": "q", "top_k": 3})
+    resp = client.post("/search", json={"query": "q", "top_k": 3})
+    assert resp.status_code == 200
     api_module.brain.vector_store.search.assert_called_once()
     _, kwargs = api_module.brain.vector_store.search.call_args
     assert kwargs.get("top_k") == 3

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -235,7 +235,9 @@ def test_pdf_loader_pypdf_fallback(tmp_path):
         from rag_brain.loaders import PDFLoader as _PDFLoader
         docs = _PDFLoader().load(str(p))
 
-    assert len(docs) >= 1 or docs == []  # graceful even if both fail
+    assert len(docs) == 1
+    assert docs[0]["text"] == "Fallback text"
+    assert docs[0]["metadata"]["type"] == "pdf"
 
 
 def test_pdf_loader_no_deps(tmp_path):


### PR DESCRIPTION
## Summary
This PR improves the robustness of image loading, updates configuration defaults for better security, and fixes various documentation inconsistencies across the project.

## Key Changes

### Source Code
- **ImageLoader refactoring** (`src/rag_brain/loaders.py`):
  - Moved PIL and ollama imports into `__init__` with graceful fallback handling
  - Store PIL as instance variable (`self._pil`) to handle missing Pillow dependency
  - Added check for both PIL and ollama availability before attempting image processing
  - Removed unused top-level imports (`base64`)
  - Extended image format support to PNG, TIF/TIFF, and PGM (in addition to BMP)

- **Configuration & Security**:
  - Changed default `RAG_BRAIN_HOST` from `0.0.0.0` to `127.0.0.1` for better security posture
  - Added clarifying comments about when to use `0.0.0.0` (authenticated deployments only)
  - Updated Ollama embedding config to use `OLLAMA_HOST` env var instead of `base_url`

- **Test improvements** (`tests/test_api.py`, `tests/test_loaders.py`):
  - Added assertion for HTTP 200 response in search endpoint test
  - Strengthened PDF loader fallback test with specific assertions on content and metadata

### Documentation & Configuration
- Updated `.pre-commit-config.yaml` indentation for consistency
- Clarified CLI usage examples (removed `--query` flag, simplified syntax)
- Updated supported file types documentation to reflect new image formats
- Corrected health check and ingestion endpoint response examples
- Updated `.env.example` and `SETUP.md` with new defaults and clarifications

## Implementation Details
- PIL and ollama imports are now lazy-loaded in `ImageLoader.__init__`, allowing the class to be instantiated even if dependencies are missing (graceful degradation)
- Image normalization to PNG via Pillow ensures maximum VLM compatibility across different input formats
- Default binding to `127.0.0.1` prevents accidental exposure of the API to the network unless explicitly configured

https://claude.ai/code/session_01QYKmqmyiqnBHRJP17sQ9kj