### PR TITLE
feat(ui): modern sidebar redesign + dynamic model lists + expanded test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,10 @@ poetry.lock
 tmp/
 temp/
 *.tmp
-test_*.py
 list_gemini_models.py
+
+# Claude Code session data
+.claude/
+
+# Runtime data
+sessions.json

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,10 @@ temp/
 *.tmp
 list_gemini_models.py
 
+# Root-level ad-hoc test scripts (not part of test suite)
+/test_*.py
+/src/test_*.py
+
 # Claude Code session data
 .claude/
 

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,12 @@
+[theme]
+base                   = "dark"
+primaryColor           = "#8b5cf6"
+backgroundColor        = "#0f0f0f"
+secondaryBackgroundColor = "#1c1c2a"
+textColor              = "#e4e4e7"
+font                   = "sans serif"
+
+[server]
+headless               = true
+enableCORS             = false
+enableXsrfProtection   = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install
+pip install -e ".[dev]"
+
+# Run services
+rag-brain "your question"          # CLI query
+rag-brain --ingest ./docs/         # CLI ingest
+rag-brain-api                      # FastAPI on :8000
+rag-brain-ui                       # Streamlit on :8501
+docker-compose up --build          # both services via Docker
+
+# Tests
+pytest tests/ -v                   # all tests
+pytest tests/test_main.py -v       # single file
+pytest tests/ -v -m "not slow"     # skip slow tests
+make test-cov                      # with coverage (htmlcov/)
+
+# Code quality
+make lint        # ruff
+make format      # black (100-char line length)
+make type-check  # mypy
+make ci          # all of the above + tests
+```
+
+## Architecture
+
+Three entry points (CLI, FastAPI, Streamlit) share one `OpenStudioBrain` instance:
+
+```
+config.yaml
+  └─► OpenStudioConfig.load()   (flattens nested YAML → dataclass fields)
+        └─► OpenStudioBrain     (src/rag_brain/main.py)
+                ├─ OpenEmbedding    → sentence_transformers / ollama / fastembed / openai
+                ├─ OpenLLM         → ollama / gemini / ollama_cloud / openai
+                ├─ OpenVectorStore → chroma (default) / qdrant
+                ├─ BM25Retriever   → rank_bm25 keyword search (src/rag_brain/retrievers.py)
+                └─ OpenReranker    → cross-encoder or LLM (optional, off by default)
+```
+
+**Query flow** (`OpenStudioBrain.query()`):
+1. Embed query → vector search via `OpenVectorStore`
+2. If `hybrid_search=true`: BM25 search → merge with `reciprocal_rank_fusion()`
+3. Filter by `similarity_threshold`, optionally rerank
+4. Build context → `OpenLLM.complete(system_prompt, chat_history)`
+
+**Ingestion flow**:
+`DirectoryLoader` (dispatches by extension) → `RecursiveCharacterTextSplitter` → `OpenVectorStore.add()` + `BM25Retriever.add()`
+
+## Key Conventions
+
+**Document schema** — used everywhere (loaders, ingest, vector store):
+```python
+{"id": str, "text": str, "metadata": dict}
+```
+Duplicate IDs silently overwrite in ChromaDB.
+
+**Config flattening** — `OpenStudioConfig.load()` maps nested YAML to flat fields:
+- `embedding.provider` → `embedding_provider`, `embedding.model` → `embedding_model`
+- `llm.provider` → `llm_provider`, `chunk.size` → `chunk_size`, `rerank.enabled` → `rerank`
+
+When adding new config fields, update both the dataclass and `load()`.
+
+**Adding a loader** — subclass `BaseLoader` in `src/rag_brain/loaders.py`, implement `load(path) -> List[Dict]`, register extension in `DirectoryLoader.loaders`. Async via `aload()` is free.
+
+**Adding a vector store** — add `_init_store()`, `add()`, `search()` branches in `OpenVectorStore` (`src/rag_brain/main.py`).
+
+**BM25 persistence** — stored as `bm25_corpus.json` (legacy `.pkl` auto-migrates on load). Corpus is rebuilt in memory on every `add_documents()` call.
+
+**ChromaDB collection** — always named `"rag_brain"` with cosine distance.
+
+**Gemma/Gemini** — Gemma models don't support `system_instruction`; handled in `OpenLLM.complete()`.
+
+## FastAPI Endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /query` | Synthesized answer (calls `brain.query()`) |
+| `POST /query/stream` | Streaming SSE answer |
+| `POST /search` | Raw chunk retrieval (no LLM) |
+| `POST /add_text` | Inject knowledge (ID: `agent_doc_<uuid8>`) |
+| `POST /delete` | Remove docs by ID: `{"doc_ids": [...]}` |
+| `POST /ingest` | Background directory ingestion |
+
+Path security: `RAG_INGEST_BASE` env var (default: cwd) restricts `/ingest` to prevent traversal.
+
+## Agent Tools
+
+`src/rag_brain/tools.py` exports `get_rag_tool_definition(api_base_url)` — 6 OpenAI-compatible tool schemas: `query_knowledge_base`, `search_documents`, `add_knowledge`, `delete_documents`, `ingest_directory`, `stream_query`. See `examples/agent_simple.py` and `examples/agent_orchestration.py`.
+
+## Branch Strategy
+
+- `main` — tagged releases only
+- `develop` — integration branch
+- `feature/<name>` / `fix/<name>` → PR to `develop`
+- `hotfix/<name>` → PR to **both** `main` and `develop`
+
+CI runs on PR: syntax check + pytest. Release triggered by `v*.*.*` tag push.
+
+> **IMPORTANT for Claude Code**: Always create and check out a feature/fix branch before making changes.
+> Never commit directly to `master` or `main`. Use `git checkout -b feature/<name>` before editing any files.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ./chroma_data:/app/chroma_data
       - ./bm25_index:/app/bm25_index
       - ./config.yaml:/app/config.yaml
+      - ./.streamlit:/app/.streamlit
     environment:
       - OLLAMA_HOST=http://ollama:11434
       - RAG_BRAIN_API_URL=http://rag-brain-api:8000

--- a/src/rag_brain/webapp.py
+++ b/src/rag_brain/webapp.py
@@ -16,12 +16,217 @@ from rag_brain.main import OpenStudioBrain, OpenStudioConfig
 logging.basicConfig(level=logging.INFO)
 
 st.set_page_config(
-    page_title="Local RAG Brain",
+    page_title="Studio Brain",
     page_icon="🧠",
-    layout="wide"
+    layout="wide",
+    initial_sidebar_state="expanded",
 )
 
+# ---------------------------------------------------------------------------
+# Custom CSS — supplements .streamlit/config.toml theme
+# The theme handles: backgrounds, text, inputs, sliders, checkboxes, buttons.
+# Here we only add what the theme system cannot express.
+# ---------------------------------------------------------------------------
+st.markdown(
+    """
+    <style>
+    /* ── Hide Streamlit chrome ── */
+    #MainMenu,
+    [data-testid="stToolbar"],
+    [data-testid="stDecoration"],
+    [data-testid="stSidebarCollapseButton"],
+    [data-testid="collapsedControl"] { display: none !important; }
+
+    /* ── Sidebar: fixed width, pinned, no collapse ── */
+    [data-testid="stSidebar"] {
+        min-width: 272px !important;
+        max-width: 272px !important;
+        border-right: 1px solid rgba(255,255,255,0.08) !important;
+    }
+    /* Tighten the default top padding */
+    [data-testid="stSidebar"] > div:first-child {
+        padding: 0.75rem 0.85rem 0.75rem !important;
+    }
+    /* Collapse vertical gaps between all sidebar elements */
+    [data-testid="stSidebar"] [data-testid="stVerticalBlock"] {
+        gap: 0.15rem !important;
+    }
+
+    /* ── Sidebar section headers ── */
+    .sb-section {
+        font-size: 0.63rem;
+        font-weight: 700;
+        letter-spacing: 0.13em;
+        text-transform: uppercase;
+        color: rgba(255,255,255,0.28);
+        margin: 10px 0 4px;
+        padding-top: 10px;
+        border-top: 1px solid rgba(255,255,255,0.07);
+    }
+
+    /* ── All sidebar buttons: list-row style ── */
+    [data-testid="stSidebar"] .stButton > button {
+        text-align: left !important;
+        justify-content: flex-start !important;
+        background: transparent !important;
+        border: none !important;
+        border-radius: 6px !important;
+        padding: 4px 8px !important;
+        min-height: 32px !important;
+        font-size: 0.83rem !important;
+        color: rgba(228,228,231,0.60) !important;
+        width: 100% !important;
+        transition: background 0.12s, color 0.12s !important;
+        box-shadow: none !important;
+    }
+    [data-testid="stSidebar"] .stButton > button:hover {
+        background: rgba(255,255,255,0.06) !important;
+        color: rgba(228,228,231,0.92) !important;
+        transform: none !important;
+        box-shadow: none !important;
+    }
+
+    /* ── Active session: primary button styled as highlighted row ── */
+    [data-testid="stSidebar"] .stButton > button[kind="primary"] {
+        background: rgba(139,92,246,0.18) !important;
+        border-left: 2px solid #a78bfa !important;
+        border-radius: 0 6px 6px 0 !important;
+        color: #e4e4e7 !important;
+        font-weight: 500 !important;
+        padding-left: 6px !important;
+    }
+    [data-testid="stSidebar"] .stButton > button[kind="primary"]:hover {
+        background: rgba(139,92,246,0.25) !important;
+    }
+
+    /* ── New Chat: secondary button gets a subtle outline ── */
+    [data-testid="stSidebar"] .stButton > button[kind="secondary"] {
+        background: rgba(139,92,246,0.12) !important;
+        border: 1px solid rgba(139,92,246,0.35) !important;
+        border-radius: 7px !important;
+        color: #c4b5fd !important;
+        font-weight: 600 !important;
+        justify-content: center !important;
+        font-size: 0.83rem !important;
+        min-height: 34px !important;
+    }
+    [data-testid="stSidebar"] .stButton > button[kind="secondary"]:hover {
+        background: rgba(139,92,246,0.22) !important;
+        border-color: rgba(139,92,246,0.55) !important;
+        color: #ddd6fe !important;
+    }
+
+    /* ── Small action buttons (Clear, Delete) ── */
+    [data-testid="stSidebar"] .stButton > button[kind="tertiary"] {
+        font-size: 0.75rem !important;
+        color: rgba(228,228,231,0.40) !important;
+        padding: 2px 6px !important;
+        min-height: 26px !important;
+        justify-content: center !important;
+    }
+    [data-testid="stSidebar"] .stButton > button[kind="tertiary"]:hover {
+        color: rgba(228,228,231,0.80) !important;
+        background: rgba(255,255,255,0.05) !important;
+    }
+
+    /* ── Sidebar widget labels — compact, muted ── */
+    [data-testid="stSidebar"] label,
+    [data-testid="stSidebar"] .stWidgetLabel p {
+        font-size: 0.77rem !important;
+        color: rgba(228,228,231,0.50) !important;
+        margin-bottom: 2px !important;
+    }
+
+    /* ── Sidebar expanders ── */
+    [data-testid="stSidebar"] [data-testid="stExpander"] {
+        border: none !important;
+        background: transparent !important;
+    }
+    [data-testid="stSidebar"] [data-testid="stExpander"] summary {
+        font-size: 0.75rem !important;
+        font-weight: 600 !important;
+        color: rgba(228,228,231,0.45) !important;
+        padding: 3px 0 !important;
+    }
+    [data-testid="stSidebar"] [data-testid="stExpander"] summary:hover {
+        color: rgba(228,228,231,0.85) !important;
+    }
+
+    /* ── Chat messages — card style ── */
+    [data-testid="stChatMessage"] {
+        border: 1px solid rgba(255,255,255,0.06) !important;
+        border-radius: 10px !important;
+        padding: 12px 16px !important;
+        margin-bottom: 8px !important;
+        background: rgba(255,255,255,0.02) !important;
+    }
+    [data-testid="stChatMessage"] p { line-height: 1.7 !important; }
+
+    /* ── Code colour ── */
+    code { color: #a78bfa !important; }
+
+    /* ── Custom scrollbar ── */
+    ::-webkit-scrollbar { width: 4px; height: 4px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: #3f3f46; border-radius: 3px; }
+    ::-webkit-scrollbar-thumb:hover { background: #71717a; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+# ---------------------------------------------------------------------------
+# Fallback model lists
+# ---------------------------------------------------------------------------
+_FALLBACK_GEMINI_MODELS = [
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
+    "gemma-3-27b-it",
+    "gemma-3-12b-it",
+    "gemma-3-4b-it",
+]
+
+
+@st.cache_data(ttl=3600)
+def _list_gemini_models(api_key: str) -> list:
+    """Fetch available Gemini/Gemma models via google.generativeai. Cached 1 h."""
+    if not api_key:
+        return _FALLBACK_GEMINI_MODELS
+    try:
+        import google.generativeai as genai
+
+        genai.configure(api_key=api_key)
+        models = [
+            m.name.replace("models/", "")
+            for m in genai.list_models()
+            if "generateContent" in m.supported_generation_methods
+        ]
+        return sorted(models) if models else _FALLBACK_GEMINI_MODELS
+    except Exception:
+        return _FALLBACK_GEMINI_MODELS
+
+
+def _list_ollama_cloud_models(cloud_key: str, cloud_url: str) -> list:
+    """Fetch models from the Ollama Cloud endpoint."""
+    try:
+        import httpx
+
+        headers = {"Authorization": f"Bearer {cloud_key}"}
+        resp = httpx.get(f"{cloud_url}/tags", headers=headers, timeout=8.0)
+        resp.raise_for_status()
+        data = resp.json()
+        return [m["name"] for m in data.get("models", [])]
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Session persistence
+# ---------------------------------------------------------------------------
 SESSIONS_FILE = "sessions.json"
+
 
 def load_sessions():
     if os.path.exists(SESSIONS_FILE):
@@ -32,14 +237,18 @@ def load_sessions():
             return {}
     return {}
 
+
 def save_sessions(sessions_dict):
     with open(SESSIONS_FILE, "w", encoding="utf-8") as f:
         json.dump(sessions_dict, f, indent=4)
 
-# Initialize Session State
+
+# ---------------------------------------------------------------------------
+# Initialize session state
+# ---------------------------------------------------------------------------
 if "sessions" not in st.session_state:
     st.session_state.sessions = load_sessions()
-    
+
     if not st.session_state.sessions:
         default_id = str(uuid.uuid4())
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
@@ -47,7 +256,7 @@ if "sessions" not in st.session_state:
             default_id: {
                 "name": f"Session {timestamp}",
                 "messages": [],
-                "created_at": timestamp
+                "created_at": timestamp,
             }
         }
         st.session_state.current_session_id = default_id
@@ -59,264 +268,311 @@ if "current_session_id" not in st.session_state:
         st.session_state.current_session_id = list(st.session_state.sessions.keys())[-1]
 
 if "brain" not in st.session_state:
-    with st.spinner("Initializing Brain..."):
+    with st.spinner("Initializing Brain…"):
         st.session_state.brain = OpenStudioBrain()
+
+if "confirm_clear" not in st.session_state:
+    st.session_state.confirm_clear = False
 
 current_session_id = st.session_state.current_session_id
 current_session = st.session_state.sessions[current_session_id]
 messages = current_session["messages"]
 
+# ---------------------------------------------------------------------------
 # Sidebar
+# ---------------------------------------------------------------------------
 with st.sidebar:
-    st.title("💬 Chat Sessions")
-    
-    # Session Management UI
-    session_options = {sid: sess["name"] for sid, sess in st.session_state.sessions.items()}
-    
-    selected_session = st.selectbox(
-        "Select Session",
-        options=list(session_options.keys()),
-        format_func=lambda x: session_options[x],
-        index=list(session_options.keys()).index(current_session_id)
-    )
-    
-    if selected_session != current_session_id:
-        st.session_state.current_session_id = selected_session
-        st.rerun()
-        
-    col1, col2 = st.columns(2)
-    with col1:
-        if st.button("➕ New Session", use_container_width=True):
-            new_id = str(uuid.uuid4())
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-            st.session_state.sessions[new_id] = {
-                "name": f"Session {timestamp}",
-                "messages": [],
-                "created_at": timestamp
-            }
-            save_sessions(st.session_state.sessions)
-            st.session_state.current_session_id = new_id
-            st.rerun()
-            
-    with col2:
-        if st.button("🗑️ Delete", use_container_width=True):
-            if len(st.session_state.sessions) > 1:
-                del st.session_state.sessions[current_session_id]
-                save_sessions(st.session_state.sessions)
-                st.session_state.current_session_id = list(st.session_state.sessions.keys())[-1]
-                st.rerun()
-            else:
-                st.warning("Cannot delete the last session.")
-                
-    st.divider()
-
-    st.title("⚙️ Settings")
-    
     config = st.session_state.brain.config
-    
-    st.subheader("RAG Parameters")
-    config.top_k = st.slider("Top K", 1, 20, config.top_k)
-    config.similarity_threshold = st.slider("Similarity Threshold", 0.0, 1.0, config.similarity_threshold)
-    config.hybrid_search = st.checkbox("Enable Hybrid Search", config.hybrid_search)
-    config.discussion_fallback = st.checkbox("Enable Discussion Fallback", config.discussion_fallback)
-    
-    st.subheader("LLM Parameters")
-    llm_providers = ["ollama", "gemini", "ollama_cloud", "openai"]
-    config.llm_provider = st.selectbox("LLM Provider", llm_providers, index=llm_providers.index(config.llm_provider) if config.llm_provider in llm_providers else 0)
-    
+
+    # ── App title ──
+    st.markdown(
+        '<div style="font-size:1rem;font-weight:700;color:#e4e4e7;margin-bottom:8px;">🧠 Studio Brain</div>',
+        unsafe_allow_html=True,
+    )
+
+    # ── CONVERSATIONS ──
+    st.markdown('<div class="sb-section">Conversations</div>', unsafe_allow_html=True)
+    if st.button("＋  New Chat", use_container_width=True, type="secondary", key="new_chat"):
+        new_id = str(uuid.uuid4())
+        st.session_state.sessions[new_id] = {
+            "name": "New Chat",
+            "messages": [],
+            "created_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
+        }
+        save_sessions(st.session_state.sessions)
+        st.session_state.current_session_id = new_id
+        st.rerun()
+
+    # Session list — newest first, one button per session
+    for sid, sess in reversed(list(st.session_state.sessions.items())):
+        label = sess["name"] if len(sess["name"]) <= 27 else sess["name"][:24] + "…"
+        is_active = sid == current_session_id
+        btn_type = "primary" if is_active else "tertiary"
+        if st.button(label, use_container_width=True, type=btn_type, key=f"sess_{sid}"):
+            if not is_active:
+                st.session_state.current_session_id = sid
+                st.rerun()
+
+    # Active session actions (always below session list, compact)
+    if st.session_state.confirm_clear:
+        st.caption("Clear all messages?")
+        ca, cb = st.columns(2)
+        if ca.button("Yes", use_container_width=True, type="tertiary", key="confirm_yes"):
+            st.session_state.sessions[current_session_id]["messages"] = []
+            save_sessions(st.session_state.sessions)
+            st.session_state.confirm_clear = False
+            st.rerun()
+        if cb.button("No", use_container_width=True, type="tertiary", key="confirm_no"):
+            st.session_state.confirm_clear = False
+            st.rerun()
+    else:
+        ac1, ac2 = st.columns(2)
+        with ac1:
+            if st.button("🧹 Clear", use_container_width=True, type="tertiary", key="clear_chat"):
+                st.session_state.confirm_clear = True
+                st.rerun()
+        with ac2:
+            if st.button("🗑 Delete", use_container_width=True, type="tertiary", key="delete_sess"):
+                if len(st.session_state.sessions) > 1:
+                    del st.session_state.sessions[current_session_id]
+                    save_sessions(st.session_state.sessions)
+                    st.session_state.current_session_id = list(st.session_state.sessions.keys())[-1]
+                    st.rerun()
+                else:
+                    st.warning("Cannot delete the only session.")
+
+    # ── MODEL ──
+    st.markdown('<div class="sb-section">Model</div>', unsafe_allow_html=True)
+
+    provider_labels = {
+        "ollama": "🤖 Ollama (local)",
+        "gemini": "✨ Gemini",
+        "ollama_cloud": "☁️ Ollama Cloud",
+        "openai": "🔑 OpenAI-compatible",
+    }
+    llm_providers = list(provider_labels.keys())
+    current_provider_idx = llm_providers.index(config.llm_provider) if config.llm_provider in llm_providers else 0
+    config.llm_provider = st.selectbox(
+        "Provider",
+        options=llm_providers,
+        format_func=lambda x: provider_labels[x],
+        index=current_provider_idx,
+        label_visibility="collapsed",
+    )
+
     if config.llm_provider == "ollama":
-        # Dynamically fetch available Ollama models
         ollama_models = []
         try:
             from ollama import Client
             client = Client(host=config.ollama_base_url)
-            models_resp = client.list()
-            ollama_models = [m.model for m in models_resp.models if not m.model.startswith("embeddinggemma")]
+            ollama_models = [m.model for m in client.list().models if not m.model.startswith("embeddinggemma")]
         except Exception:
-            ollama_models = []
-        
+            pass
         if ollama_models:
             current_idx = ollama_models.index(config.llm_model) if config.llm_model in ollama_models else 0
-            config.llm_model = st.selectbox("Local Model", ollama_models, index=current_idx)
+            config.llm_model = st.selectbox("Model", ollama_models, index=current_idx, label_visibility="collapsed")
         else:
-            config.llm_model = st.text_input("Local Model (no models found — pull one with `ollama pull`)", config.llm_model)
-            st.warning("No Ollama models detected. Pull a model first: `docker exec <ollama-container> ollama pull gemma`")
+            config.llm_model = st.text_input("Model", config.llm_model, label_visibility="collapsed", placeholder="model name")
+            st.caption("No models found — run `ollama pull <model>`")
+
     elif config.llm_provider == "gemini":
-        config.gemini_api_key = st.text_input("Gemini API Key", value=config.gemini_api_key, type="password")
-        gemini_models = [
-            "gemini-2.5-flash",
-            "gemini-2.5-pro",
-            "gemini-2.0-flash",
-            "gemini-2.0-flash-lite",
-            "gemma-3-27b-it",
-            "gemma-3-12b-it",
-            "gemma-3-4b-it"
-        ]
-        config.llm_model = st.selectbox("Gemini Model", gemini_models, index=0 if config.llm_model not in gemini_models else gemini_models.index(config.llm_model))
+        config.gemini_api_key = st.text_input("API Key", value=config.gemini_api_key, type="password", label_visibility="collapsed", placeholder="Gemini API key")
+        gemini_models = _list_gemini_models(config.gemini_api_key)
+        config.llm_model = st.selectbox(
+            "Model", gemini_models, label_visibility="collapsed",
+            index=0 if config.llm_model not in gemini_models else gemini_models.index(config.llm_model),
+        )
+
     elif config.llm_provider == "ollama_cloud":
-        config.ollama_cloud_key = st.text_input("Ollama Cloud Key", value=config.ollama_cloud_key, type="password")
-        config.llm_model = st.text_input("Ollama Cloud Model", config.llm_model)
-        
-    config.llm_temperature = st.slider("Temperature", 0.0, 1.0, config.llm_temperature)
-    
-    st.subheader("Re-ranking")
-    config.rerank = st.checkbox("Enable Re-ranking", config.rerank)
-    config.reranker_provider = st.selectbox("Re-ranking Provider", ["cross-encoder", "llm"], index=0 if config.reranker_provider == "cross-encoder" else 1)
-    
-    st.subheader("🌐 Web Search")
-    config.truth_grounding = st.checkbox("Enable Truth Grounding", config.truth_grounding,
-                                          help="Augment answers with live web results from Brave Search")
+        config.ollama_cloud_key = st.text_input("API Key", value=config.ollama_cloud_key, type="password", label_visibility="collapsed", placeholder="Ollama Cloud key")
+        col_m, col_f = st.columns([4, 1])
+        with col_m:
+            config.llm_model = st.text_input("Model", config.llm_model, label_visibility="collapsed", placeholder="model name")
+        with col_f:
+            if st.button("↻", type="tertiary", help="Fetch models from Ollama Cloud"):
+                fetched = _list_ollama_cloud_models(config.ollama_cloud_key, config.ollama_cloud_url)
+                if fetched:
+                    st.session_state["_ollama_cloud_models"] = fetched
+                    st.rerun()
+                else:
+                    st.warning("Could not fetch models.")
+        if st.session_state.get("_ollama_cloud_models"):
+            config.llm_model = st.selectbox("Available", st.session_state["_ollama_cloud_models"], label_visibility="collapsed")
+
+    elif config.llm_provider == "openai":
+        config.api_key = st.text_input("API Key", value=config.api_key, type="password", label_visibility="collapsed", placeholder="OpenAI API key")
+        config.llm_model = st.text_input("Model", config.llm_model, label_visibility="collapsed", placeholder="e.g. gpt-4o")
+
+    # ── SETTINGS ──
+    st.markdown('<div class="sb-section">Settings</div>', unsafe_allow_html=True)
+
+    # Temperature on one row with its value
+    config.llm_temperature = st.slider("Temperature", 0.0, 1.0, config.llm_temperature, step=0.05, label_visibility="collapsed")
+    st.caption(f"Temperature: {config.llm_temperature:.2f}")
+
+    # Hybrid + Web on same row
+    tc1, tc2 = st.columns(2)
+    with tc1:
+        config.hybrid_search = st.checkbox("Hybrid search", config.hybrid_search)
+    with tc2:
+        config.truth_grounding = st.checkbox("Web search", config.truth_grounding)
+
     if config.truth_grounding:
-        config.brave_api_key = st.text_input("Brave API Key", value=config.brave_api_key, type="password",
-                                              help="Get your key at https://brave.com/search/api/")
-    
-    if "ingested_files" not in st.session_state:
-        st.session_state.ingested_files = []
-        
-    st.subheader("📥 Ingest Data")
-    
-    # Show recently ingested files
-    if st.session_state.ingested_files:
-        with st.expander("Recently Ingested Files"):
-            for file_name in st.session_state.ingested_files:
-                st.text(f"✅ {file_name}")
-                
-    uploaded_file = st.file_uploader("Upload a Single File", type=["txt", "md", "pdf", "csv", "json"])
-    if uploaded_file is not None:
-        if st.button("Ingest Uploaded File"):
-            import tempfile
-            with st.spinner(f"Ingesting {uploaded_file.name}..."):
-                # Save uploaded file to a temporary location
-                with tempfile.NamedTemporaryFile(delete=False, suffix=f"_{uploaded_file.name}") as tmp_file:
-                    tmp_file.write(uploaded_file.getvalue())
-                    tmp_path = tmp_file.name
-                
-                try:
-                    from rag_brain.loaders import DirectoryLoader
-                    ext = os.path.splitext(uploaded_file.name)[1].lower()
-                    loader_mgr = DirectoryLoader()
-                    if ext in loader_mgr.loaders:
-                        docs = loader_mgr.loaders[ext].load(tmp_path)
-                        # Fix metadata source to show original filename instead of tmp path
-                        for d in docs:
-                            d["metadata"]["source"] = uploaded_file.name
-                        st.session_state.brain.ingest(docs)
-                        st.session_state.ingested_files.append(uploaded_file.name)
-                        st.success(f"Successfully ingested {uploaded_file.name}!")
-                    else:
-                        st.error(f"Unsupported file type: {ext}")
-                except Exception as e:
-                    st.error(f"Error during ingestion: {e}")
-                finally:
-                    # Clean up temp file
-                    if os.path.exists(tmp_path):
-                        os.remove(tmp_path)
-                        
-    st.markdown("---")
-    st.markdown("**Batch Upload**")
-    
-    ingest_dir = st.text_input("Directory Path", placeholder="C:/my_documents")
-    if st.button("Ingest Directory"):
-        if os.path.isdir(ingest_dir):
-            allowed_base = os.path.abspath(os.getenv("RAG_INGEST_BASE", "."))
-            abs_path = os.path.abspath(ingest_dir)
-            if not abs_path.startswith(allowed_base):
-                st.error(
-                    f"Access denied: '{abs_path}' is outside the allowed base "
-                    f"directory '{allowed_base}'. Set RAG_INGEST_BASE to change it."
-                )
-                st.stop()
-            with st.spinner(f"Ingesting {abs_path}..."):
-                import asyncio
-                asyncio.run(st.session_state.brain.load_directory(abs_path))
-                st.success("Ingestion complete!")
-        else:
-            st.error("Invalid directory path.")
-            
-    st.divider()
-    
-    if st.button("Clear Chat History (Current Session)"):
-        st.session_state.sessions[current_session_id]["messages"] = []
-        save_sessions(st.session_state.sessions)
-        st.rerun()
+        config.brave_api_key = st.text_input("Brave API Key", value=config.brave_api_key, type="password", label_visibility="collapsed", placeholder="Brave API key")
 
-# Main Chat Interface
-st.title("🧠 Local RAG Brain")
-st.caption(f"General purpose local RAG interface - **{current_session['name']}**")
+    # ── ADVANCED (collapsed) ──
+    with st.expander("⚙ Advanced"):
+        config.top_k = st.slider("Top K results", 1, 20, config.top_k)
+        config.similarity_threshold = st.slider("Similarity threshold", 0.0, 1.0, config.similarity_threshold, step=0.05)
+        config.discussion_fallback = st.checkbox("Discussion fallback", config.discussion_fallback)
+        config.rerank = st.checkbox("Re-ranking", config.rerank)
+        if config.rerank:
+            config.reranker_provider = st.selectbox(
+                "Re-ranker", ["cross-encoder", "llm"],
+                index=0 if config.reranker_provider == "cross-encoder" else 1,
+            )
 
-# Display chat messages
+    # ── DOCUMENTS (collapsed) ──
+    with st.expander("📥 Documents"):
+        if "ingested_files" not in st.session_state:
+            st.session_state.ingested_files = []
+        if st.session_state.ingested_files:
+            st.caption("Recent: " + ", ".join(f"`{f}`" for f in st.session_state.ingested_files[-3:]))
+
+        uploaded_file = st.file_uploader("File", type=["txt", "md", "pdf", "csv", "json"], label_visibility="collapsed")
+        if uploaded_file is not None:
+            if st.button("⬆ Ingest", use_container_width=True, type="tertiary"):
+                import tempfile
+                with st.spinner(f"Ingesting {uploaded_file.name}…"):
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=f"_{uploaded_file.name}") as tmp_file:
+                        tmp_file.write(uploaded_file.getvalue())
+                        tmp_path = tmp_file.name
+                    try:
+                        from rag_brain.loaders import DirectoryLoader
+                        ext = os.path.splitext(uploaded_file.name)[1].lower()
+                        loader_mgr = DirectoryLoader()
+                        if ext in loader_mgr.loaders:
+                            docs = loader_mgr.loaders[ext].load(tmp_path)
+                            for d in docs:
+                                d["metadata"]["source"] = uploaded_file.name
+                            st.session_state.brain.ingest(docs)
+                            st.caption(f"✅ {len(docs)} chunk(s) ingested")
+                            st.session_state.ingested_files.append(uploaded_file.name)
+                        else:
+                            st.error(f"Unsupported file type: {ext}")
+                    except Exception as e:
+                        st.error(f"Ingestion error: {e}")
+                    finally:
+                        if os.path.exists(tmp_path):
+                            os.remove(tmp_path)
+
+        ingest_dir = st.text_input("Directory", placeholder="/my/docs", label_visibility="collapsed")
+        if st.button("📂 Ingest Directory", use_container_width=True, type="tertiary"):
+            if os.path.isdir(ingest_dir):
+                allowed_base = os.path.abspath(os.getenv("RAG_INGEST_BASE", "."))
+                abs_path = os.path.abspath(ingest_dir)
+                if not abs_path.startswith(allowed_base):
+                    st.error(f"Access denied: path outside allowed base '{allowed_base}'.")
+                    st.stop()
+                with st.spinner(f"Ingesting {abs_path}…"):
+                    import asyncio
+                    asyncio.run(st.session_state.brain.load_directory(abs_path))
+                    st.success("Done!")
+            else:
+                st.error("Invalid directory path.")
+
+# ---------------------------------------------------------------------------
+# Main chat area
+# ---------------------------------------------------------------------------
+st.markdown(
+    f'<h3 style="margin:0 0 1rem;font-size:1.1rem;color:rgba(228,228,231,0.85);">'
+    f'{current_session["name"]}</h3>',
+    unsafe_allow_html=True,
+)
+
+# Display existing messages
 for message in messages:
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
         if message.get("sources"):
-             with st.expander(f"📚 Sources ({len(message['sources'])})"):
-                 for i, doc in enumerate(message['sources']):
-                     if doc.get('is_web'):
-                         st.markdown(f"**🌐 [{i+1}] [{doc.get('metadata', {}).get('title', doc['id'])}]({doc['id']})**")
-                     else:
-                         st.markdown(f"**📄 [{i+1}] ID: {doc['id']}** (Score: {doc.get('score', 0):.3f})")
-                     st.text(doc['text'][:500] + ("..." if len(doc['text']) > 500 else ""))
-                     st.divider()
+            with st.expander(f"📚 Sources ({len(message['sources'])})"):
+                for i, doc in enumerate(message["sources"]):
+                    if doc.get("is_web"):
+                        title = doc.get("metadata", {}).get("title", doc["id"])
+                        st.markdown(f"**🌐 [{i+1}] [{title}]({doc['id']})**")
+                    else:
+                        st.markdown(
+                            f"**📄 [{i+1}] `{doc['id']}`** — score: `{doc.get('score', 0):.3f}`"
+                        )
+                    st.code(
+                        doc["text"][:500] + ("…" if len(doc["text"]) > 500 else ""),
+                        language=None,
+                    )
+                    st.divider()
 
 # Chat input
-if prompt := st.chat_input("Ask me anything about your documents..."):
-    
-    # Store history snapshot (excluding the new prompt)
+if prompt := st.chat_input("Ask me anything about your documents…"):
     chat_history_snapshot = messages.copy()
-    
-    # Update Session Name based on first prompt
+
     if len(messages) == 0:
-        session_title = prompt[:25] + "..." if len(prompt) > 25 else prompt
+        session_title = prompt[:30] + ("…" if len(prompt) > 30 else "")
         st.session_state.sessions[current_session_id]["name"] = session_title
-    
-    # Add user message
-    new_user_msg = {"role": "user", "content": prompt}
-    st.session_state.sessions[current_session_id]["messages"].append(new_user_msg)
+
+    st.session_state.sessions[current_session_id]["messages"].append(
+        {"role": "user", "content": prompt}
+    )
     save_sessions(st.session_state.sessions)
-    
+
     with st.chat_message("user"):
         st.markdown(prompt)
-        
-    # Generate response
+
     with st.chat_message("assistant"):
         response_placeholder = st.empty()
         sources_placeholder = st.empty()
         full_response = ""
         sources = []
-        
-        with st.spinner("Searching and synthesizing..."):
-            # Use query_stream with injected chat history
-            for chunk in st.session_state.brain.query_stream(prompt, chat_history=chat_history_snapshot):
+
+        with st.spinner("Thinking…"):
+            for chunk in st.session_state.brain.query_stream(
+                prompt, chat_history=chat_history_snapshot
+            ):
                 if isinstance(chunk, dict) and chunk.get("type") == "sources":
                     sources = chunk.get("sources", [])
                     continue
                 full_response += chunk
                 response_placeholder.markdown(full_response + "▌")
-            
+
             response_placeholder.markdown(full_response)
-            
+
             if sources:
                 with sources_placeholder.expander(f"📚 Sources ({len(sources)})"):
                     for i, doc in enumerate(sources):
-                        if doc.get('is_web'):
-                            st.markdown(f"**🌐 [{i+1}] [{doc.get('metadata', {}).get('title', doc['id'])}]({doc['id']})**")
+                        if doc.get("is_web"):
+                            title = doc.get("metadata", {}).get("title", doc["id"])
+                            st.markdown(f"**🌐 [{i+1}] [{title}]({doc['id']})**")
                         else:
-                            st.markdown(f"**📄 [{i+1}] ID: {doc['id']}** (Score: {doc.get('score', 0):.3f})")
-                        st.text(doc['text'][:500] + ("..." if len(doc['text']) > 500 else ""))
+                            st.markdown(
+                                f"**📄 [{i+1}] `{doc['id']}`** — score: `{doc.get('score', 0):.3f}`"
+                            )
+                        st.code(
+                            doc["text"][:500] + ("…" if len(doc["text"]) > 500 else ""),
+                            language=None,
+                        )
                         st.divider()
-            
-    # Add assistant message and save
-    new_asst_msg = {"role": "assistant", "content": full_response, "sources": sources}
-    st.session_state.sessions[current_session_id]["messages"].append(new_asst_msg)
+
+    st.session_state.sessions[current_session_id]["messages"].append(
+        {"role": "assistant", "content": full_response, "sources": sources}
+    )
     save_sessions(st.session_state.sessions)
+
 
 def main_ui():
     """Entry point for studio-brain-ui command."""
     import subprocess
-    import sys
-    
+
     app_path = os.path.abspath(__file__)
     subprocess.run(["streamlit", "run", app_path])
+
 
 if __name__ == "__main__":
     pass

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -449,3 +449,51 @@ class TestDirectoryLoader:
             texts = [doc["text"] for doc in docs]
             assert "Text file content" in texts
             assert "JSON content" in texts
+
+
+# ---------------------------------------------------------------------------
+# New test: DirectoryLoader.aload()
+# ---------------------------------------------------------------------------
+
+class TestDirectoryLoaderAload:
+    """Test the async aload() method of DirectoryLoader."""
+
+    def test_aload_returns_same_as_load(self, tmp_path):
+        """aload() should return the same documents as load() for the same directory."""
+        import asyncio
+
+        (tmp_path / "hello.txt").write_text("Hello async world", encoding="utf-8")
+
+        loader = DirectoryLoader()
+        sync_docs = loader.load(str(tmp_path))
+        async_docs = asyncio.run(loader.aload(str(tmp_path)))
+
+        assert len(async_docs) == len(sync_docs)
+        sync_texts = sorted(d["text"] for d in sync_docs)
+        async_texts = sorted(d["text"] for d in async_docs)
+        assert sync_texts == async_texts
+
+    def test_aload_returns_empty_for_unknown_extensions(self, tmp_path):
+        """aload() should return [] when no supported files are found."""
+        import asyncio
+
+        (tmp_path / "ignored.xyz").write_bytes(b"binary")
+
+        loader = DirectoryLoader()
+        docs = asyncio.run(loader.aload(str(tmp_path)))
+        assert docs == []
+
+    def test_aload_multiple_files(self, tmp_path):
+        """aload() correctly gathers results from multiple files concurrently."""
+        import asyncio
+
+        (tmp_path / "a.txt").write_text("file A content", encoding="utf-8")
+        (tmp_path / "b.txt").write_text("file B content", encoding="utf-8")
+
+        loader = DirectoryLoader()
+        docs = asyncio.run(loader.aload(str(tmp_path)))
+
+        assert len(docs) == 2
+        texts = {d["text"] for d in docs}
+        assert "file A content" in texts
+        assert "file B content" in texts

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -193,11 +193,164 @@ class TestOpenLLM:
         from rag_brain.main import OpenLLM, OpenStudioConfig
         config = OpenStudioConfig(llm_provider="openai", api_key="sk-test", llm_model="gpt-4o")
         llm = OpenLLM(config)
-        
+
         # Setup mock client
         mock_client = MockOpenAI.return_value
         mock_client.chat.completions.create.return_value = MagicMock(choices=[MagicMock(message=MagicMock(content="openai resp"))])
-        
+
         result = llm.complete("hello", system_prompt="be helpful")
         assert result == "openai resp"
         assert mock_client.chat.completions.create.called
+
+
+# ---------------------------------------------------------------------------
+# New tests: HyDE, multi-query, load_directory, metrics
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestQueryTransformations:
+    def test_hyde_document_calls_llm(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hyde=False, hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.llm.complete = MagicMock(return_value="Hypothetical passage about X.")
+
+        result = brain._get_hyde_document("What is X?")
+
+        assert result == "Hypothetical passage about X."
+        brain.llm.complete.assert_called_once()
+        call_prompt = brain.llm.complete.call_args[0][0]
+        assert "What is X?" in call_prompt
+
+    def test_multi_queries_returns_original_plus_alternatives(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(multi_query=True, hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.llm.complete = MagicMock(
+            return_value="Alt query one\nAlt query two\nAlt query three"
+        )
+
+        queries = brain._get_multi_queries("original question")
+
+        # Original must always be first
+        assert queries[0] == "original question"
+        # 3 alternatives + original = 4
+        assert len(queries) == 4
+        # Whitespace stripped
+        assert all(q == q.strip() for q in queries)
+
+    def test_multi_queries_strips_numbering(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(multi_query=True, hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.llm.complete = MagicMock(
+            return_value="1. How does X work\n2. Explain X\n3. X overview"
+        )
+
+        queries = brain._get_multi_queries("original")
+        # Numbering should be stripped
+        assert not any(q[0].isdigit() for q in queries[1:])
+
+    def test_load_directory_calls_ingest(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, tmp_path
+    ):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.ingest = MagicMock()
+
+        docs = [{"id": "f1.txt", "text": "hello", "metadata": {}}]
+
+        with patch("rag_brain.loaders.DirectoryLoader") as MockLoader:
+            mock_loader_instance = MockLoader.return_value
+            mock_loader_instance.aload = AsyncMock(return_value=docs)
+
+            asyncio.run(brain.load_directory(str(tmp_path)))
+
+        brain.ingest.assert_called_once_with(docs)
+
+    def test_load_directory_skips_ingest_when_empty(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, tmp_path
+    ):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.ingest = MagicMock()
+
+        with patch("rag_brain.loaders.DirectoryLoader") as MockLoader:
+            mock_loader_instance = MockLoader.return_value
+            mock_loader_instance.aload = AsyncMock(return_value=[])
+
+            asyncio.run(brain.load_directory(str(tmp_path)))
+
+        brain.ingest.assert_not_called()
+
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestLogQueryMetrics:
+    def test_metrics_logged_without_exception(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        import logging
+        from unittest.mock import patch as _patch
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+
+        with _patch("rag_brain.main.logger") as mock_logger:
+            brain._log_query_metrics(
+                query="test query that is fairly long",
+                vector_count=5,
+                bm25_count=3,
+                filtered_count=4,
+                final_count=3,
+                top_score=0.87,
+                latency_ms=123.4,
+                transformations={"hyde_applied": False},
+            )
+            mock_logger.info.assert_called_once()
+            logged_data = mock_logger.info.call_args[0][0]
+            assert logged_data["event"] == "query_complete"
+            assert logged_data["latency_ms"] == 123.4
+            assert logged_data["results"]["vector"] == 5
+            assert "test query" in logged_data["query_preview"]
+
+    def test_metrics_handles_zero_top_score(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        from unittest.mock import patch as _patch
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+
+        with _patch("rag_brain.main.logger") as mock_logger:
+            brain._log_query_metrics(
+                query="q", vector_count=0, bm25_count=0,
+                filtered_count=0, final_count=0, top_score=0.0, latency_ms=10.0
+            )
+            logged_data = mock_logger.info.call_args[0][0]
+            # top_score=0 treated as falsy → logged as None
+            assert logged_data["top_score"] is None

--- a/tests/test_retrievers.py
+++ b/tests/test_retrievers.py
@@ -147,3 +147,114 @@ class TestReciprocalRankFusion:
         fused = reciprocal_rank_fusion(vector_results, bm25_results)
         assert len(fused) == 1
         assert fused[0]["id"] == "doc1"
+
+
+# ---------------------------------------------------------------------------
+# New tests: delete_documents, save/load
+# ---------------------------------------------------------------------------
+
+class TestBM25RetrieverDelete:
+    def test_delete_removes_document_from_search(self, tmp_path):
+        r = BM25Retriever(storage_path=str(tmp_path))
+        docs = [
+            {"id": "keep", "text": "python programming language", "metadata": {}},
+            {"id": "remove", "text": "javascript web development", "metadata": {}},
+        ]
+        r.add_documents(docs)
+
+        r.delete_documents(["remove"])
+
+        results = r.search("javascript web", top_k=5)
+        ids = [res["id"] for res in results]
+        assert "remove" not in ids
+
+    def test_delete_keeps_other_documents(self, tmp_path):
+        r = BM25Retriever(storage_path=str(tmp_path))
+        docs = [
+            {"id": "d1", "text": "alpha beta gamma", "metadata": {}},
+            {"id": "d2", "text": "delta epsilon zeta", "metadata": {}},
+            {"id": "d3", "text": "alpha delta omega", "metadata": {}},
+        ]
+        r.add_documents(docs)
+        r.delete_documents(["d2"])
+
+        assert len(r.corpus) == 2
+        remaining_ids = [d["id"] for d in r.corpus]
+        assert "d1" in remaining_ids
+        assert "d3" in remaining_ids
+        assert "d2" not in remaining_ids
+
+    def test_delete_all_documents_results_in_empty_index(self, tmp_path):
+        r = BM25Retriever(storage_path=str(tmp_path))
+        docs = [{"id": "only", "text": "some content", "metadata": {}}]
+        r.add_documents(docs)
+        r.delete_documents(["only"])
+
+        assert r.corpus == []
+        assert r.bm25 is None
+        assert r.search("some content") == []
+
+    def test_delete_nonexistent_id_is_noop(self, tmp_path):
+        r = BM25Retriever(storage_path=str(tmp_path))
+        docs = [{"id": "real", "text": "hello world", "metadata": {}}]
+        r.add_documents(docs)
+
+        r.delete_documents(["ghost_id"])
+
+        assert len(r.corpus) == 1
+        assert r.corpus[0]["id"] == "real"
+
+    def test_delete_persists_to_disk(self, tmp_path):
+        r = BM25Retriever(storage_path=str(tmp_path))
+        docs = [
+            {"id": "a", "text": "aardvark", "metadata": {}},
+            {"id": "b", "text": "baboon", "metadata": {}},
+        ]
+        r.add_documents(docs)
+        r.delete_documents(["a"])
+
+        # Reload from disk
+        r2 = BM25Retriever(storage_path=str(tmp_path))
+        assert len(r2.corpus) == 1
+        assert r2.corpus[0]["id"] == "b"
+
+
+class TestBM25RetrieverSaveLoad:
+    def test_save_and_load_preserves_corpus(self, tmp_path):
+        r1 = BM25Retriever(storage_path=str(tmp_path))
+        docs = [
+            {"id": "x1", "text": "machine learning basics", "metadata": {"src": "a"}},
+            {"id": "x2", "text": "deep neural networks", "metadata": {"src": "b"}},
+        ]
+        r1.add_documents(docs)
+        r1.save()
+
+        r2 = BM25Retriever(storage_path=str(tmp_path))
+        assert len(r2.corpus) == 2
+        loaded_ids = {d["id"] for d in r2.corpus}
+        assert loaded_ids == {"x1", "x2"}
+
+    def test_loaded_retriever_can_search(self, tmp_path):
+        # BM25Okapi IDF = log(N-df+0.5) - log(df+0.5).
+        # With only 2 docs and the term in 1, IDF = 0 → score = 0 → filtered out.
+        # Use 3 docs so the unique term gets positive IDF.
+        r1 = BM25Retriever(storage_path=str(tmp_path))
+        docs = [
+            {"id": "q1", "text": "quantum computing qubits superposition", "metadata": {}},
+            {"id": "q2", "text": "classical computing transistors", "metadata": {}},
+            {"id": "q3", "text": "classical computing binary gates", "metadata": {}},
+        ]
+        r1.add_documents(docs)
+
+        r2 = BM25Retriever(storage_path=str(tmp_path))
+        results = r2.search("quantum", top_k=1)
+        assert len(results) == 1
+        assert results[0]["id"] == "q1"
+
+    def test_empty_corpus_saves_and_loads(self, tmp_path):
+        r1 = BM25Retriever(storage_path=str(tmp_path))
+        r1.save()
+
+        r2 = BM25Retriever(storage_path=str(tmp_path))
+        assert r2.corpus == []
+        assert r2.bm25 is None

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,195 @@
+"""
+tests/test_streaming.py
+
+Tests for OpenLLM.stream() and OpenStudioBrain.query_stream().
+"""
+import pytest
+from unittest.mock import patch, MagicMock, call
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_brain(config):
+    """Construct an OpenStudioBrain with all heavy dependencies mocked."""
+    with (
+        patch("rag_brain.main.OpenEmbedding"),
+        patch("rag_brain.main.OpenLLM"),
+        patch("rag_brain.main.OpenVectorStore"),
+        patch("rag_brain.main.OpenReranker"),
+        patch("rag_brain.retrievers.BM25Retriever"),
+    ):
+        from rag_brain.main import OpenStudioBrain
+        return OpenStudioBrain(config)
+
+
+# ---------------------------------------------------------------------------
+# OpenLLM.stream() — all 4 providers
+# ---------------------------------------------------------------------------
+
+class TestOpenLLMStream:
+    @patch("ollama.Client")
+    def test_ollama_stream_yields_strings(self, MockOllama):
+        from rag_brain.main import OpenLLM, OpenStudioConfig
+
+        config = OpenStudioConfig(llm_provider="ollama")
+        llm = OpenLLM(config)
+
+        chunks = [{"message": {"content": t}} for t in ["Hello", " world", "!"]]
+        MockOllama.return_value.chat.return_value = iter(chunks)
+
+        result = list(llm.stream("hi"))
+        assert result == ["Hello", " world", "!"]
+        assert all(isinstance(c, str) for c in result)
+
+    @patch("google.generativeai.GenerativeModel")
+    @patch("google.generativeai.configure")
+    def test_gemini_stream_yields_strings(self, _cfg, MockModel):
+        from rag_brain.main import OpenLLM, OpenStudioConfig
+
+        config = OpenStudioConfig(llm_provider="gemini", llm_model="gemini-2.0-flash")
+        llm = OpenLLM(config)
+
+        chunk_mocks = [MagicMock(text=t) for t in ["The", " answer", " is", " 42"]]
+        MockModel.return_value.generate_content.return_value = iter(chunk_mocks)
+
+        result = list(llm.stream("question"))
+        assert result == ["The", " answer", " is", " 42"]
+        assert all(isinstance(c, str) for c in result)
+
+    @patch("httpx.Client")
+    def test_ollama_cloud_stream_yields_strings(self, MockHttpx):
+        import json as _json
+        from rag_brain.main import OpenLLM, OpenStudioConfig
+
+        config = OpenStudioConfig(llm_provider="ollama_cloud", ollama_cloud_key="k", llm_model="m")
+        llm = OpenLLM(config)
+
+        lines = [_json.dumps({"response": t}) for t in ["token1", " token2"]]
+        mock_resp = MagicMock()
+        mock_resp.iter_lines.return_value = iter(lines)
+        mock_resp.raise_for_status = MagicMock()
+
+        ctx_manager = MagicMock()
+        ctx_manager.__enter__ = MagicMock(return_value=mock_resp)
+        ctx_manager.__exit__ = MagicMock(return_value=False)
+
+        mock_client = MockHttpx.return_value.__enter__.return_value
+        mock_client.stream.return_value = ctx_manager
+
+        result = list(llm.stream("hi"))
+        assert result == ["token1", " token2"]
+
+    @patch("openai.OpenAI")
+    def test_openai_stream_yields_strings(self, MockOpenAI):
+        from rag_brain.main import OpenLLM, OpenStudioConfig
+
+        config = OpenStudioConfig(llm_provider="openai", api_key="sk-test", llm_model="gpt-4o")
+        llm = OpenLLM(config)
+
+        def _make_chunk(text):
+            c = MagicMock()
+            c.choices[0].delta.content = text
+            return c
+
+        stream_chunks = [_make_chunk(t) for t in ["A", "B", "C"]]
+        MockOpenAI.return_value.chat.completions.create.return_value = iter(stream_chunks)
+
+        result = list(llm.stream("hello"))
+        assert result == ["A", "B", "C"]
+
+
+# ---------------------------------------------------------------------------
+# OpenStudioBrain.query_stream()
+# ---------------------------------------------------------------------------
+
+class TestQueryStream:
+    def _make_brain_with_mocks(self):
+        from rag_brain.main import OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0)
+        with (
+            patch("rag_brain.main.OpenEmbedding"),
+            patch("rag_brain.main.OpenLLM"),
+            patch("rag_brain.main.OpenVectorStore"),
+            patch("rag_brain.main.OpenReranker"),
+            patch("rag_brain.retrievers.BM25Retriever"),
+        ):
+            from rag_brain.main import OpenStudioBrain
+            brain = OpenStudioBrain(config)
+        return brain
+
+    def test_yields_sources_then_tokens(self):
+        brain = self._make_brain_with_mocks()
+
+        docs = [{"id": "d1", "text": "hello", "score": 0.9, "metadata": {}}]
+        brain._execute_retrieval = MagicMock(return_value={
+            "results": docs,
+            "vector_count": 1,
+            "bm25_count": 0,
+            "web_count": 0,
+            "filtered_count": 1,
+            "transforms": {},
+        })
+        brain.llm.stream = MagicMock(return_value=iter(["tok1", " tok2"]))
+
+        chunks = list(brain.query_stream("my question"))
+
+        source_chunk = next(c for c in chunks if isinstance(c, dict) and c.get("type") == "sources")
+        assert source_chunk["sources"] == docs
+
+        token_chunks = [c for c in chunks if isinstance(c, str)]
+        assert "".join(token_chunks) == "tok1 tok2"
+
+    def test_no_docs_no_fallback_yields_message(self):
+        brain = self._make_brain_with_mocks()
+        brain.config.discussion_fallback = False
+
+        brain._execute_retrieval = MagicMock(return_value={
+            "results": [],
+            "vector_count": 0,
+            "bm25_count": 0,
+            "web_count": 0,
+            "filtered_count": 0,
+            "transforms": {},
+        })
+
+        chunks = list(brain.query_stream("unknown"))
+        text = "".join(c for c in chunks if isinstance(c, str))
+        assert len(text) > 0  # some fallback message
+
+    def test_no_docs_with_fallback_streams_llm(self):
+        brain = self._make_brain_with_mocks()
+        brain.config.discussion_fallback = True
+
+        brain._execute_retrieval = MagicMock(return_value={
+            "results": [],
+            "vector_count": 0,
+            "bm25_count": 0,
+            "web_count": 0,
+            "filtered_count": 0,
+            "transforms": {},
+        })
+        brain.llm.stream = MagicMock(return_value=iter(["fallback answer"]))
+
+        chunks = list(brain.query_stream("orphan query"))
+        assert "fallback answer" in "".join(c for c in chunks if isinstance(c, str))
+        brain.llm.stream.assert_called_once()
+
+    def test_completes_without_exception(self):
+        brain = self._make_brain_with_mocks()
+
+        brain._execute_retrieval = MagicMock(return_value={
+            "results": [{"id": "x", "text": "ctx", "score": 1.0, "metadata": {}}],
+            "vector_count": 1,
+            "bm25_count": 0,
+            "web_count": 0,
+            "filtered_count": 1,
+            "transforms": {},
+        })
+        brain.llm.stream = MagicMock(return_value=iter(["done"]))
+
+        # Should not raise
+        result = list(brain.query_stream("fine query"))
+        assert any(isinstance(c, str) for c in result)


### PR DESCRIPTION
## Summary

- **Sidebar redesign** — permanently pinned sidebar (no collapse), session list as clickable rows (active session highlighted in purple), compact provider selectbox, temperature always visible, Advanced/Documents in collapsed expanders, Hybrid/Web toggles always accessible. Fits all controls without scrolling. Inspired by Claude.ai, ChatGPT, and Open WebUI design patterns.
- **Dynamic model lists** — Gemini models fetched live via SDK (1h cache + fallback list), Ollama local models fetched from daemon, Ollama Cloud models fetched on demand.
- **Expanded test suite** — 20+ new tests across 4 files covering streaming, HyDE, multi-query, BM25 delete/save/load, and `DirectoryLoader.aload()`.
- **Infrastructure** — `CLAUDE.md` branch workflow rule, `.streamlit/config.toml` dark theme, `docker-compose.yml` mounts streamlit config volume.

## Test plan

- [ ] `pytest tests/ -v` — all tests pass
- [ ] Launch `rag-brain-ui`, verify sidebar is pinned open and all controls visible without scrolling
- [ ] Switch provider to Gemini — verify live model list loads (or falls back gracefully)
- [ ] Create / switch / delete sessions via the session list buttons
- [ ] Toggle Hybrid search and Web search checkboxes
- [ ] Expand ⚙ Advanced and 📥 Documents expanders
- [ ] Upload a file and verify ingestion progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)