### PR TITLE
feat: knowledge base viewer — list ingested sources in UI, API, and CLI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ ollama pull llava            # optional, for image captioning (BMP, PNG, TIF/TIF
 | Command | Description |
 |---|---|
 | `rag-brain --ingest ./docs/` | Ingest a directory via CLI |
+| `rag-brain --list` | List all ingested sources and chunk counts |
 | `rag-brain "your question"` | Query from CLI |
 | `rag-brain-api` | Start FastAPI server (port 8000) |
 | `rag-brain-ui` | Launch Streamlit web UI (port 8501) |
@@ -79,6 +80,7 @@ config.yaml
 - `POST /add_text` – real-time knowledge injection (auto-generates doc ID: `agent_doc_<uuid8>`)
 - `POST /delete` – delete documents by ID (body: `{"doc_ids": ["id1","id2"]}`, returns `{"status":"success","deleted":N,"doc_ids":[...]}`)
 - `POST /ingest` – background directory/file ingestion via `BackgroundTasks`
+- `GET /collection` – list all ingested sources with chunk counts (returns `{total_files, total_chunks, files:[{source,chunks}]}`)
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Agents can use this brain as a "Collective Memory."
 | `/add_text` | POST | Direct string ingestion (allows agents to "learn" new facts in real-time). |
 | `/delete` | POST | Delete documents by ID. Request body: `{"doc_ids": ["id1","id2"]}`. |
 | `/ingest` | POST | Background directory/file ingestion. Request body: `{"path": "/path/to/docs"}`. Path must be within `RAG_INGEST_BASE`. |
+| `/collection` | GET | List all ingested sources with chunk counts. Returns `{total_files, total_chunks, files:[{source,chunks}]}`. |
 
 ### Tool Definitions
 Standardized JSON schemas for tool-calling are provided in `src/rag_brain/tools.py`. The `get_rag_tool_definition()` function returns 6 OpenAI-compatible tools: `query_knowledge_base`, `search_documents`, `add_knowledge`, `delete_documents`, `ingest_directory`, and `stream_query`. See `examples/agent_simple.py` for a minimal integration, or `examples/agent_orchestration.py` for a richer multi-step planner-critic loop.

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -181,6 +181,22 @@ async def add_text(request: TextIngestRequest):
         logger.error(f"Error adding text: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
+@app.get("/collection")
+async def get_collection():
+    """List all unique sources in the knowledge base with chunk counts."""
+    if not brain:
+        raise HTTPException(status_code=503, detail="Brain not initialized")
+    try:
+        docs = brain.list_documents()
+        return {
+            "total_files": len(docs),
+            "total_chunks": sum(d["chunks"] for d in docs),
+            "files": [{"source": d["source"], "chunks": d["chunks"]} for d in docs],
+        }
+    except Exception as e:
+        logger.error(f"Error listing collection: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
 @app.post("/delete")
 async def delete_documents(request: DeleteRequest):
     if brain is None:

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -575,6 +575,38 @@ class OpenVectorStore:
                 points.append(PointStruct(id=id, vector=embedding, payload=payload))
             self.client.upsert(collection_name="rag_brain", points=points)
     
+    def list_documents(self) -> List[Dict[str, Any]]:
+        """Return all unique source files stored in the knowledge base with chunk counts.
+
+        Returns:
+            List of dicts sorted by source name, each with keys:
+                - source (str): The metadata 'source' value, or 'unknown' if not set.
+                - chunks (int): Number of chunks stored for that source.
+                - doc_ids (List[str]): All chunk IDs belonging to this source.
+        """
+        if self.provider == "chroma":
+            result = self.collection.get(include=["metadatas"])
+            sources: Dict[str, Dict[str, Any]] = {}
+            for doc_id, meta in zip(result["ids"], result["metadatas"] or [{}] * len(result["ids"])):
+                source = (meta or {}).get("source", "unknown")
+                if source not in sources:
+                    sources[source] = {"source": source, "chunks": 0, "doc_ids": []}
+                sources[source]["chunks"] += 1
+                sources[source]["doc_ids"].append(doc_id)
+            return sorted(sources.values(), key=lambda x: x["source"])
+        elif self.provider == "qdrant":
+            from qdrant_client.models import ScrollRequest
+            results, _ = self.client.scroll(collection_name="rag_brain", limit=10000, with_payload=True)
+            sources: Dict[str, Dict[str, Any]] = {}
+            for point in results:
+                source = point.payload.get("source", "unknown")
+                if source not in sources:
+                    sources[source] = {"source": source, "chunks": 0, "doc_ids": []}
+                sources[source]["chunks"] += 1
+                sources[source]["doc_ids"].append(str(point.id))
+            return sorted(sources.values(), key=lambda x: x["source"])
+        return []
+
     def search(self, query_embedding: List[float], top_k: int = 10, filter_dict: Dict = None) -> List[Dict]:
         if self.provider == "chroma":
             results = self.collection.query(query_embeddings=[query_embedding], n_results=top_k)
@@ -865,12 +897,24 @@ Your primary goal is to help the user by answering questions based on the provid
         documents = await loader.aload(directory)
         if documents: self.ingest(documents)
 
+    def list_documents(self) -> List[Dict[str, Any]]:
+        """Return all unique source files in the knowledge base with chunk counts.
+
+        Returns:
+            List of dicts sorted by source name, each with keys:
+                - source (str): File name / source identifier.
+                - chunks (int): Number of stored chunks for this source.
+                - doc_ids (List[str]): All chunk IDs for this source.
+        """
+        return self.vector_store.list_documents()
+
 
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Local RAG Brain CLI")
     parser.add_argument('query', nargs='?', help='Question to ask')
     parser.add_argument('--ingest', help='Path to file or directory to ingest')
+    parser.add_argument('--list', action='store_true', help='List all ingested sources in the knowledge base')
     parser.add_argument('--config', default='config.yaml', help='Path to config file')
     parser.add_argument('--stream', action='store_true', help='Stream the response')
     args = parser.parse_args()
@@ -885,6 +929,19 @@ def main():
             ext = os.path.splitext(args.ingest)[1].lower()
             loader_mgr = DirectoryLoader()
             if ext in loader_mgr.loaders: brain.ingest(loader_mgr.loaders[ext].load(args.ingest))
+
+    if args.list:
+        docs = brain.list_documents()
+        if not docs:
+            print("📭 Knowledge base is empty.")
+        else:
+            total_chunks = sum(d["chunks"] for d in docs)
+            print(f"\n📚 Knowledge Base — {len(docs)} file(s), {total_chunks} chunk(s)\n")
+            print(f"  {'Source':<60} {'Chunks':>6}")
+            print(f"  {'-'*60} {'-'*6}")
+            for d in docs:
+                print(f"  {d['source']:<60} {d['chunks']:>6}")
+        return
     
     if args.query:
         if args.stream:

--- a/src/rag_brain/webapp.py
+++ b/src/rag_brain/webapp.py
@@ -481,6 +481,40 @@ with st.sidebar:
             else:
                 st.error("Invalid directory path.")
 
+    # ── KNOWLEDGE BASE VIEWER (collapsed) ──
+    with st.expander("📚 Knowledge Base"):
+        brain_obj = st.session_state.get("brain")
+        if brain_obj is None:
+            st.caption("Brain not initialised yet.")
+        else:
+            if st.button("🔄 Refresh", use_container_width=True, type="tertiary", key="kb_refresh"):
+                st.session_state.pop("kb_docs_cache", None)
+
+            if "kb_docs_cache" not in st.session_state:
+                with st.spinner("Loading…"):
+                    try:
+                        st.session_state.kb_docs_cache = brain_obj.list_documents()
+                    except Exception as e:
+                        st.error(f"Could not load knowledge base: {e}")
+                        st.session_state.kb_docs_cache = []
+
+            docs_cache = st.session_state.get("kb_docs_cache", [])
+            total_chunks = sum(d["chunks"] for d in docs_cache)
+
+            if not docs_cache:
+                st.caption("📭 Knowledge base is empty.")
+            else:
+                st.caption(f"{len(docs_cache)} file(s) · {total_chunks} chunk(s)")
+                for d in docs_cache:
+                    st.markdown(
+                        f"<div style='display:flex;justify-content:space-between;"
+                        f"font-size:0.78rem;padding:2px 0;'>"
+                        f"<span>📄 {d['source']}</span>"
+                        f"<span style='color:rgba(200,200,200,0.6);'>{d['chunks']} chunks</span>"
+                        f"</div>",
+                        unsafe_allow_html=True,
+                    )
+
 # ---------------------------------------------------------------------------
 # Main chat area
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -250,3 +250,49 @@ def test_search_propagates_error():
     api_module.brain.embedding.embed_query.side_effect = RuntimeError("embed fail")
     resp = client.post("/search", json={"query": "test"})
     assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# GET /collection
+# ---------------------------------------------------------------------------
+
+def test_collection_503_no_brain():
+    resp = client.get("/collection")
+    assert resp.status_code == 503
+
+
+def test_collection_empty():
+    api_module.brain = _make_brain()
+    api_module.brain.list_documents.return_value = []
+    resp = client.get("/collection")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_files"] == 0
+    assert data["total_chunks"] == 0
+    assert data["files"] == []
+
+
+def test_collection_returns_sources():
+    api_module.brain = _make_brain()
+    api_module.brain.list_documents.return_value = [
+        {"source": "notes.txt", "chunks": 4, "doc_ids": ["a", "b", "c", "d"]},
+        {"source": "report.pdf", "chunks": 12, "doc_ids": [f"r{i}" for i in range(12)]},
+    ]
+    resp = client.get("/collection")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_files"] == 2
+    assert data["total_chunks"] == 16
+    sources = [f["source"] for f in data["files"]]
+    assert "notes.txt" in sources
+    assert "report.pdf" in sources
+    # doc_ids should NOT be exposed by this endpoint (internal detail)
+    for f in data["files"]:
+        assert "doc_ids" not in f
+
+
+def test_collection_propagates_error():
+    api_module.brain = _make_brain()
+    api_module.brain.list_documents.side_effect = RuntimeError("chroma down")
+    resp = client.get("/collection")
+    assert resp.status_code == 500

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -354,3 +354,92 @@ class TestLogQueryMetrics:
             logged_data = mock_logger.info.call_args[0][0]
             # top_score=0 treated as falsy → logged as None
             assert logged_data["top_score"] is None
+
+
+# ---------------------------------------------------------------------------
+# list_documents
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestListDocuments:
+    def test_list_documents_delegates_to_vector_store(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.vector_store.list_documents = MagicMock(return_value=[
+            {"source": "a.txt", "chunks": 3, "doc_ids": ["1", "2", "3"]},
+            {"source": "b.pdf", "chunks": 7, "doc_ids": [str(i) for i in range(7)]},
+        ])
+
+        result = brain.list_documents()
+
+        brain.vector_store.list_documents.assert_called_once()
+        assert len(result) == 2
+        assert result[0]["source"] == "a.txt"
+        assert result[0]["chunks"] == 3
+        assert result[1]["source"] == "b.pdf"
+
+    def test_list_documents_empty_kb(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.vector_store.list_documents = MagicMock(return_value=[])
+
+        result = brain.list_documents()
+        assert result == []
+
+
+class TestOpenVectorStoreListDocuments:
+    def test_chroma_groups_by_source(self):
+        from rag_brain.main import OpenVectorStore, OpenStudioConfig
+        from unittest.mock import MagicMock, patch
+
+        config = OpenStudioConfig(vector_store="chroma")
+        with patch("chromadb.PersistentClient") as MockClient:
+            mock_col = MagicMock()
+            MockClient.return_value.get_or_create_collection.return_value = mock_col
+            mock_col.get.return_value = {
+                "ids": ["c1", "c2", "c3", "c4"],
+                "metadatas": [
+                    {"source": "notes.txt"},
+                    {"source": "notes.txt"},
+                    {"source": "report.pdf"},
+                    {"source": "report.pdf"},
+                ],
+            }
+            store = OpenVectorStore(config)
+            result = store.list_documents()
+
+        assert len(result) == 2
+        by_source = {d["source"]: d for d in result}
+        assert by_source["notes.txt"]["chunks"] == 2
+        assert by_source["report.pdf"]["chunks"] == 2
+        assert set(by_source["notes.txt"]["doc_ids"]) == {"c1", "c2"}
+
+    def test_chroma_handles_missing_source_metadata(self):
+        from rag_brain.main import OpenVectorStore, OpenStudioConfig
+        from unittest.mock import MagicMock, patch
+
+        config = OpenStudioConfig(vector_store="chroma")
+        with patch("chromadb.PersistentClient") as MockClient:
+            mock_col = MagicMock()
+            MockClient.return_value.get_or_create_collection.return_value = mock_col
+            mock_col.get.return_value = {
+                "ids": ["x1"],
+                "metadatas": [{}],  # no 'source' key
+            }
+            store = OpenVectorStore(config)
+            result = store.list_documents()
+
+        assert len(result) == 1
+        assert result[0]["source"] == "unknown"


### PR DESCRIPTION
## Summary

Adds visibility into what's currently stored in the RAG knowledge base.

## Changes

### Backend (src/rag_brain/main.py)
- **OpenVectorStore.list_documents()** — queries ChromaDB (or Qdrant) for all stored chunks, groups by \metadata.source\, returns \[{source, chunks, doc_ids}]\ sorted alphabetically. Falls back to \'unknown'\ when source metadata is missing.
- **OpenStudioBrain.list_documents()** — thin public wrapper.

### API (src/rag_brain/api.py)
- **\GET /collection\** — new endpoint returning \{total_files, total_chunks, files:[{source,chunks}]}\. Returns 503 if brain not initialised.

### UI (src/rag_brain/webapp.py)
- **\📚 Knowledge Base\ sidebar expander** — shows total file + chunk count, lists every source with its chunk count, has a 🔄 Refresh button. Results are cached in \session_state\ (cleared on refresh). View-only — no delete in UI to prevent accidental data loss.

### CLI (src/rag_brain/main.py)
- **\ag-brain --list\** — prints a formatted table of all ingested sources and chunk counts, then exits.

### Tests
- 8 new tests (129 total, all pass): \TestListDocuments\, \TestOpenVectorStoreListDocuments\ in \	est_main.py\; \	est_collection_*\ in \	est_api.py\

### Docs
- \README.md\: added \GET /collection\ to API table
- \copilot-instructions.md\: added \--list\ to commands table and \GET /collection\ to API section