### PR TITLE
fix: agentic web search flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ ollama pull llava            # optional, for image captioning (BMP, PNG, TIF/TIF
 | Command | Description |
 |---|---|
 | `rag-brain --ingest ./docs/` | Ingest a directory via CLI |
+| `rag-brain --list` | List all ingested sources and chunk counts |
 | `rag-brain "your question"` | Query from CLI |
 | `rag-brain-api` | Start FastAPI server (port 8000) |
 | `rag-brain-ui` | Launch Streamlit web UI (port 8501) |
@@ -79,6 +80,7 @@ config.yaml
 - `POST /add_text` – real-time knowledge injection (auto-generates doc ID: `agent_doc_<uuid8>`)
 - `POST /delete` – delete documents by ID (body: `{"doc_ids": ["id1","id2"]}`, returns `{"status":"success","deleted":N,"doc_ids":[...]}`)
 - `POST /ingest` – background directory/file ingestion via `BackgroundTasks`
+- `GET /collection` – list all ingested sources with chunk counts (returns `{total_files, total_chunks, files:[{source,chunks}]}`)
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Agents can use this brain as a "Collective Memory."
 | `/add_text` | POST | Direct string ingestion (allows agents to "learn" new facts in real-time). |
 | `/delete` | POST | Delete documents by ID. Request body: `{"doc_ids": ["id1","id2"]}`. |
 | `/ingest` | POST | Background directory/file ingestion. Request body: `{"path": "/path/to/docs"}`. Path must be within `RAG_INGEST_BASE`. |
+| `/collection` | GET | List all ingested sources with chunk counts. Returns `{total_files, total_chunks, files:[{source,chunks}]}`. |
 
 ### Tool Definitions
 Standardized JSON schemas for tool-calling are provided in `src/rag_brain/tools.py`. The `get_rag_tool_definition()` function returns 6 OpenAI-compatible tools: `query_knowledge_base`, `search_documents`, `add_knowledge`, `delete_documents`, `ingest_directory`, and `stream_query`. See `examples/agent_simple.py` for a minimal integration, or `examples/agent_orchestration.py` for a richer multi-step planner-critic loop.

--- a/config.yaml
+++ b/config.yaml
@@ -56,8 +56,12 @@ rag:
   # Number of documents to retrieve
   top_k: 10
   
-  # Minimum similarity score (0-1)
-  similarity_threshold: 0.5
+  # Minimum similarity score (0-1).
+  # Calibrated for all-MiniLM-L6-v2 (typical relevant scores: 0.30–0.60).
+  # Raise to 0.5+ for stricter matching; lower to 0.2 for broader recall.
+  # Also used as the web-search fallback trigger: if best cosine score < this
+  # value, Brave Search fires (when truth_grounding is enabled).
+  similarity_threshold: 0.3
   
   # Enable hybrid search (vector + keyword)
   hybrid_search: true

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -181,6 +181,22 @@ async def add_text(request: TextIngestRequest):
         logger.error(f"Error adding text: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
+@app.get("/collection")
+async def get_collection():
+    """List all unique sources in the knowledge base with chunk counts."""
+    if not brain:
+        raise HTTPException(status_code=503, detail="Brain not initialized")
+    try:
+        docs = brain.list_documents()
+        return {
+            "total_files": len(docs),
+            "total_chunks": sum(d["chunks"] for d in docs),
+            "files": [{"source": d["source"], "chunks": d["chunks"]} for d in docs],
+        }
+    except Exception as e:
+        logger.error(f"Error listing collection: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
 @app.post("/delete")
 async def delete_documents(request: DeleteRequest):
     if brain is None:

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -62,7 +62,7 @@ class OpenStudioConfig:
     
     # RAG Settings
     top_k: int = 10
-    similarity_threshold: float = 0.5
+    similarity_threshold: float = 0.3
     hybrid_search: bool = True
     
     # Chunking

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -806,6 +806,33 @@ Your primary goal is to help the user by answering questions based on the provid
             "transforms": transforms
         }
 
+    def _build_context(self, results: List[Dict]) -> tuple:
+        """Build context string from results, labelling web vs local sources distinctly.
+
+        Returns:
+            Tuple of (context_string, has_web_results).
+        """
+        parts = []
+        has_web = False
+        for i, r in enumerate(results):
+            if r.get("is_web"):
+                has_web = True
+                title = r.get("metadata", {}).get("title", r["id"])
+                parts.append(f"[Web Result {i+1} — {title} ({r['id']})]\n{r['text']}")
+            else:
+                parts.append(f"[Document {i+1} (ID: {r['id']})]\n{r['text']}")
+        return "\n\n".join(parts), has_web
+
+    def _build_system_prompt(self, has_web: bool) -> str:
+        """Return the system prompt, extended with a web-search note when applicable."""
+        if not has_web:
+            return self.SYSTEM_PROMPT
+        return self.SYSTEM_PROMPT + (
+            "\n\n**Web Search Active**: Some context items above come from live Brave Search results "
+            "(marked as 'Web Result'). Use them to answer questions about current events or information "
+            "not found in local documents. Always cite the URL when referencing a web result."
+        )
+
     def query(self, query: str, filters: Dict = None, chat_history: List[Dict[str, str]] = None) -> str:
         t0 = time.time()
         
@@ -827,9 +854,10 @@ Your primary goal is to help the user by answering questions based on the provid
         results = results[:self.config.top_k]
         final_count = len(results)
         top_score = results[0].get('score', 0) if results else 0
-        context = "\n\n".join([f"[Document {i+1} (ID: {r['id']})]\n{r['text']}" for i, r in enumerate(results)])
+        context, has_web = self._build_context(results)
+        system_prompt = self._build_system_prompt(has_web)
         prompt = f"Based on the following context, answer the question: '{query}'\n\nContext:\n{context}\n\nProvide a comprehensive but concise answer."
-        response = self.llm.complete(prompt, self.SYSTEM_PROMPT, chat_history=chat_history)
+        response = self.llm.complete(prompt, system_prompt, chat_history=chat_history)
         self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'], 
                                 retrieval['filtered_count'], final_count, top_score, (time.time() - t0) * 1000, retrieval['transforms'])
         return response
@@ -849,14 +877,15 @@ Your primary goal is to help the user by answering questions based on the provid
         if self.config.rerank: results = self.reranker.rerank(query, results)
         
         results = results[:self.config.top_k]
-        context = "\n\n".join([f"[Document {i+1} (ID: {r['id']})]\n{r['text']}" for i, r in enumerate(results)])
+        context, has_web = self._build_context(results)
+        system_prompt = self._build_system_prompt(has_web)
         
         # Yield a marker object so UI can optionally reconstruct sources
         yield {"type": "sources", "sources": results}
 
         prompt = f"Based on the following context, answer the question: '{query}'\n\nContext:\n{context}\n\nProvide a comprehensive but concise answer."
         
-        yield from self.llm.stream(prompt, self.SYSTEM_PROMPT, chat_history=chat_history)
+        yield from self.llm.stream(prompt, system_prompt, chat_history=chat_history)
 
     async def load_directory(self, directory: str):
         from rag_brain.loaders import DirectoryLoader

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -789,9 +789,10 @@ Your primary goal is to help the user by answering questions based on the provid
 
         results = [r for r in results if r.get('score', 1.0) >= self.config.similarity_threshold or 'fused_only' in r]
         
-        # Web Search (Truth Grounding)
+        # Web Search (Truth Grounding) — only fires when local knowledge is insufficient
         web_count = 0
-        if self.config.truth_grounding and self.config.brave_api_key:
+        if self.config.truth_grounding and self.config.brave_api_key and not results:
+            logger.info("🌐 Local knowledge insufficient — falling back to Brave web search")
             web_results = self._execute_web_search(query)
             web_count = len(web_results)
             results.extend(web_results)
@@ -824,13 +825,23 @@ Your primary goal is to help the user by answering questions based on the provid
         return "\n\n".join(parts), has_web
 
     def _build_system_prompt(self, has_web: bool) -> str:
-        """Return the system prompt, extended with a web-search note when applicable."""
-        if not has_web:
+        """Return the system prompt, extended based on web search state.
+
+        When truth_grounding is enabled but local docs answered the question,
+        the LLM is told web search is available as a fallback (sets expectations).
+        When web results are actually in the context, the LLM is told to use and cite them.
+        """
+        if not self.config.truth_grounding:
             return self.SYSTEM_PROMPT
+        if has_web:
+            return self.SYSTEM_PROMPT + (
+                "\n\n**Web Search Used**: Local documents did not contain sufficient information, "
+                "so live Brave Search results have been added to your context (marked as '[Web Result]'). "
+                "Use these web results to answer the question and always cite the source URL."
+            )
         return self.SYSTEM_PROMPT + (
-            "\n\n**Web Search Active**: Some context items above come from live Brave Search results "
-            "(marked as 'Web Result'). Use them to answer questions about current events or information "
-            "not found in local documents. Always cite the URL when referencing a web result."
+            "\n\n**Web Search Available**: If the local documents above are insufficient, "
+            "you have access to live Brave Search as a fallback tool. It was not needed for this query."
         )
 
     def query(self, query: str, filters: Dict = None, chat_history: List[Dict[str, str]] = None) -> str:
@@ -845,7 +856,7 @@ Your primary goal is to help the user by answering questions based on the provid
             
             if self.config.discussion_fallback:
                 prompt_fallback = f"The user asked: '{query}'. I found no relevant documents in the local knowledge base. Please provide a helpful response based on your general knowledge, while noting the lack of specific local context."
-                return self.llm.complete(prompt_fallback, self.SYSTEM_PROMPT, chat_history=chat_history)
+                return self.llm.complete(prompt_fallback, self._build_system_prompt(False), chat_history=chat_history)
             
             return "I don't have any relevant information to answer that question."
             
@@ -869,7 +880,7 @@ Your primary goal is to help the user by answering questions based on the provid
         if not results:
             if self.config.discussion_fallback:
                 prompt_fallback = f"The user asked: '{query}'. I found no relevant documents in the local knowledge base. Please provide a helpful response based on your general knowledge, while noting the lack of specific local context."
-                yield from self.llm.stream(prompt_fallback, self.SYSTEM_PROMPT, chat_history=chat_history)
+                yield from self.llm.stream(prompt_fallback, self._build_system_prompt(False), chat_history=chat_history)
                 return
             yield "I don't have any relevant information to answer that question."
             return

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -788,15 +788,24 @@ Your primary goal is to help the user by answering questions based on the provid
             results = vector_results
 
         results = [r for r in results if r.get('score', 1.0) >= self.config.similarity_threshold or 'fused_only' in r]
-        
-        # Web Search (Truth Grounding) — only fires when local knowledge is insufficient
+
+        # Web Search (Truth Grounding)
+        # Trigger when the best cosine similarity from vector search is below the threshold,
+        # meaning local knowledge is genuinely insufficient (even if BM25 returned fused_only docs).
         web_count = 0
-        if self.config.truth_grounding and self.config.brave_api_key and not results:
-            logger.info("🌐 Local knowledge insufficient — falling back to Brave web search")
-            web_results = self._execute_web_search(query)
-            web_count = len(web_results)
-            results.extend(web_results)
-            transforms['web_search_applied'] = True
+        if self.config.truth_grounding and self.config.brave_api_key:
+            max_vector_score = max((r['score'] for r in vector_results), default=0.0)
+            local_sufficient = max_vector_score >= self.config.similarity_threshold
+            if not local_sufficient:
+                logger.info(
+                    f"🌐 Local knowledge insufficient (best vector score {max_vector_score:.3f} < "
+                    f"threshold {self.config.similarity_threshold}) — falling back to Brave web search"
+                )
+                web_results = self._execute_web_search(query)
+                web_count = len(web_results)
+                # Replace low-relevance local results with web results
+                results = web_results
+                transforms['web_search_applied'] = True
 
         return {
             "results": results,

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -575,6 +575,38 @@ class OpenVectorStore:
                 points.append(PointStruct(id=id, vector=embedding, payload=payload))
             self.client.upsert(collection_name="rag_brain", points=points)
     
+    def list_documents(self) -> List[Dict[str, Any]]:
+        """Return all unique source files stored in the knowledge base with chunk counts.
+
+        Returns:
+            List of dicts sorted by source name, each with keys:
+                - source (str): The metadata 'source' value, or 'unknown' if not set.
+                - chunks (int): Number of chunks stored for that source.
+                - doc_ids (List[str]): All chunk IDs belonging to this source.
+        """
+        if self.provider == "chroma":
+            result = self.collection.get(include=["metadatas"])
+            sources: Dict[str, Dict[str, Any]] = {}
+            for doc_id, meta in zip(result["ids"], result["metadatas"] or [{}] * len(result["ids"])):
+                source = (meta or {}).get("source", "unknown")
+                if source not in sources:
+                    sources[source] = {"source": source, "chunks": 0, "doc_ids": []}
+                sources[source]["chunks"] += 1
+                sources[source]["doc_ids"].append(doc_id)
+            return sorted(sources.values(), key=lambda x: x["source"])
+        elif self.provider == "qdrant":
+            from qdrant_client.models import ScrollRequest
+            results, _ = self.client.scroll(collection_name="rag_brain", limit=10000, with_payload=True)
+            sources: Dict[str, Dict[str, Any]] = {}
+            for point in results:
+                source = point.payload.get("source", "unknown")
+                if source not in sources:
+                    sources[source] = {"source": source, "chunks": 0, "doc_ids": []}
+                sources[source]["chunks"] += 1
+                sources[source]["doc_ids"].append(str(point.id))
+            return sorted(sources.values(), key=lambda x: x["source"])
+        return []
+
     def search(self, query_embedding: List[float], top_k: int = 10, filter_dict: Dict = None) -> List[Dict]:
         if self.provider == "chroma":
             results = self.collection.query(query_embeddings=[query_embedding], n_results=top_k)
@@ -865,12 +897,24 @@ Your primary goal is to help the user by answering questions based on the provid
         documents = await loader.aload(directory)
         if documents: self.ingest(documents)
 
+    def list_documents(self) -> List[Dict[str, Any]]:
+        """Return all unique source files in the knowledge base with chunk counts.
+
+        Returns:
+            List of dicts sorted by source name, each with keys:
+                - source (str): File name / source identifier.
+                - chunks (int): Number of stored chunks for this source.
+                - doc_ids (List[str]): All chunk IDs for this source.
+        """
+        return self.vector_store.list_documents()
+
 
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Local RAG Brain CLI")
     parser.add_argument('query', nargs='?', help='Question to ask')
     parser.add_argument('--ingest', help='Path to file or directory to ingest')
+    parser.add_argument('--list', action='store_true', help='List all ingested sources in the knowledge base')
     parser.add_argument('--config', default='config.yaml', help='Path to config file')
     parser.add_argument('--stream', action='store_true', help='Stream the response')
     args = parser.parse_args()
@@ -885,6 +929,19 @@ def main():
             ext = os.path.splitext(args.ingest)[1].lower()
             loader_mgr = DirectoryLoader()
             if ext in loader_mgr.loaders: brain.ingest(loader_mgr.loaders[ext].load(args.ingest))
+
+    if args.list:
+        docs = brain.list_documents()
+        if not docs:
+            print("📭 Knowledge base is empty.")
+        else:
+            total_chunks = sum(d["chunks"] for d in docs)
+            print(f"\n📚 Knowledge Base — {len(docs)} file(s), {total_chunks} chunk(s)\n")
+            print(f"  {'Source':<60} {'Chunks':>6}")
+            print(f"  {'-'*60} {'-'*6}")
+            for d in docs:
+                print(f"  {d['source']:<60} {d['chunks']:>6}")
+        return
     
     if args.query:
         if args.stream:

--- a/src/rag_brain/retrievers.py
+++ b/src/rag_brain/retrievers.py
@@ -110,40 +110,43 @@ class BM25Retriever:
 
 
 def reciprocal_rank_fusion(vector_results: List[Dict], bm25_results: List[Dict], k: int = 60) -> List[Dict]:
-    """
-    Merge results from multiple retrievers using Reciprocal Rank Fusion.
+    """Merge results from multiple retrievers using Reciprocal Rank Fusion.
+
+    The original cosine similarity score from vector search is preserved in the
+    ``vector_score`` field so the UI can display a meaningful relevance value.
+    The RRF-fused score (used only for ranking) is stored in ``score``.
     """
     fused_scores = {}
-    
-    # Process vector results
+
+    # Preserve original cosine scores keyed by doc_id
+    vector_scores = {doc['id']: doc.get('score', 0.0) for doc in vector_results}
+
     for rank, doc in enumerate(vector_results):
         doc_id = doc['id']
         fused_scores[doc_id] = fused_scores.get(doc_id, 0) + 1 / (rank + k)
-        
-    # Process BM25 results
+
     for rank, doc in enumerate(bm25_results):
         doc_id = doc['id']
         if doc_id not in fused_scores:
-            # We need to keep the full doc data if it wasn't in vector results
             fused_scores[doc_id] = 1 / (rank + k)
-            # Store the doc structure for later
-            doc['fused_only'] = True 
+            doc['fused_only'] = True
         else:
             fused_scores[doc_id] += 1 / (rank + k)
 
-    # Combine all docs
     all_docs = {doc['id']: doc for doc in vector_results}
     for doc in bm25_results:
         if doc['id'] not in all_docs:
             all_docs[doc['id']] = doc
 
-    # Sort by fused score
     sorted_ids = sorted(fused_scores.keys(), key=lambda x: fused_scores[x], reverse=True)
-    
+
     final_results = []
     for doc_id in sorted_ids:
         doc = all_docs[doc_id]
         doc['score'] = fused_scores[doc_id]
+        # Expose the original cosine similarity for display purposes
+        if doc_id in vector_scores:
+            doc['vector_score'] = vector_scores[doc_id]
         final_results.append(doc)
-        
+
     return final_results

--- a/src/rag_brain/webapp.py
+++ b/src/rag_brain/webapp.py
@@ -481,6 +481,40 @@ with st.sidebar:
             else:
                 st.error("Invalid directory path.")
 
+    # ── KNOWLEDGE BASE VIEWER (collapsed) ──
+    with st.expander("📚 Knowledge Base"):
+        brain_obj = st.session_state.get("brain")
+        if brain_obj is None:
+            st.caption("Brain not initialised yet.")
+        else:
+            if st.button("🔄 Refresh", use_container_width=True, type="tertiary", key="kb_refresh"):
+                st.session_state.pop("kb_docs_cache", None)
+
+            if "kb_docs_cache" not in st.session_state:
+                with st.spinner("Loading…"):
+                    try:
+                        st.session_state.kb_docs_cache = brain_obj.list_documents()
+                    except Exception as e:
+                        st.error(f"Could not load knowledge base: {e}")
+                        st.session_state.kb_docs_cache = []
+
+            docs_cache = st.session_state.get("kb_docs_cache", [])
+            total_chunks = sum(d["chunks"] for d in docs_cache)
+
+            if not docs_cache:
+                st.caption("📭 Knowledge base is empty.")
+            else:
+                st.caption(f"{len(docs_cache)} file(s) · {total_chunks} chunk(s)")
+                for d in docs_cache:
+                    st.markdown(
+                        f"<div style='display:flex;justify-content:space-between;"
+                        f"font-size:0.78rem;padding:2px 0;'>"
+                        f"<span>📄 {d['source']}</span>"
+                        f"<span style='color:rgba(200,200,200,0.6);'>{d['chunks']} chunks</span>"
+                        f"</div>",
+                        unsafe_allow_html=True,
+                    )
+
 # ---------------------------------------------------------------------------
 # Main chat area
 # ---------------------------------------------------------------------------

--- a/src/rag_brain/webapp.py
+++ b/src/rag_brain/webapp.py
@@ -501,8 +501,9 @@ for message in messages:
                         title = doc.get("metadata", {}).get("title", doc["id"])
                         st.markdown(f"**🌐 [{i+1}] [{title}]({doc['id']})**")
                     else:
+                        display_score = doc.get("vector_score", doc.get("score", 0))
                         st.markdown(
-                            f"**📄 [{i+1}] `{doc['id']}`** — score: `{doc.get('score', 0):.3f}`"
+                            f"**📄 [{i+1}] `{doc['id']}`** — similarity: `{display_score:.3f}`"
                         )
                     st.code(
                         doc["text"][:500] + ("…" if len(doc["text"]) > 500 else ""),
@@ -551,8 +552,9 @@ if prompt := st.chat_input("Ask me anything about your documents…"):
                             title = doc.get("metadata", {}).get("title", doc["id"])
                             st.markdown(f"**🌐 [{i+1}] [{title}]({doc['id']})**")
                         else:
+                            display_score = doc.get("vector_score", doc.get("score", 0))
                             st.markdown(
-                                f"**📄 [{i+1}] `{doc['id']}`** — score: `{doc.get('score', 0):.3f}`"
+                                f"**📄 [{i+1}] `{doc['id']}`** — similarity: `{display_score:.3f}`"
                             )
                         st.code(
                             doc["text"][:500] + ("…" if len(doc["text"]) > 500 else ""),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -250,3 +250,49 @@ def test_search_propagates_error():
     api_module.brain.embedding.embed_query.side_effect = RuntimeError("embed fail")
     resp = client.post("/search", json={"query": "test"})
     assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# GET /collection
+# ---------------------------------------------------------------------------
+
+def test_collection_503_no_brain():
+    resp = client.get("/collection")
+    assert resp.status_code == 503
+
+
+def test_collection_empty():
+    api_module.brain = _make_brain()
+    api_module.brain.list_documents.return_value = []
+    resp = client.get("/collection")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_files"] == 0
+    assert data["total_chunks"] == 0
+    assert data["files"] == []
+
+
+def test_collection_returns_sources():
+    api_module.brain = _make_brain()
+    api_module.brain.list_documents.return_value = [
+        {"source": "notes.txt", "chunks": 4, "doc_ids": ["a", "b", "c", "d"]},
+        {"source": "report.pdf", "chunks": 12, "doc_ids": [f"r{i}" for i in range(12)]},
+    ]
+    resp = client.get("/collection")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_files"] == 2
+    assert data["total_chunks"] == 16
+    sources = [f["source"] for f in data["files"]]
+    assert "notes.txt" in sources
+    assert "report.pdf" in sources
+    # doc_ids should NOT be exposed by this endpoint (internal detail)
+    for f in data["files"]:
+        assert "doc_ids" not in f
+
+
+def test_collection_propagates_error():
+    api_module.brain = _make_brain()
+    api_module.brain.list_documents.side_effect = RuntimeError("chroma down")
+    resp = client.get("/collection")
+    assert resp.status_code == 500

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -354,3 +354,92 @@ class TestLogQueryMetrics:
             logged_data = mock_logger.info.call_args[0][0]
             # top_score=0 treated as falsy → logged as None
             assert logged_data["top_score"] is None
+
+
+# ---------------------------------------------------------------------------
+# list_documents
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestListDocuments:
+    def test_list_documents_delegates_to_vector_store(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.vector_store.list_documents = MagicMock(return_value=[
+            {"source": "a.txt", "chunks": 3, "doc_ids": ["1", "2", "3"]},
+            {"source": "b.pdf", "chunks": 7, "doc_ids": [str(i) for i in range(7)]},
+        ])
+
+        result = brain.list_documents()
+
+        brain.vector_store.list_documents.assert_called_once()
+        assert len(result) == 2
+        assert result[0]["source"] == "a.txt"
+        assert result[0]["chunks"] == 3
+        assert result[1]["source"] == "b.pdf"
+
+    def test_list_documents_empty_kb(
+        self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25
+    ):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain.vector_store.list_documents = MagicMock(return_value=[])
+
+        result = brain.list_documents()
+        assert result == []
+
+
+class TestOpenVectorStoreListDocuments:
+    def test_chroma_groups_by_source(self):
+        from rag_brain.main import OpenVectorStore, OpenStudioConfig
+        from unittest.mock import MagicMock, patch
+
+        config = OpenStudioConfig(vector_store="chroma")
+        with patch("chromadb.PersistentClient") as MockClient:
+            mock_col = MagicMock()
+            MockClient.return_value.get_or_create_collection.return_value = mock_col
+            mock_col.get.return_value = {
+                "ids": ["c1", "c2", "c3", "c4"],
+                "metadatas": [
+                    {"source": "notes.txt"},
+                    {"source": "notes.txt"},
+                    {"source": "report.pdf"},
+                    {"source": "report.pdf"},
+                ],
+            }
+            store = OpenVectorStore(config)
+            result = store.list_documents()
+
+        assert len(result) == 2
+        by_source = {d["source"]: d for d in result}
+        assert by_source["notes.txt"]["chunks"] == 2
+        assert by_source["report.pdf"]["chunks"] == 2
+        assert set(by_source["notes.txt"]["doc_ids"]) == {"c1", "c2"}
+
+    def test_chroma_handles_missing_source_metadata(self):
+        from rag_brain.main import OpenVectorStore, OpenStudioConfig
+        from unittest.mock import MagicMock, patch
+
+        config = OpenStudioConfig(vector_store="chroma")
+        with patch("chromadb.PersistentClient") as MockClient:
+            mock_col = MagicMock()
+            MockClient.return_value.get_or_create_collection.return_value = mock_col
+            mock_col.get.return_value = {
+                "ids": ["x1"],
+                "metadatas": [{}],  # no 'source' key
+            }
+            store = OpenVectorStore(config)
+            result = store.list_documents()
+
+        assert len(result) == 1
+        assert result[0]["source"] == "unknown"


### PR DESCRIPTION
Two bugs fixed in truth grounding / Brave Search:

**Bug 1 — Wrong trigger**: Brave Search always fired when truth_grounding=True, even when local docs were sufficient. Now it only fires when local results are empty after filtering.

**Bug 2 — LLM blind to context origin**: Web results were formatted as [Document N] identical to local docs. LLM had no way to know they came from the web, causing it to say 'I cannot search the internet'.

## New agentic flow
1. Local vector + BM25 retrieval runs
2. Filtered by similarity threshold
3. If results still empty AND truth_grounding=True → Brave Search fires as fallback
4. LLM receives dynamic system prompt based on state:
   - truth_grounding OFF → base prompt unchanged
   - truth_grounding ON, local answered → prompt notes 'web search available but not needed'
   - truth_grounding ON, web used → prompt says 'web search was used, cite URLs'

## Context labeling
- Local: [Document N (ID: ...)]
- Web:   [Web Result N — Title (url)]