### PR TITLE
feat: implement inline citations, RAPTOR, GraphRAG, and evaluation CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
             echo "No tests found — skipping pytest. Add tests to tests/ to enable this step."
           fi
 
+      - name: Run RAG evaluation smoke tests
+        run: |
+          python -m pytest tests/test_eval_smoke.py -m eval -v --tb=short --no-header
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -68,10 +68,10 @@ Current system indexes fixed-size chunks. SOTA systems use more sophisticated in
 - **Why it matters:** Enables both fine-grained chunk retrieval (leaf level) and broad thematic retrieval (summary level). Especially effective for long documents and thematic questions.
 - **Papers:** Sarthi et al., 2024 — "RAPTOR: Recursive Abstractive Processing for Tree-Organized Retrieval"
 
-#### 2.2 Parent-Document / Small-to-Big Retrieval
-- **What it does:** Indexes small, granular chunks (sentences or short passages) for precise semantic matching, but when retrieved, returns the full parent paragraph or section as context.
-- **Why it matters:** Small chunks = precise retrieval; large context = better answer generation. Best of both worlds.
-- **Implementation note:** Requires storing chunk-to-parent mapping in metadata.
+#### 2.2 Parent-Document / Small-to-Big Retrieval ✅ DONE
+- **Status:** Implemented. Set `parent_chunk_size: 2000` (or any value > `chunk_size`) in `config.yaml` under `rag:`, or use `--parent-chunk-size 2000` CLI flag.
+- **What it does:** Indexes small child chunks (`chunk_size`) for precise semantic matching. At generation time, returns the full parent passage (`parent_chunk_size`) as LLM context. Parent text stored in chunk metadata — no separate store needed.
+- **Typical config:** `chunk_size: 256`, `parent_chunk_size: 1500` gives precise retrieval with rich context windows.
 
 #### 2.3 Sentence-Window Retrieval
 - **What it does:** Embeds individual sentences for retrieval, but returns a sliding window of ±2–3 surrounding sentences as the actual context.
@@ -90,10 +90,10 @@ Current system indexes fixed-size chunks. SOTA systems use more sophisticated in
 - **Status:** Implemented. Set `reranker_provider: llm` in config or pass `"rerank": true` to the API. Uses the configured LLM to score each document with a ThreadPoolExecutor for speed.
 - **Papers:** Sun et al., 2023 — "Is ChatGPT Good at Search? Investigating Large Language Models as Re-Ranking Agents"
 
-#### 3.2 BGE Reranker v2-m3 — ⚙️ AVAILABLE (config only)
-- **Status:** Usable today — set `reranker_model: "BAAI/bge-reranker-v2-m3"` in `config.yaml`. No code changes needed; `sentence-transformers` CrossEncoder loads it automatically.
+#### 3.2 BGE Reranker v2-m3 ✅ DONE
+- **Status:** Fully accessible. Use `--reranker-model BAAI/bge-reranker-v2-m3` (CLI) or set `reranker_model: "BAAI/bge-reranker-v2-m3"` in `config.yaml` under `rerank:`. No code changes needed; `sentence-transformers` CrossEncoder loads it automatically.
 - **Why it matters:** Significantly outperforms the default `ms-marco-MiniLM-L-6-v2` on BEIR benchmarks; supports 100+ languages.
-- **Effort to surface:** Low — add it as a documented preset or default recommendation.
+- **Default kept as** `ms-marco-MiniLM-L-6-v2` (smaller, faster, already commonly cached). Upgrade when accuracy matters more than speed.
 
 #### 3.3 Contextual Compression — ⬜ MISSING
 - **What it does:** After retrieval, uses an LLM to extract only the specific sentences directly relevant to the query, discarding surrounding noise.
@@ -212,14 +212,14 @@ Ordered by **impact / effort** ratio. ✅ = shipped, ⬜ = open.
 | ~~6~~ | ~~Ingest deduplication~~ | Low | Medium | ✅ Shipped (default on) |
 | ~~7~~ | ~~API parity with CLI~~ | Low | High | ✅ Shipped |
 | ~~8~~ | ~~Step-back prompting~~ | Low | Medium | ✅ Shipped |
-| 1 | **BGE Reranker v2-m3** (default model swap) | Low | Medium | ⬜ Config only — needs docs/default change |
-| 2 | **Parent-document / small-to-big retrieval** | Medium | High | ⬜ Not implemented |
-| 3 | **Query decomposition** | Medium | Medium | ⬜ Not implemented |
-| 4 | **Context compression (LLMLingua)** | Medium | Medium | ⬜ Not implemented |
-| 5 | **Inline chunk-level citations in answers** | Medium | Medium | ⬜ Partial — sources in stream but not in text |
-| 6 | **RAPTOR hierarchical indexing** | High | High | ⬜ Not implemented |
-| 7 | **GraphRAG integration** | High | High | ⬜ Not implemented |
-| 8 | **Evaluation in CI** | Medium | Medium | ⬜ Script exists; not in CI pipeline |
+| ~~9~~ | ~~BGE Reranker v2-m3~~ | Low | Medium | ✅ Shipped — `--reranker-model BAAI/bge-reranker-v2-m3` or config |
+| ~~10~~ | ~~Parent-document / small-to-big retrieval~~ | Medium | High | ✅ Shipped — `parent_chunk_size` config / `--parent-chunk-size` CLI |
+| 1 | **Query decomposition** | Medium | Medium | ⬜ Not implemented |
+| 2 | **Context compression (LLMLingua)** | Medium | Medium | ⬜ Not implemented |
+| 3 | **Inline chunk-level citations in answers** | Medium | Medium | ⬜ Partial — sources in stream but not in text |
+| 4 | **RAPTOR hierarchical indexing** | High | High | ⬜ Not implemented |
+| 5 | **GraphRAG integration** | High | High | ⬜ Not implemented |
+| 6 | **Evaluation in CI** | Medium | Medium | ⬜ Script exists; not in CI pipeline |
 
 ---
 
@@ -241,4 +241,4 @@ Ordered by **impact / effort** ratio. ✅ = shipped, ⬜ = open.
 
 ---
 
-*Last updated: March 2026 — Sprint 2 (API parity + caching + dedup + step-back)*
+*Last updated: March 2026 — Sprint 3 (BGE reranker flag + parent-document retrieval)*

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -17,7 +17,7 @@ The following features are already implemented:
 | **Query transformations** | HyDE, Multi-Query, Step-Back, Query Decomposition — all available via CLI flags, REPL slash commands (`/rag hyde`, `/rag multi`, `/rag step-back`, `/rag decompose`, `/rag compress`, `/rag cite`), and REST API overrides |
 | **Embedding providers** | sentence-transformers (`all-MiniLM-L6-v2`), Ollama (`nomic-embed-text`), FastEmbed (`BAAI/bge-small-en-v1.5`, BGE-M3 via fastembed), OpenAI |
 | **LLM** | Ollama (local), Gemini, OpenAI, Ollama Cloud, vLLM — all with streaming |
-| **Vector stores** | ChromaDB (default), Qdrant |
+| **Vector stores** | ChromaDB (default), Qdrant, LanceDB |
 | **Document formats** | PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, plain text, BMP/PNG/TIF/TIFF/PGM images |
 | **Multimodal** | Raster image ingestion (BMP/PNG/TIF/PGM) with VLM auto-captioning (llava) |
 | **Agent interface** | FastAPI with per-request RAG flag overrides (full CLI parity); 8+ REST endpoints |
@@ -87,7 +87,8 @@ Current system indexes fixed-size chunks. SOTA systems use more sophisticated in
 ### 3. Advanced Re-ranking — ✅ Partially Implemented
 
 #### 3.1 LLM-Based Pointwise Re-ranking (RankGPT) ✅ DONE
-- **Status:** Implemented. Set `reranker_provider: llm` in config or pass `"rerank": true` to the API. Uses the configured LLM to score each document with a ThreadPoolExecutor for speed.
+- **Status:** Implemented. Set `reranker_provider: llm` in config and pass `"rerank": true` to the API (or CLI). Uses the configured LLM to score each document with a ThreadPoolExecutor for speed.
+- **Note:** The `"rerank": true` API/CLI flag enables or disables re-ranking but does **not** change the `reranker_provider`. LLM-based RankGPT requires `reranker_provider: llm` set in `config.yaml`; the default provider is `cross-encoder`.
 - **Papers:** Sun et al., 2023 — "Is ChatGPT Good at Search? Investigating Large Language Models as Re-Ranking Agents"
 
 #### 3.2 BGE Reranker v2-m3 ✅ DONE

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -13,43 +13,49 @@ The following features are already implemented:
 | Category | What We Have |
 |----------|-------------|
 | **Retrieval** | Hybrid search: dense vector + BM25 keyword, fused via Reciprocal Rank Fusion (RRF) |
-| **Re-ranking** | Optional cross-encoder re-ranking (`cross-encoder/ms-marco-MiniLM-L-6-v2`) |
-| **Embedding providers** | sentence-transformers (`all-MiniLM-L6-v2`), Ollama (`nomic-embed-text`), FastEmbed (`BAAI/bge-small-en-v1.5`) |
-| **LLM** | Ollama-backed LLM with streaming (llama3.1, qwen2.5, phi3, mistral) |
-| **Vector stores** | ChromaDB (default), Qdrant |
+| **Re-ranking** | Cross-encoder re-ranking (`cross-encoder/ms-marco-MiniLM-L-6-v2`) **and** LLM-based pointwise re-ranking via `reranker_provider: llm` |
+| **Query transformations** | HyDE, Multi-Query, **Step-Back prompting** — all available via CLI flags, REPL slash commands, and REST API overrides |
+| **Embedding providers** | sentence-transformers (`all-MiniLM-L6-v2`), Ollama (`nomic-embed-text`), FastEmbed (`BAAI/bge-small-en-v1.5`, BGE-M3 via fastembed), OpenAI |
+| **LLM** | Ollama (local), Gemini, OpenAI, Ollama Cloud, vLLM — all with streaming |
+| **Vector stores** | ChromaDB (default), Qdrant, LanceDB |
 | **Document formats** | PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, plain text, BMP/PNG/TIF/TIFF/PGM images |
 | **Multimodal** | Raster image ingestion (BMP/PNG/TIF/PGM) with VLM auto-captioning (llava) |
-| **Agent interface** | FastAPI with 6 OpenAI-compatible tools |
+| **Agent interface** | FastAPI with per-request RAG flag overrides (full CLI parity); 8+ REST endpoints |
+| **Ingest quality** | Hash-based content deduplication on ingest (skips re-ingesting identical chunks) |
+| **Performance** | In-memory query result cache (`query_cache: true`) with LRU eviction |
+| **Web search** | Brave Search fallback when local KB is insufficient (truth grounding) |
 | **Evaluation** | RAGAS evaluation script (`scripts/evaluate.py`) |
 | **Chunking** | Recursive character text splitter with configurable size/overlap |
+| **Projects** | Named knowledge base namespaces with isolated vector/BM25 stores |
 
 ---
 
 ## Gaps vs. State of the Art
 
-### 1. Query Transformation — Not Implemented
+### 1. Query Transformation — ✅ Mostly Implemented
 
 Standard RAG sends the raw user query directly to the retriever. SOTA systems transform the query first.
 
-#### 1.1 HyDE — Hypothetical Document Embeddings
-- **What it does:** Generates a hypothetical "ideal" answer to the query using the LLM, then embeds that answer (not the original query) for retrieval. The hypothesis is semantically closer to relevant documents than a short question.
-- **Why it matters:** Short questions and long document chunks exist in very different embedding spaces. HyDE bridges this gap.
+#### 1.1 HyDE — Hypothetical Document Embeddings ✅ DONE
+- **Status:** Fully implemented. Enable with `--hyde` (CLI), `/rag hyde on` (REPL), or `"hyde": true` (API).
+- **What it does:** Generates a hypothetical "ideal" answer to the query using the LLM, then embeds that answer (not the original query) for retrieval.
 - **Impact:** ~5–15% recall improvement on knowledge-intensive tasks.
 - **Papers:** Gao et al., 2022 — "Precise Zero-Shot Dense Retrieval without Relevance Labels"
 
-#### 1.2 Multi-Query Retrieval
-- **What it does:** Generates N alternative phrasings of the user query (via LLM), runs retrieval for each, then deduplicates and merges results.
-- **Why it matters:** Eliminates single-phrasing bias; catches documents that use different vocabulary.
+#### 1.2 Multi-Query Retrieval ✅ DONE
+- **Status:** Fully implemented. Enable with `--multi-query` (CLI) or `"multi_query": true` (API).
+- **What it does:** Generates 3 alternative phrasings of the user query, runs retrieval for each, deduplicates and merges with the original.
 - **Impact:** Consistently improves recall with minimal added latency.
 
-#### 1.3 Step-Back Prompting
-- **What it does:** Prompts the LLM to first identify a higher-level concept or principle behind the user's question, then retrieves context for both the abstract and specific questions.
-- **Why it matters:** Useful when the question is highly specific and the KB has general background information.
+#### 1.3 Step-Back Prompting ✅ DONE
+- **Status:** Fully implemented. Enable with `--step-back` (CLI) or `"step_back": true` (API).
+- **What it does:** Generates an abstract, higher-level version of the query and runs retrieval for both the specific and abstract queries. Useful when KB has general background but query is highly specific.
 - **Papers:** Zheng et al., 2023 — "Take a Step Back: Evoking Reasoning via Abstraction in Large Language Models"
 
-#### 1.4 Query Decomposition
+#### 1.4 Query Decomposition — ⬜ MISSING
 - **What it does:** Breaks multi-part or complex questions into atomic sub-questions, retrieves independently, and synthesizes a combined answer.
 - **Why it matters:** Without decomposition, the retriever tries to satisfy multiple requirements with a single search — often poorly.
+- **Effort:** Medium — similar pattern to multi-query; needs a synthesis step.
 
 ---
 
@@ -78,24 +84,21 @@ Current system indexes fixed-size chunks. SOTA systems use more sophisticated in
 
 ---
 
-### 3. Advanced Re-ranking — Partially Implemented
+### 3. Advanced Re-ranking — ✅ Partially Implemented
 
-We have a single cross-encoder re-ranker. SOTA systems have multiple re-ranking options.
-
-#### 3.1 LLM-Based Listwise / Pointwise Re-ranking (RankGPT)
-- **What it does:** Uses the generation LLM itself to score or sort retrieved documents by relevance to the query.
-- **Why it matters:** LLMs have strong natural language understanding that cross-encoders lack. Can leverage existing Ollama infrastructure — no new model needed.
-- **Implementation note:** Pointwise scoring is simpler; listwise (permutation-based) is more accurate.
+#### 3.1 LLM-Based Pointwise Re-ranking (RankGPT) ✅ DONE
+- **Status:** Implemented. Set `reranker_provider: llm` in config or pass `"rerank": true` to the API. Uses the configured LLM to score each document with a ThreadPoolExecutor for speed.
 - **Papers:** Sun et al., 2023 — "Is ChatGPT Good at Search? Investigating Large Language Models as Re-Ranking Agents"
 
-#### 3.2 BGE Reranker v2-m3
-- **What it does:** A multilingual cross-encoder trained for retrieval re-ranking, significantly outperforming `ms-marco-MiniLM-L-6-v2` on BEIR benchmarks.
-- **Why it matters:** Drop-in replacement for the current re-ranker with substantially better accuracy; supports 100+ languages.
-- **Model:** `BAAI/bge-reranker-v2-m3` from HuggingFace
+#### 3.2 BGE Reranker v2-m3 — ⚙️ AVAILABLE (config only)
+- **Status:** Usable today — set `reranker_model: "BAAI/bge-reranker-v2-m3"` in `config.yaml`. No code changes needed; `sentence-transformers` CrossEncoder loads it automatically.
+- **Why it matters:** Significantly outperforms the default `ms-marco-MiniLM-L-6-v2` on BEIR benchmarks; supports 100+ languages.
+- **Effort to surface:** Low — add it as a documented preset or default recommendation.
 
-#### 3.3 Contextual Compression
-- **What it does:** After retrieval, uses an LLM to extract only the specific sentences or passages from each retrieved chunk that are directly relevant to the query. Discards irrelevant surrounding text.
+#### 3.3 Contextual Compression — ⬜ MISSING
+- **What it does:** After retrieval, uses an LLM to extract only the specific sentences directly relevant to the query, discarding surrounding noise.
 - **Why it matters:** Reduces context noise; allows fitting more unique sources into the LLM context window.
+- **Effort:** Medium.
 
 ---
 
@@ -185,34 +188,38 @@ Current gap: No evaluation runs in CI. No hallucination/groundedness metric is t
 
 ### 9. Infrastructure Gaps
 
-| Gap | Impact | Effort |
-|-----|--------|--------|
-| No query result caching | Every identical query hits the LLM | Low — add `functools.lru_cache` or Redis |
-| No metadata filtering in vector search | Can't filter by date, source, tag | Medium — ChromaDB/Qdrant support `where` filters |
-| No document deduplication | Re-ingesting same doc creates duplicates | Low — hash-based dedup on ingest |
-| No async streaming for hybrid path | BM25 runs sync, blocks | Medium |
-| No chunk-level source citations | Answers don't show which chunk they came from | Medium |
+| Gap | Impact | Effort | Status |
+|-----|--------|--------|--------|
+| Query result caching | Every identical query hits the LLM | Low | ✅ DONE — `query_cache: true` in config or `--cache` CLI |
+| Metadata filtering in vector search | Can't filter by date, source, tag | Medium | ✅ DONE — `filters` field on `/query` and `/search` endpoints |
+| Document deduplication on ingest | Re-ingesting same doc creates duplicates | Low | ✅ DONE — hash-based, enabled by default (`dedup_on_ingest: true`) |
+| Async streaming for hybrid path | BM25 runs sync, blocks | Medium | ⬜ Missing |
+| Chunk-level source citations in answers | Answers don't show which chunk they came from | Medium | ⚙️ Partial — sources returned in stream (`type: sources`); not yet inline in text |
 
 ---
 
 ## Priority Roadmap
 
-Ordered by **impact / effort** ratio:
+Ordered by **impact / effort** ratio. ✅ = shipped, ⬜ = open.
 
-| Priority | Feature | Effort | Impact |
-|----------|---------|--------|--------|
-| 1 | **Multi-query retrieval** | Low | High — recall improvement |
-| 2 | **BGE-M3 embedding support** | Low | High — SOTA local embeddings |
-| 3 | **HyDE query transformation** | Medium | High — precision improvement |
-| 4 | **Parent-document / small-to-big retrieval** | Medium | High — context quality |
-| 5 | **LLM-based re-ranking (RankGPT)** | Medium | High — uses existing Ollama |
-| 6 | **Query result caching** | Low | Medium — latency/cost |
-| 7 | **Metadata filtering** | Medium | Medium — precision queries |
-| 8 | **BGE Reranker v2-m3** | Low | Medium — better re-ranking |
-| 9 | **Context compression (LLMLingua)** | Medium | Medium — context efficiency |
-| 10 | **RAPTOR hierarchical indexing** | High | High — thematic queries |
-| 11 | **GraphRAG integration** | High | High — new query types |
-| 12 | **CRAG (web fallback)** | High | Medium — KB gap handling |
+| Priority | Feature | Effort | Impact | Status |
+|----------|---------|--------|--------|--------|
+| ~~1~~ | ~~Multi-query retrieval~~ | Low | High | ✅ Shipped |
+| ~~2~~ | ~~BGE-M3 embedding support~~ | Low | High | ✅ Via FastEmbed |
+| ~~3~~ | ~~HyDE query transformation~~ | Medium | High | ✅ Shipped |
+| ~~4~~ | ~~LLM-based re-ranking (RankGPT)~~ | Medium | High | ✅ Shipped |
+| ~~5~~ | ~~Query result caching~~ | Low | Medium | ✅ Shipped |
+| ~~6~~ | ~~Ingest deduplication~~ | Low | Medium | ✅ Shipped (default on) |
+| ~~7~~ | ~~API parity with CLI~~ | Low | High | ✅ Shipped |
+| ~~8~~ | ~~Step-back prompting~~ | Low | Medium | ✅ Shipped |
+| 1 | **BGE Reranker v2-m3** (default model swap) | Low | Medium | ⬜ Config only — needs docs/default change |
+| 2 | **Parent-document / small-to-big retrieval** | Medium | High | ⬜ Not implemented |
+| 3 | **Query decomposition** | Medium | Medium | ⬜ Not implemented |
+| 4 | **Context compression (LLMLingua)** | Medium | Medium | ⬜ Not implemented |
+| 5 | **Inline chunk-level citations in answers** | Medium | Medium | ⬜ Partial — sources in stream but not in text |
+| 6 | **RAPTOR hierarchical indexing** | High | High | ⬜ Not implemented |
+| 7 | **GraphRAG integration** | High | High | ⬜ Not implemented |
+| 8 | **Evaluation in CI** | Medium | Medium | ⬜ Script exists; not in CI pipeline |
 
 ---
 
@@ -234,4 +241,4 @@ Ordered by **impact / effort** ratio:
 
 ---
 
-*Last updated: March 2026*
+*Last updated: March 2026 — Sprint 2 (API parity + caching + dedup + step-back)*

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -216,10 +216,10 @@ Ordered by **impact / effort** ratio. ✅ = shipped, ⬜ = open.
 | ~~10~~ | ~~Parent-document / small-to-big retrieval~~ | Medium | High | ✅ Shipped — `parent_chunk_size` config / `--parent-chunk-size` CLI |
 | ~~1~~ | ~~Query decomposition~~ | Medium | Medium | ✅ Shipped — `--decompose` CLI / `"decompose": true` API |
 | ~~2~~ | ~~Context compression (LLMLingua)~~ | Medium | Medium | ✅ Shipped (LLM-based) — `--compress` CLI / `"compress": true` API |
-| 3 | **Inline chunk-level citations in answers** | Medium | Medium | ⬜ Partial — sources in stream but not in text |
-| 4 | **RAPTOR hierarchical indexing** | High | High | ⬜ Not implemented |
-| 5 | **GraphRAG integration** | High | High | ⬜ Not implemented |
-| 6 | **Evaluation in CI** | Medium | Medium | ⬜ Script exists; not in CI pipeline |
+| ~~3~~ | ~~Inline chunk-level citations in answers~~ | Medium | Medium | ✅ Shipped — `--cite` CLI / `"cite": true` API / `cite_sources` config |
+| ~~4~~ | ~~RAPTOR hierarchical indexing~~ | High | High | ✅ Shipped — `--raptor` CLI / `rag.raptor` config; LLM summary nodes indexed alongside leaf chunks |
+| ~~5~~ | ~~GraphRAG integration~~ | High | High | ✅ Shipped — `--graph-rag` CLI / `rag.graph_rag` config; entity graph persisted to `.entity_graph.json`; result expansion at query time |
+| ~~6~~ | ~~Evaluation in CI~~ | Medium | Medium | ✅ Shipped — `tests/test_eval_smoke.py` (precision@k, context relevance, faithfulness, recall@k); `@pytest.mark.eval`; dedicated CI step |
 
 ---
 

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -14,15 +14,15 @@ The following features are already implemented:
 |----------|-------------|
 | **Retrieval** | Hybrid search: dense vector + BM25 keyword, fused via Reciprocal Rank Fusion (RRF) |
 | **Re-ranking** | Cross-encoder re-ranking (`cross-encoder/ms-marco-MiniLM-L-6-v2`) **and** LLM-based pointwise re-ranking via `reranker_provider: llm` |
-| **Query transformations** | HyDE, Multi-Query, **Step-Back prompting** — all available via CLI flags, REPL slash commands, and REST API overrides |
+| **Query transformations** | HyDE, Multi-Query, Step-Back, Query Decomposition — all available via CLI flags, REPL slash commands (`/rag hyde`, `/rag multi`, `/rag step-back`, `/rag decompose`, `/rag compress`, `/rag cite`), and REST API overrides |
 | **Embedding providers** | sentence-transformers (`all-MiniLM-L6-v2`), Ollama (`nomic-embed-text`), FastEmbed (`BAAI/bge-small-en-v1.5`, BGE-M3 via fastembed), OpenAI |
 | **LLM** | Ollama (local), Gemini, OpenAI, Ollama Cloud, vLLM — all with streaming |
-| **Vector stores** | ChromaDB (default), Qdrant, LanceDB |
+| **Vector stores** | ChromaDB (default), Qdrant |
 | **Document formats** | PDF, DOCX, HTML, CSV/TSV, Markdown, JSON, plain text, BMP/PNG/TIF/TIFF/PGM images |
 | **Multimodal** | Raster image ingestion (BMP/PNG/TIF/PGM) with VLM auto-captioning (llava) |
 | **Agent interface** | FastAPI with per-request RAG flag overrides (full CLI parity); 8+ REST endpoints |
 | **Ingest quality** | Hash-based content deduplication on ingest (skips re-ingesting identical chunks) |
-| **Performance** | In-memory query result cache (`query_cache: true`) with LRU eviction |
+| **Performance** | In-memory query result cache (`query_cache: true`) with true LRU eviction (`OrderedDict` + move-to-end on hit) |
 | **Web search** | Brave Search fallback when local KB is insufficient (truth grounding) |
 | **Evaluation** | RAGAS evaluation script (`scripts/evaluate.py`) |
 | **Chunking** | Recursive character text splitter with configurable size/overlap |
@@ -48,12 +48,12 @@ Standard RAG sends the raw user query directly to the retriever. SOTA systems tr
 - **Impact:** Consistently improves recall with minimal added latency.
 
 #### 1.3 Step-Back Prompting ✅ DONE
-- **Status:** Fully implemented. Enable with `--step-back` (CLI) or `"step_back": true` (API).
+- **Status:** Fully implemented. Enable with `--step-back` (CLI), `/rag step-back` (REPL), or `"step_back": true` (API).
 - **What it does:** Generates an abstract, higher-level version of the query and runs retrieval for both the specific and abstract queries. Useful when KB has general background but query is highly specific.
 - **Papers:** Zheng et al., 2023 — "Take a Step Back: Evoking Reasoning via Abstraction in Large Language Models"
 
 #### 1.4 Query Decomposition ✅ DONE
-- **Status:** Implemented. Enable with `--decompose` (CLI) or `"decompose": true` (API) or `query_decompose: true` in `config.yaml` under `query_transformations:`.
+- **Status:** Implemented. Enable with `--decompose` (CLI), `/rag decompose` (REPL), `"decompose": true` (API), or `query_decompose: true` in `config.yaml` under `query_transformations:`.
 - **What it does:** Uses the LLM to break complex multi-part questions into 2–4 atomic sub-questions, runs retrieval for each, merges and deduplicates results. Composes naturally with `multi_query` and `step_back`.
 - **Synthesis:** Retrieval merges across all sub-questions; a single LLM call generates the answer with the combined context (no extra LLM calls beyond decomposition itself).
 

--- a/SOTA_ANALYSIS.md
+++ b/SOTA_ANALYSIS.md
@@ -52,10 +52,10 @@ Standard RAG sends the raw user query directly to the retriever. SOTA systems tr
 - **What it does:** Generates an abstract, higher-level version of the query and runs retrieval for both the specific and abstract queries. Useful when KB has general background but query is highly specific.
 - **Papers:** Zheng et al., 2023 — "Take a Step Back: Evoking Reasoning via Abstraction in Large Language Models"
 
-#### 1.4 Query Decomposition — ⬜ MISSING
-- **What it does:** Breaks multi-part or complex questions into atomic sub-questions, retrieves independently, and synthesizes a combined answer.
-- **Why it matters:** Without decomposition, the retriever tries to satisfy multiple requirements with a single search — often poorly.
-- **Effort:** Medium — similar pattern to multi-query; needs a synthesis step.
+#### 1.4 Query Decomposition ✅ DONE
+- **Status:** Implemented. Enable with `--decompose` (CLI) or `"decompose": true` (API) or `query_decompose: true` in `config.yaml` under `query_transformations:`.
+- **What it does:** Uses the LLM to break complex multi-part questions into 2–4 atomic sub-questions, runs retrieval for each, merges and deduplicates results. Composes naturally with `multi_query` and `step_back`.
+- **Synthesis:** Retrieval merges across all sub-questions; a single LLM call generates the answer with the combined context (no extra LLM calls beyond decomposition itself).
 
 ---
 
@@ -95,10 +95,10 @@ Current system indexes fixed-size chunks. SOTA systems use more sophisticated in
 - **Why it matters:** Significantly outperforms the default `ms-marco-MiniLM-L-6-v2` on BEIR benchmarks; supports 100+ languages.
 - **Default kept as** `ms-marco-MiniLM-L-6-v2` (smaller, faster, already commonly cached). Upgrade when accuracy matters more than speed.
 
-#### 3.3 Contextual Compression — ⬜ MISSING
-- **What it does:** After retrieval, uses an LLM to extract only the specific sentences directly relevant to the query, discarding surrounding noise.
-- **Why it matters:** Reduces context noise; allows fitting more unique sources into the LLM context window.
-- **Effort:** Medium.
+#### 3.3 Contextual Compression ✅ DONE
+- **Status:** Implemented (LLM-based). Enable with `--compress` (CLI) or `"compress": true` (API) or `compress_context: true` in `config.yaml`.
+- **What it does:** After reranking, uses the generation LLM to extract only query-relevant sentences from each retrieved chunk (parallel via ThreadPoolExecutor). Falls back to the original chunk if compression fails or would expand the text. Integrates with small-to-big: compresses the parent passage, not the small child chunk.
+- **Note:** LLMLingua (token-level compression with a separate small LM) would be more efficient at scale but requires an additional model download. The LLM-based approach works out of the box with any configured provider.
 
 ---
 
@@ -214,8 +214,8 @@ Ordered by **impact / effort** ratio. ✅ = shipped, ⬜ = open.
 | ~~8~~ | ~~Step-back prompting~~ | Low | Medium | ✅ Shipped |
 | ~~9~~ | ~~BGE Reranker v2-m3~~ | Low | Medium | ✅ Shipped — `--reranker-model BAAI/bge-reranker-v2-m3` or config |
 | ~~10~~ | ~~Parent-document / small-to-big retrieval~~ | Medium | High | ✅ Shipped — `parent_chunk_size` config / `--parent-chunk-size` CLI |
-| 1 | **Query decomposition** | Medium | Medium | ⬜ Not implemented |
-| 2 | **Context compression (LLMLingua)** | Medium | Medium | ⬜ Not implemented |
+| ~~1~~ | ~~Query decomposition~~ | Medium | Medium | ✅ Shipped — `--decompose` CLI / `"decompose": true` API |
+| ~~2~~ | ~~Context compression (LLMLingua)~~ | Medium | Medium | ✅ Shipped (LLM-based) — `--compress` CLI / `"compress": true` API |
 | 3 | **Inline chunk-level citations in answers** | Medium | Medium | ⬜ Partial — sources in stream but not in text |
 | 4 | **RAPTOR hierarchical indexing** | High | High | ⬜ Not implemented |
 | 5 | **GraphRAG integration** | High | High | ⬜ Not implemented |
@@ -241,4 +241,4 @@ Ordered by **impact / effort** ratio. ✅ = shipped, ⬜ = open.
 
 ---
 
-*Last updated: March 2026 — Sprint 3 (BGE reranker flag + parent-document retrieval)*
+*Last updated: March 2026 — Sprint 4 (query decomposition + LLM context compression)*

--- a/config.yaml
+++ b/config.yaml
@@ -47,8 +47,11 @@ llm:
   temperature: 0.7
   max_tokens: 2048
 
+  # LLM request timeout in seconds (for openai/vllm providers that support it)
+  # llm_timeout: 60
+
 vector_store:
-  # Provider: chroma, qdrant
+  # Provider: chroma, qdrant, lancedb
   provider: chroma
   
   # Storage path
@@ -79,9 +82,20 @@ rag:
   # parent_chunk_size: 0
 
   # Inline source citations in LLM answers.
-  # When enabled the LLM is instructed to cite [Doc N] inline in its response.
+  # When enabled the LLM is instructed to cite [Document N (ID: ...)] inline in its response.
   # Also: --cite CLI flag, "cite": true API override.
   # cite_sources: false
+
+  # Query decomposition — break complex multi-part questions into 2–4 atomic sub-questions,
+  # run retrieval for each, and merge results before generation.
+  # Also: --decompose CLI flag, "decompose": true API override.
+  # query_decompose: false
+
+  # LLM context compression — after retrieval, use the generation LLM to extract only
+  # query-relevant sentences from each chunk before passing context to the answer step.
+  # Falls back to the original chunk if compression would expand the text.
+  # Also: --compress CLI flag, "compress": true API override.
+  # compress_context: false
 
   # RAPTOR hierarchical indexing (requires LLM during ingest — adds latency).
   # Groups consecutive chunks per source and generates LLM summary nodes

--- a/config.yaml
+++ b/config.yaml
@@ -61,16 +61,47 @@ bm25:
 rag:
   # Number of documents to retrieve
   top_k: 10
-  
+
   # Minimum similarity score (0-1).
   # Calibrated for all-MiniLM-L6-v2 (typical relevant scores: 0.30–0.60).
   # Raise to 0.5+ for stricter matching; lower to 0.2 for broader recall.
   # Also used as the web-search fallback trigger: if best cosine score < this
   # value, Brave Search fires (when truth_grounding is enabled).
   similarity_threshold: 0.3
-  
+
   # Enable hybrid search (vector + keyword)
   hybrid_search: true
+
+  # Parent-document / small-to-big retrieval.
+  # Set to a value larger than chunk.size (e.g. 3000) to index small child chunks
+  # for precision but return the richer parent passage to the LLM as context.
+  # 0 = disabled (use retrieval chunks directly).
+  # parent_chunk_size: 0
+
+  # Inline source citations in LLM answers.
+  # When enabled the LLM is instructed to cite [Doc N] inline in its response.
+  # Also: --cite CLI flag, "cite": true API override.
+  # cite_sources: false
+
+  # RAPTOR hierarchical indexing (requires LLM during ingest — adds latency).
+  # Groups consecutive chunks per source and generates LLM summary nodes
+  # that are indexed alongside leaf chunks for multi-hop questions.
+  # raptor: false
+  # raptor_chunk_group_size: 5
+
+  # GraphRAG entity-centric retrieval (requires LLM during ingest — adds latency).
+  # Extracts named entities from each chunk; expands query results at retrieval
+  # time using an entity→doc_id graph persisted to {bm25_path}/.entity_graph.json.
+  # graph_rag: false
+
+  # In-memory query result cache (LRU eviction, keyed on query + active flags).
+  # Speeds up repeated identical queries. Bypassed when chat history is non-empty.
+  # query_cache: false
+  # query_cache_size: 128
+
+  # Ingest deduplication — skip chunks with identical content (MD5 hash).
+  # Persisted to {bm25_path}/.content_hashes across restarts.
+  # dedup_on_ingest: true
 
 # Chunking Settings
 chunk:
@@ -88,6 +119,15 @@ query_transformations:
   multi_query: false
   hyde: false
   discussion_fallback: true
+  # step_back: false     # generate a more abstract query before retrieval
+  # query_decompose: false  # break complex questions into sub-questions
+
+# Context Compression
+# Uses the generation LLM to extract only query-relevant sentences from each
+# retrieved chunk before generation. Falls back to the full chunk if compression
+# would expand the text.
+# context_compression:
+#   enabled: false
 
 # Web Search / Truth Grounding
 # Uses Brave Search API to ground answers with live web results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ addopts = [
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
+    "eval: marks RAG evaluation smoke tests (precision@k, context relevance, faithfulness)",
 ]
 
 [tool.coverage.run]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ rich>=13.0.0
 # Vector Stores
 chromadb>=0.4.0
 qdrant-client>=1.7.0
+lancedb>=0.8.0
 
 # LLM Providers
 ollama>=0.1.0
@@ -33,6 +34,9 @@ tf-keras>=2.0.0
 python-docx>=1.0.0
 pymupdf>=1.24.0
 pypdf>=4.0.0
+
+# Optional: FastEmbed (lightweight embedding alternative to sentence-transformers)
+# fastembed>=0.2.0
 
 # Optional: For future vLLM support
 # vllm>=0.2.0

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -56,6 +56,8 @@ class QueryRequest(BaseModel):
     hyde: Optional[bool] = Field(None, description="Override HyDE query transformation toggle")
     multi_query: Optional[bool] = Field(None, description="Override multi-query retrieval toggle")
     step_back: Optional[bool] = Field(None, description="Override step-back prompting toggle")
+    decompose: Optional[bool] = Field(None, description="Override query decomposition toggle")
+    compress: Optional[bool] = Field(None, description="Override LLM context compression toggle")
     discuss: Optional[bool] = Field(None, description="Override discussion fallback toggle")
 
 class SearchRequest(BaseModel):
@@ -98,6 +100,8 @@ async def query_brain(request: QueryRequest):
             "hyde": request.hyde,
             "multi_query": request.multi_query,
             "step_back": request.step_back,
+            "query_decompose": request.decompose,
+            "compress_context": request.compress,
             "discussion_fallback": request.discuss,
         }
         response = brain.query(request.query, filters=request.filters, overrides=overrides)
@@ -109,6 +113,8 @@ async def query_brain(request: QueryRequest):
             "hyde": cfg.hyde,
             "multi_query": cfg.multi_query,
             "step_back": cfg.step_back,
+            "decompose": cfg.query_decompose,
+            "compress": cfg.compress_context,
             "discuss": cfg.discussion_fallback,
         }
         return {"query": request.query, "response": response, "settings": settings}
@@ -129,6 +135,8 @@ async def query_brain_stream(request: QueryRequest):
         "hyde": request.hyde,
         "multi_query": request.multi_query,
         "step_back": request.step_back,
+        "query_decompose": request.decompose,
+        "compress_context": request.compress,
         "discussion_fallback": request.discuss,
     }
 

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -48,6 +48,15 @@ class QueryRequest(BaseModel):
     query: str = Field(..., description="The question or prompt to ask the brain")
     filters: Optional[Dict[str, Any]] = Field(None, description="Metadata filters for retrieval")
     stream: bool = Field(False, description="Whether to stream the response (not fully implemented in REST yet)")
+    # Per-request RAG overrides (match CLI flags exactly)
+    top_k: Optional[int] = Field(None, description="Override number of chunks to retrieve")
+    threshold: Optional[float] = Field(None, description="Override similarity threshold (0.0–1.0)")
+    hybrid: Optional[bool] = Field(None, description="Override hybrid BM25+vector search toggle")
+    rerank: Optional[bool] = Field(None, description="Override cross-encoder re-ranking toggle")
+    hyde: Optional[bool] = Field(None, description="Override HyDE query transformation toggle")
+    multi_query: Optional[bool] = Field(None, description="Override multi-query retrieval toggle")
+    step_back: Optional[bool] = Field(None, description="Override step-back prompting toggle")
+    discuss: Optional[bool] = Field(None, description="Override discussion fallback toggle")
 
 class SearchRequest(BaseModel):
     query: str = Field(..., description="The query string for semantic search")
@@ -81,8 +90,28 @@ async def query_brain(request: QueryRequest):
     if not brain:
         raise HTTPException(status_code=503, detail="Brain not initialized")
     try:
-        response = brain.query(request.query, filters=request.filters)
-        return {"query": request.query, "response": response}
+        overrides = {
+            "top_k": request.top_k,
+            "similarity_threshold": request.threshold,
+            "hybrid_search": request.hybrid,
+            "rerank": request.rerank,
+            "hyde": request.hyde,
+            "multi_query": request.multi_query,
+            "step_back": request.step_back,
+            "discussion_fallback": request.discuss,
+        }
+        response = brain.query(request.query, filters=request.filters, overrides=overrides)
+        cfg = brain._apply_overrides(overrides)
+        settings = {
+            "top_k": cfg.top_k,
+            "hybrid": cfg.hybrid_search,
+            "rerank": cfg.rerank,
+            "hyde": cfg.hyde,
+            "multi_query": cfg.multi_query,
+            "step_back": cfg.step_back,
+            "discuss": cfg.discussion_fallback,
+        }
+        return {"query": request.query, "response": response, "settings": settings}
     except Exception as e:
         logger.error(f"Error during query: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -92,10 +121,21 @@ async def query_brain_stream(request: QueryRequest):
     if not brain:
         raise HTTPException(status_code=503, detail="Brain not initialized")
 
+    overrides = {
+        "top_k": request.top_k,
+        "similarity_threshold": request.threshold,
+        "hybrid_search": request.hybrid,
+        "rerank": request.rerank,
+        "hyde": request.hyde,
+        "multi_query": request.multi_query,
+        "step_back": request.step_back,
+        "discussion_fallback": request.discuss,
+    }
+
     def generate():
         try:
             import json
-            for chunk in brain.query_stream(request.query, filters=request.filters):
+            for chunk in brain.query_stream(request.query, filters=request.filters, overrides=overrides):
                 if isinstance(chunk, dict):
                     yield f"data: {json.dumps(chunk)}\n\n"
                 else:

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -1,5 +1,5 @@
-from fastapi import FastAPI, HTTPException, BackgroundTasks
-from fastapi.responses import StreamingResponse
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Request
+from fastapi.responses import StreamingResponse, JSONResponse
 from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Optional
 import os
@@ -30,6 +30,23 @@ app = FastAPI(
     version="2.0.0"
 )
 
+# Optional API key authentication — enabled when RAG_API_KEY env var is set
+_RAG_API_KEY: Optional[str] = os.getenv("RAG_API_KEY")
+
+@app.middleware("http")
+async def api_key_middleware(request: Request, call_next):
+    """Enforce X-API-Key header when RAG_API_KEY is configured."""
+    if _RAG_API_KEY:
+        # Allow health-check without auth so load-balancers can probe freely
+        if request.url.path != "/health":
+            provided = request.headers.get("X-API-Key")
+            if provided != _RAG_API_KEY:
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Invalid or missing X-API-Key header."},
+                )
+    return await call_next(request)
+
 # Global Brain Instance
 brain: Optional[OpenStudioBrain] = None
 
@@ -49,8 +66,8 @@ class QueryRequest(BaseModel):
     filters: Optional[Dict[str, Any]] = Field(None, description="Metadata filters for retrieval")
     stream: bool = Field(False, description="Whether to stream the response (not fully implemented in REST yet)")
     # Per-request RAG overrides (match CLI flags exactly)
-    top_k: Optional[int] = Field(None, description="Override number of chunks to retrieve")
-    threshold: Optional[float] = Field(None, description="Override similarity threshold (0.0–1.0)")
+    top_k: Optional[int] = Field(None, ge=1, description="Override number of chunks to retrieve")
+    threshold: Optional[float] = Field(None, ge=0.0, le=1.0, description="Override similarity threshold (0.0–1.0)")
     hybrid: Optional[bool] = Field(None, description="Override hybrid BM25+vector search toggle")
     rerank: Optional[bool] = Field(None, description="Override cross-encoder re-ranking toggle")
     hyde: Optional[bool] = Field(None, description="Override HyDE query transformation toggle")
@@ -76,6 +93,9 @@ class TextIngestRequest(BaseModel):
 
 class DeleteRequest(BaseModel):
     doc_ids: List[str] = Field(..., description="List of document IDs to delete")
+
+class ProjectSwitchRequest(BaseModel):
+    project_name: str = Field(..., description="Project name to switch to, or 'default' for the global knowledge base")
 
 class SearchResult(BaseModel):
     id: str
@@ -186,7 +206,7 @@ async def ingest_data(request: IngestRequest, background_tasks: BackgroundTasks)
     validated_path = _validate_ingest_path(request.path)
 
     try:
-        requested_path = pathlib.Path(validated_path).resolve()
+        requested_path = pathlib.Path(os.path.realpath(validated_path))
         if not requested_path.exists():
             raise HTTPException(status_code=404, detail="Path does not exist")
     except (ValueError, OSError) as e:
@@ -254,9 +274,7 @@ async def delete_documents(request: DeleteRequest):
     if brain is None:
         raise HTTPException(status_code=503, detail="Brain not initialized")
     try:
-        # Delete from ChromaDB if provider is chroma
-        if brain.vector_store.provider == "chroma":
-            brain.vector_store.collection.delete(ids=request.doc_ids)
+        brain.vector_store.delete_by_ids(request.doc_ids)
         # Delete from BM25
         if brain.bm25 is not None:
             brain.bm25.delete_documents(request.doc_ids)
@@ -264,6 +282,21 @@ async def delete_documents(request: DeleteRequest):
     except Exception as e:
         logger.error(f"Delete failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/project/switch")
+async def switch_project(request: ProjectSwitchRequest):
+    """Switch the active project, reinitializing vector store and BM25."""
+    if not brain:
+        raise HTTPException(status_code=503, detail="Brain not initialized")
+    try:
+        brain.switch_project(request.project_name)
+        return {"status": "success", "active_project": request.project_name}
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.error(f"Project switch failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
 
 def main():
     """Main entry point for rag-brain-api command."""

--- a/src/rag_brain/api.py
+++ b/src/rag_brain/api.py
@@ -59,6 +59,7 @@ class QueryRequest(BaseModel):
     decompose: Optional[bool] = Field(None, description="Override query decomposition toggle")
     compress: Optional[bool] = Field(None, description="Override LLM context compression toggle")
     discuss: Optional[bool] = Field(None, description="Override discussion fallback toggle")
+    cite: Optional[bool] = Field(None, description="Override inline source citation toggle")
 
 class SearchRequest(BaseModel):
     query: str = Field(..., description="The query string for semantic search")
@@ -103,6 +104,7 @@ async def query_brain(request: QueryRequest):
             "query_decompose": request.decompose,
             "compress_context": request.compress,
             "discussion_fallback": request.discuss,
+            "cite_sources": request.cite,
         }
         response = brain.query(request.query, filters=request.filters, overrides=overrides)
         cfg = brain._apply_overrides(overrides)
@@ -116,6 +118,7 @@ async def query_brain(request: QueryRequest):
             "decompose": cfg.query_decompose,
             "compress": cfg.compress_context,
             "discuss": cfg.discussion_fallback,
+            "cite": cfg.cite_sources,
         }
         return {"query": request.query, "response": response, "settings": settings}
     except Exception as e:
@@ -138,6 +141,7 @@ async def query_brain_stream(request: QueryRequest):
         "query_decompose": request.decompose,
         "compress_context": request.compress,
         "discussion_fallback": request.discuss,
+        "cite_sources": request.cite,
     }
 
     def generate():

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -106,7 +106,13 @@ class OpenStudioConfig:
     multi_query: bool = False
     hyde: bool = False
     step_back: bool = False
+    query_decompose: bool = False
     discussion_fallback: bool = True
+
+    # Context Compression
+    # Uses the generation LLM to extract only query-relevant sentences from each
+    # retrieved chunk before passing context to the final answer generation step.
+    compress_context: bool = False
 
     # Web Search / Truth Grounding
     truth_grounding: bool = False
@@ -159,9 +165,11 @@ class OpenStudioConfig:
                 config_dict['reranker_model'] = data['rerank']['model']
                 
         if 'query_transformations' in data:
-            for key in ('multi_query', 'hyde', 'step_back', 'discussion_fallback'):
+            for key in ('multi_query', 'hyde', 'step_back', 'query_decompose', 'discussion_fallback'):
                 if key in data['query_transformations']:
                     config_dict[key] = data['query_transformations'][key]
+        if 'context_compression' in data:
+            config_dict['compress_context'] = data['context_compression'].get('enabled', False)
         if 'web_search' in data:
             ws = data['web_search']
             config_dict['truth_grounding'] = ws.get('enabled', False)
@@ -999,6 +1007,65 @@ Your primary goal is to help the user by answering questions based on the provid
             "total_ms": round((time.time() - t0) * 1000, 1),
         })
 
+    def _decompose_query(self, query: str) -> List[str]:
+        """Break a complex query into atomic sub-questions for independent retrieval.
+
+        Returns the original query plus up to 4 sub-questions.
+        """
+        prompt = (
+            "Break the following question into 2–4 simpler, atomic sub-questions that together "
+            "cover all aspects of the original. Output each sub-question on a new line with no "
+            "numbering or bullet prefix. If the question is already simple, output it unchanged.\n\n"
+            "Question: " + query
+        )
+        response = self.llm.complete(prompt, system_prompt="You are an expert at decomposing complex questions.")
+        sub_qs = [q.strip("- \t1234567890.)") for q in response.split("\n") if q.strip()]
+        # Dedupe while preserving order; always keep original first
+        seen = {query}
+        unique = [query]
+        for q in sub_qs[:4]:
+            if q and q not in seen:
+                seen.add(q)
+                unique.append(q)
+        return unique
+
+    def _compress_context(self, query: str, results: List[Dict]) -> List[Dict]:
+        """Extract only query-relevant sentences from each retrieved chunk (parallel).
+
+        Compresses non-web results by asking the LLM to strip irrelevant text.
+        Falls back to the original chunk if compression fails or makes it longer.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        def _compress_one(result: Dict) -> Dict:
+            if result.get("is_web"):
+                return result
+            # Use parent_text if available (small-to-big path), else chunk text
+            source_text = result.get("metadata", {}).get("parent_text") or result["text"]
+            prompt = (
+                "Extract only the sentences from the passage below that directly help answer "
+                "the question. Output only those sentences verbatim, nothing else. "
+                "If no sentence is relevant, keep the single most informative sentence.\n\n"
+                f"Question: {query}\n\nPassage:\n{source_text}"
+            )
+            try:
+                compressed = self.llm.complete(prompt, system_prompt="You are an expert at extracting relevant information.")
+                if compressed and len(compressed.strip()) < len(source_text):
+                    r = {**result, "metadata": {**result.get("metadata", {})}}
+                    # Overwrite whichever field _build_context reads
+                    if "parent_text" in r["metadata"]:
+                        r["metadata"]["parent_text"] = compressed.strip()
+                    else:
+                        r["text"] = compressed.strip()
+                    r["metadata"]["compressed"] = True
+                    return r
+            except Exception as e:
+                logger.debug(f"Context compression failed for {result.get('id')}: {e}")
+            return result
+
+        with ThreadPoolExecutor(max_workers=min(len(results), 4)) as pool:
+            return list(pool.map(_compress_one, results))
+
     def _get_step_back_query(self, query: str) -> str:
         """Generate a more abstract, step-back version of the query for retrieval."""
         prompt = (
@@ -1059,7 +1126,7 @@ Your primary goal is to help the user by answering questions based on the provid
         """Central retrieval execution logic supporting HyDE, Multi-Query, and Web Search."""
         if cfg is None:
             cfg = self.config
-        transforms = {"hyde_applied": False, "multi_query_applied": False, "step_back_applied": False, "web_search_applied": False, "queries": [query]}
+        transforms = {"hyde_applied": False, "multi_query_applied": False, "step_back_applied": False, "decompose_applied": False, "web_search_applied": False, "queries": [query]}
 
         search_queries = [query]
         vector_query = query
@@ -1074,6 +1141,17 @@ Your primary goal is to help the user by answering questions based on the provid
             if abstract_query not in search_queries:
                 search_queries = search_queries + [abstract_query]
             transforms['step_back_applied'] = True
+            transforms['queries'] = search_queries
+
+        if cfg.query_decompose:
+            sub_questions = self._decompose_query(query)
+            # Merge without duplicates, preserving order
+            existing = set(search_queries)
+            for sq in sub_questions:
+                if sq not in existing:
+                    search_queries = search_queries + [sq]
+                    existing.add(sq)
+            transforms['decompose_applied'] = True
             transforms['queries'] = search_queries
 
         if cfg.hyde:
@@ -1237,6 +1315,8 @@ Your primary goal is to help the user by answering questions based on the provid
         if cfg.rerank: results = self.reranker.rerank(query, results)
 
         results = results[:cfg.top_k]
+        if cfg.compress_context:
+            results = self._compress_context(query, results)
         final_count = len(results)
         top_score = results[0].get('score', 0) if results else 0
         context, has_web = self._build_context(results)
@@ -1271,6 +1351,8 @@ Your primary goal is to help the user by answering questions based on the provid
         if cfg.rerank: results = self.reranker.rerank(query, results)
 
         results = results[:cfg.top_k]
+        if cfg.compress_context:
+            results = self._compress_context(query, results)
         context, has_web = self._build_context(results)
         # Inject RAG context into system prompt so the user message stays as the plain
         # question — this keeps multi-turn chat_history consistent across turns.
@@ -1361,6 +1443,10 @@ def main():
                         help='Enable/disable multi-query retrieval')
     parser.add_argument('--step-back', action=argparse.BooleanOptionalAction, default=None,
                         help='Enable/disable step-back prompting (abstracts query before retrieval)')
+    parser.add_argument('--decompose', action=argparse.BooleanOptionalAction, default=None,
+                        help='Enable/disable query decomposition (breaks complex questions into sub-questions)')
+    parser.add_argument('--compress', action=argparse.BooleanOptionalAction, default=None,
+                        help='Enable/disable LLM context compression (extracts only relevant sentences before generation)')
     parser.add_argument('--cache', action=argparse.BooleanOptionalAction, default=None,
                         help='Enable/disable in-memory query result caching')
     parser.add_argument('--no-dedup', action='store_true',
@@ -1429,6 +1515,10 @@ def main():
         config.multi_query = args.multi_query
     if args.step_back is not None:
         config.step_back = args.step_back
+    if args.decompose is not None:
+        config.query_decompose = args.decompose
+    if args.compress is not None:
+        config.compress_context = args.compress
     if args.cache is not None:
         config.query_cache = args.cache
     if args.no_dedup:

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -761,6 +761,25 @@ class OpenVectorStore:
             ):
                 docs.append({"id": doc_id, "text": text or "", "score": 1.0, "metadata": meta or {}})
             return docs
+        if self.provider == "qdrant":
+            try:
+                points = self.client.retrieve(
+                    collection_name="rag_brain",
+                    ids=ids,
+                    with_payload=True,
+                )
+                return [
+                    {
+                        "id": str(p.id),
+                        "text": p.payload.get("text", ""),
+                        "score": 1.0,
+                        "metadata": {k: v for k, v in p.payload.items() if k != "text"},
+                    }
+                    for p in points
+                ]
+            except Exception as e:
+                logger.debug(f"GraphRAG get_by_ids (Qdrant) failed: {e}")
+                return []
         return []
 
 
@@ -858,8 +877,11 @@ Your primary goal is to help the user by answering questions based on the provid
         except ImportError:
             self.splitter = None
 
-        # In-memory query result cache (keyed by hash of query + filters + active flags)
-        self._query_cache: Dict[str, str] = {}
+        # In-memory query result cache (keyed by hash of query + filters + active flags).
+        # Uses OrderedDict for true LRU eviction: hits are moved to the end so the
+        # least-recently-used entry is always at the front and evicted first.
+        from collections import OrderedDict
+        self._query_cache: "OrderedDict[str, str]" = OrderedDict()
 
         # Content hash store for ingest deduplication
         self._ingested_hashes: set = self._load_hash_store()
@@ -904,6 +926,13 @@ Your primary goal is to help the user by answering questions based on the provid
             self.bm25 = BM25Retriever(storage_path=self.config.bm25_path)
         except ImportError:
             self.bm25 = None
+
+        # Reload project-scoped state so dedup/GraphRAG use the new project's data
+        # and cached answers from the previous project cannot bleed across.
+        from collections import OrderedDict
+        self._query_cache = OrderedDict()
+        self._ingested_hashes = self._load_hash_store()
+        self._entity_graph = self._load_entity_graph()
 
         self._active_project = name
         set_active_project(name)
@@ -996,9 +1025,12 @@ Your primary goal is to help the user by answering questions based on the provid
                     )
                     if not summary_text or not summary_text.strip():
                         continue
-                    # Build a deterministic ID from source + window position
+                    # Build a deterministic ID from source + window position + content
+                    # so that re-ingesting updated content produces a new ID and
+                    # does not silently collide with a stale RAPTOR node in the store.
                     import hashlib
-                    uid = hashlib.md5(f"{source}|raptor|{i}".encode()).hexdigest()[:12]
+                    content_sig = hashlib.md5(summary_text.strip().encode("utf-8", errors="replace")).hexdigest()[:8]
+                    uid = hashlib.md5(f"{source}|raptor|{i}|{content_sig}".encode()).hexdigest()[:12]
                     summaries.append({
                         "id": f"raptor_{uid}",
                         "text": summary_text.strip(),
@@ -1016,7 +1048,7 @@ Your primary goal is to help the user by answering questions based on the provid
             logger.info(f"   RAPTOR: generated {len(summaries)} summary node(s)")
         return summaries
 
-    def _expand_with_entity_graph(self, query: str, results: List[Dict]) -> List[Dict]:
+    def _expand_with_entity_graph(self, query: str, results: List[Dict], cfg=None) -> List[Dict]:
         """Expand retrieval results using GraphRAG entity linkage.
 
         1. Extract entities from the query.
@@ -1027,6 +1059,8 @@ Your primary goal is to help the user by answering questions based on the provid
         query_entities = self._extract_entities(query)
         if not query_entities:
             return results
+
+        active_top_k = (cfg.top_k if cfg is not None else None) or self.config.top_k
 
         existing_ids = {r["id"] for r in results}
         extra_ids: List[str] = []
@@ -1040,9 +1074,9 @@ Your primary goal is to help the user by answering questions based on the provid
         if not extra_ids:
             return results
 
-        # Fetch the extra chunks from the vector store (up to top_k worth)
+        # Fetch the extra chunks from the vector store (capped to the active top_k)
         try:
-            extra_results = self.vector_store.get_by_ids(extra_ids[: self.config.top_k])
+            extra_results = self.vector_store.get_by_ids(extra_ids[:active_top_k])
             if extra_results:
                 logger.info(f"   GraphRAG: expanded results by {len(extra_results)} entity-linked doc(s)")
                 results = list(results) + extra_results
@@ -1057,19 +1091,34 @@ Your primary goal is to help the user by answering questions based on the provid
         return hashlib.md5(doc.get("text", "").encode("utf-8", errors="replace")).hexdigest()
 
     def _make_cache_key(self, query: str, filters, cfg) -> str:
-        """Return a stable cache key for the given query + active config."""
+        """Return a stable cache key for the given query + active config.
+
+        All flags that change retrieval or generation are included so two
+        requests that differ only by (e.g.) cite_sources or compress_context
+        receive distinct cache entries.
+        """
         import hashlib, json
+        # Serialize filters safely regardless of type
+        try:
+            filters_key = json.dumps(filters or {}, sort_keys=True, default=str)
+        except Exception:
+            filters_key = str(filters)
         key_data = {
             "q": query,
-            "f": filters or {},
+            "f": filters_key,
             "top_k": cfg.top_k,
             "hybrid": cfg.hybrid_search,
             "rerank": cfg.rerank,
             "hyde": cfg.hyde,
             "multi_query": cfg.multi_query,
             "step_back": cfg.step_back,
+            "query_decompose": cfg.query_decompose,
             "threshold": cfg.similarity_threshold,
             "discuss": cfg.discussion_fallback,
+            "compress_context": cfg.compress_context,
+            "cite_sources": cfg.cite_sources,
+            "truth_grounding": cfg.truth_grounding,
+            "graph_rag": cfg.graph_rag,
         }
         return hashlib.md5(json.dumps(key_data, sort_keys=True).encode()).hexdigest()
 
@@ -1227,6 +1276,9 @@ Your primary goal is to help the user by answering questions based on the provid
         Compresses non-web results by asking the LLM to strip irrelevant text.
         Falls back to the original chunk if compression fails or makes it longer.
         """
+        if not results:
+            return results
+
         from concurrent.futures import ThreadPoolExecutor
 
         def _compress_one(result: Dict) -> Dict:
@@ -1401,7 +1453,7 @@ Your primary goal is to help the user by answering questions based on the provid
 
         # GraphRAG: expand results with entity-linked documents
         if cfg.graph_rag and self._entity_graph:
-            results = self._expand_with_entity_graph(query, results)
+            results = self._expand_with_entity_graph(query, results, cfg=cfg)
 
         # Web Search (Truth Grounding)
         # Trigger when the best cosine similarity from vector search is below the threshold,
@@ -1495,10 +1547,13 @@ Your primary goal is to help the user by answering questions based on the provid
         cfg = self._apply_overrides(overrides)
 
         # Cache lookup (only when chat_history is empty — cached responses don't track turns)
-        if cfg.query_cache and not chat_history:
+        cache_key = None
+        if cfg.query_cache and not chat_history and cfg.query_cache_size >= 1:
             cache_key = self._make_cache_key(query, filters, cfg)
             if cache_key in self._query_cache:
                 logger.info(f"💾 Cache hit for query: {query[:60]}")
+                # Move to end so this entry is treated as most-recently-used (LRU)
+                self._query_cache.move_to_end(cache_key)
                 return self._query_cache[cache_key]
 
         retrieval = self._execute_retrieval(query, filters, cfg=cfg)
@@ -1529,11 +1584,12 @@ Your primary goal is to help the user by answering questions based on the provid
         self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'],
                                 retrieval['filtered_count'], final_count, top_score, (time.time() - t0) * 1000, retrieval['transforms'])
 
-        if cfg.query_cache and not chat_history:
-            # Evict oldest entry if cache is full
+        if cache_key is not None:
+            # Evict least-recently-used entry when cache is at capacity
             if len(self._query_cache) >= cfg.query_cache_size:
-                self._query_cache.pop(next(iter(self._query_cache)))
+                self._query_cache.popitem(last=False)  # pop LRU (front of OrderedDict)
             self._query_cache[cache_key] = response
+            self._query_cache.move_to_end(cache_key)  # mark as most-recently-used
 
         return response
 
@@ -2649,7 +2705,7 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                                              display_meta=f"{turns} turns")
                 # ── /rag <option> ─────────────────────────────────────────
                 elif text.startswith("/rag "):
-                    opts = ["topk ", "threshold ", "hybrid", "rerank", "hyde", "multi"]
+                    opts = ["topk ", "threshold ", "hybrid", "rerank", "rerank-model ", "hyde", "multi", "step-back", "decompose", "compress", "cite"]
                     prefix = text[len("/rag "):]
                     for o in opts:
                         if o.startswith(prefix):
@@ -2856,7 +2912,11 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                                     "  /rag rerank                  toggle cross-encoder reranker\n"
                                     "  /rag rerank-model <model>    set reranker model (HF ID or local path)\n"
                                     "  /rag hyde                    toggle HyDE query expansion\n"
-                                    "  /rag multi                   toggle multi-query expansion",
+                                    "  /rag multi                   toggle multi-query expansion\n"
+                                    "  /rag step-back               toggle step-back prompting\n"
+                                    "  /rag decompose               toggle query decomposition\n"
+                                    "  /rag compress                toggle LLM context compression\n"
+                                    "  /rag cite                    toggle inline [Doc N] citations",
                         "sessions": "  /sessions                    list recent saved sessions\n"
                                     "  /resume <id>                 load a session by ID\n"
                                     "  Sessions auto-save after each turn.",
@@ -3068,7 +3128,6 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                 print(f"  💬 Discussion mode {state}.")
 
             elif cmd == "/rag":
-                _RAG_TOGGLES = {"hybrid", "rerank", "hyde", "multi"}
                 if not arg:
                     print(
                         f"\n  top-k        · {brain.config.top_k}\n"
@@ -3078,6 +3137,10 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                         + (f"  [{brain.config.reranker_model}]" if brain.config.rerank else "") + "\n"
                         f"  hyde         · {'ON' if brain.config.hyde else 'OFF'}\n"
                         f"  multi-query  · {'ON' if brain.config.multi_query else 'OFF'}\n"
+                        f"  step-back    · {'ON' if brain.config.step_back else 'OFF'}\n"
+                        f"  decompose    · {'ON' if brain.config.query_decompose else 'OFF'}\n"
+                        f"  compress     · {'ON' if brain.config.compress_context else 'OFF'}\n"
+                        f"  cite         · {'ON' if brain.config.cite_sources else 'OFF'}\n"
                         f"\n  /help rag   for usage details\n"
                     )
                 else:
@@ -3112,6 +3175,18 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                     elif rag_opt == "multi":
                         brain.config.multi_query = not brain.config.multi_query
                         print(f"  ✅ Multi-query {'ON' if brain.config.multi_query else 'OFF'}")
+                    elif rag_opt == "step-back":
+                        brain.config.step_back = not brain.config.step_back
+                        print(f"  ✅ Step-back prompting {'ON' if brain.config.step_back else 'OFF'}")
+                    elif rag_opt == "decompose":
+                        brain.config.query_decompose = not brain.config.query_decompose
+                        print(f"  ✅ Query decomposition {'ON' if brain.config.query_decompose else 'OFF'}")
+                    elif rag_opt == "compress":
+                        brain.config.compress_context = not brain.config.compress_context
+                        print(f"  ✅ Context compression {'ON' if brain.config.compress_context else 'OFF'}")
+                    elif rag_opt == "cite":
+                        brain.config.cite_sources = not brain.config.cite_sources
+                        print(f"  ✅ Inline citations {'ON' if brain.config.cite_sources else 'OFF'}")
                     elif rag_opt == "rerank-model":
                         if not rag_val:
                             print(f"  Current reranker: {brain.config.reranker_model}")
@@ -3132,7 +3207,7 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                                 brain.config.rerank = False
                                 print(f"  ❌ Failed to load reranker: {e}")
                     else:
-                        print(f"  Unknown option '{rag_opt}'. Try: topk, threshold, hybrid, rerank, rerank-model, hyde, multi")
+                        print(f"  Unknown option '{rag_opt}'. Try: topk, threshold, hybrid, rerank, rerank-model, hyde, multi, step-back, decompose, compress, cite")
 
             elif cmd == "/compact":
                 _do_compact(brain, chat_history)

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -148,6 +148,9 @@ class OpenStudioConfig:
     # query are used to expand the result set with graph-connected documents.
     graph_rag: bool = False
 
+    # LLM request timeout in seconds (applied where the provider client supports it)
+    llm_timeout: int = 60
+
     @classmethod
     def load(cls, path: str = "config.yaml") -> 'OpenStudioConfig':
         """Load configuration from a YAML file."""
@@ -498,7 +501,8 @@ class OpenLLM:
                 model=self.config.llm_model,
                 messages=messages,
                 temperature=self.config.llm_temperature,
-                max_tokens=self.config.llm_max_tokens
+                max_tokens=self.config.llm_max_tokens,
+                timeout=self.config.llm_timeout,
             )
             return response.choices[0].message.content
 
@@ -516,6 +520,7 @@ class OpenLLM:
                 messages=messages,
                 temperature=self.config.llm_temperature,
                 max_tokens=self.config.llm_max_tokens,
+                timeout=self.config.llm_timeout,
             )
             return response.choices[0].message.content
 
@@ -635,7 +640,8 @@ class OpenLLM:
                 messages=messages,
                 temperature=self.config.llm_temperature,
                 max_tokens=self.config.llm_max_tokens,
-                stream=True
+                stream=True,
+                timeout=self.config.llm_timeout,
             )
             for chunk in stream:
                 if chunk.choices[0].delta.content is not None:
@@ -656,6 +662,7 @@ class OpenLLM:
                 temperature=self.config.llm_temperature,
                 max_tokens=self.config.llm_max_tokens,
                 stream=True,
+                timeout=self.config.llm_timeout,
             )
             for chunk in stream:
                 if chunk.choices[0].delta.content is not None:
@@ -687,7 +694,15 @@ class OpenVectorStore:
             from qdrant_client import QdrantClient
             logger.info(f"💾 Initializing Qdrant: {self.config.vector_store_path}")
             self.client = QdrantClient(path=self.config.vector_store_path)
-    
+        elif self.provider == "lancedb":
+            import lancedb
+            logger.info(f"💾 Initializing LanceDB: {self.config.vector_store_path}")
+            self.client = lancedb.connect(self.config.vector_store_path)
+            try:
+                self.collection = self.client.open_table("rag_brain")
+            except Exception:
+                self.collection = None   # created lazily on first add()
+
     def add(self, ids: List[str], texts: List[str], embeddings: List[List[float]], metadatas: List[Dict] = None):
         if self.provider == "chroma":
             self.collection.add(ids=ids, documents=texts, embeddings=embeddings, metadatas=metadatas)
@@ -699,7 +714,25 @@ class OpenVectorStore:
                 if metadatas: payload.update(metadatas[i])
                 points.append(PointStruct(id=id, vector=embedding, payload=payload))
             self.client.upsert(collection_name="rag_brain", points=points)
-    
+        elif self.provider == "lancedb":
+            import json
+            rows = []
+            for i, (doc_id, emb, text) in enumerate(zip(ids, embeddings, texts)):
+                meta = metadatas[i] if metadatas else {}
+                rows.append({
+                    "id": doc_id,
+                    "vector": emb,
+                    "text": text,
+                    "source": meta.get("source", ""),
+                    "metadata_json": json.dumps(meta),
+                })
+            if self.collection is None:
+                self.collection = self.client.create_table(
+                    "rag_brain", data=rows, mode="overwrite", metric="cosine"
+                )
+            else:
+                self.collection.add(rows)
+
     def list_documents(self) -> List[Dict[str, Any]]:
         """Return all unique source files stored in the knowledge base with chunk counts.
 
@@ -730,6 +763,19 @@ class OpenVectorStore:
                 sources[source]["chunks"] += 1
                 sources[source]["doc_ids"].append(str(point.id))
             return sorted(sources.values(), key=lambda x: x["source"])
+        elif self.provider == "lancedb":
+            import json
+            if self.collection is None:
+                return []
+            rows = self.collection.to_arrow().to_pydict()
+            sources: Dict[str, Dict[str, Any]] = {}
+            for doc_id, source in zip(rows.get("id", []), rows.get("source", [])):
+                src = source or "unknown"
+                if src not in sources:
+                    sources[src] = {"source": src, "chunks": 0, "doc_ids": []}
+                sources[src]["chunks"] += 1
+                sources[src]["doc_ids"].append(doc_id)
+            return sorted(sources.values(), key=lambda x: x["source"])
         return []
 
     def search(self, query_embedding: List[float], top_k: int = 10, filter_dict: Dict = None) -> List[Dict]:
@@ -742,6 +788,20 @@ class OpenVectorStore:
         elif self.provider == "qdrant":
             results = self.client.search(collection_name="rag_brain", query_vector=query_embedding, limit=top_k)
             return [{"id": str(r.id), "text": r.payload.get("text", ""), "score": r.score, "metadata": {k: v for k, v in r.payload.items() if k != "text"}} for r in results]
+        elif self.provider == "lancedb":
+            import json
+            if self.collection is None:
+                return []
+            results = self.collection.search(query_embedding).limit(top_k).to_list()
+            return [
+                {
+                    "id": r["id"],
+                    "text": r["text"],
+                    "score": max(0.0, 1.0 - r.get("_distance", 1.0)),
+                    "metadata": json.loads(r.get("metadata_json", "{}")),
+                }
+                for r in results
+            ]
 
     def get_by_ids(self, ids: List[str]) -> List[Dict]:
         """Fetch stored documents by their IDs (used by GraphRAG expansion).
@@ -753,13 +813,22 @@ class OpenVectorStore:
             return []
         if self.provider == "chroma":
             result = self.collection.get(ids=ids, include=["documents", "metadatas"])
+            result_ids = result.get("ids") or []
+            result_docs = result.get("documents") or []
+            result_metas = result.get("metadatas") or []
+            num_ids = len(result_ids)
+            if len(result_docs) < num_ids:
+                result_docs = list(result_docs) + [""] * (num_ids - len(result_docs))
+            if len(result_metas) < num_ids:
+                result_metas = list(result_metas) + [{}] * (num_ids - len(result_metas))
             docs = []
-            for doc_id, text, meta in zip(
-                result.get("ids", []),
-                result.get("documents", []),
-                result.get("metadatas", []) or [],
-            ):
-                docs.append({"id": doc_id, "text": text or "", "score": 1.0, "metadata": meta or {}})
+            for i in range(num_ids):
+                docs.append({
+                    "id": result_ids[i],
+                    "text": result_docs[i] or "",
+                    "score": 1.0,
+                    "metadata": result_metas[i] or {},
+                })
             return docs
         if self.provider == "qdrant":
             try:
@@ -780,7 +849,44 @@ class OpenVectorStore:
             except Exception as e:
                 logger.debug(f"GraphRAG get_by_ids (Qdrant) failed: {e}")
                 return []
+        if self.provider == "lancedb":
+            import json
+            if self.collection is None:
+                return []
+            try:
+                id_str = ", ".join(f"'{i}'" for i in ids)
+                rows = self.collection.search().where(f"id IN ({id_str})", prefilter=True).to_list()
+                return [
+                    {
+                        "id": r["id"],
+                        "text": r["text"],
+                        "score": 1.0,
+                        "metadata": json.loads(r.get("metadata_json", "{}")),
+                    }
+                    for r in rows
+                ]
+            except Exception as e:
+                logger.debug(f"GraphRAG get_by_ids (LanceDB) failed: {e}")
+                return []
         return []
+
+    def delete_by_ids(self, ids: List[str]) -> None:
+        """Delete documents by ID from the vector store."""
+        if not ids:
+            return
+        if self.provider == "chroma":
+            self.collection.delete(ids=ids)
+        elif self.provider == "qdrant":
+            from qdrant_client.models import PointIdsList
+            self.client.delete(
+                collection_name="rag_brain",
+                points_selector=PointIdsList(points=ids),
+            )
+        elif self.provider == "lancedb":
+            if self.collection is None:
+                return
+            id_str = ", ".join(f"'{i}'" for i in ids)
+            self.collection.delete(f"id IN ({id_str})")
 
 
 class OpenStudioBrain:
@@ -847,6 +953,18 @@ Your primary goal is to help the user by answering questions based on the provid
             if self.config.truth_grounding:
                 logger.info("Offline mode: disabling web search (truth_grounding → OFF)")
                 self.config.truth_grounding = False
+            if self.config.raptor:
+                logger.warning(
+                    "Offline mode: RAPTOR requires LLM calls and is not supported offline. "
+                    "Disabling raptor for this session."
+                )
+                self.config.raptor = False
+            if self.config.graph_rag:
+                logger.warning(
+                    "Offline mode: GraphRAG requires LLM calls and is not supported offline. "
+                    "Disabling graph_rag for this session."
+                )
+                self.config.graph_rag = False
             # Resolve bare HF model IDs to local paths
             self.config.embedding_model = self._resolve_model_path(self.config.embedding_model)
             self.config.reranker_model  = self._resolve_model_path(self.config.reranker_model)
@@ -882,6 +1000,7 @@ Your primary goal is to help the user by answering questions based on the provid
         # least-recently-used entry is always at the front and evicted first.
         from collections import OrderedDict
         self._query_cache: "OrderedDict[str, str]" = OrderedDict()
+        self._cache_lock = threading.Lock()
 
         # Content hash store for ingest deduplication
         self._ingested_hashes: set = self._load_hash_store()
@@ -930,7 +1049,8 @@ Your primary goal is to help the user by answering questions based on the provid
         # Reload project-scoped state so dedup/GraphRAG use the new project's data
         # and cached answers from the previous project cannot bleed across.
         from collections import OrderedDict
-        self._query_cache = OrderedDict()
+        with self._cache_lock:
+            self._query_cache = OrderedDict()
         self._ingested_hashes = self._load_hash_store()
         self._entity_graph = self._load_entity_graph()
 
@@ -959,7 +1079,15 @@ Your primary goal is to help the user by answering questions based on the provid
         path = pathlib.Path(self.config.bm25_path) / ".entity_graph.json"
         if path.exists():
             try:
-                return json.loads(path.read_text(encoding="utf-8"))
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(raw, dict):
+                    return {}
+                cleaned: Dict[str, List[str]] = {}
+                for key, value in raw.items():
+                    if not isinstance(key, str) or not isinstance(value, list):
+                        continue
+                    cleaned[key] = [v for v in value if isinstance(v, str)]
+                return cleaned
             except Exception:
                 pass
         return {}
@@ -1001,6 +1129,9 @@ Your primary goal is to help the user by answering questions based on the provid
         from itertools import groupby
 
         n = self.config.raptor_chunk_group_size
+        if n < 1:
+            logger.warning("raptor_chunk_group_size must be >= 1, skipping RAPTOR")
+            return []
         summaries = []
 
         # Group chunks by their source file so we only summarise within one document
@@ -1119,13 +1250,20 @@ Your primary goal is to help the user by answering questions based on the provid
             "cite_sources": cfg.cite_sources,
             "truth_grounding": cfg.truth_grounding,
             "graph_rag": cfg.graph_rag,
+            "llm_provider": cfg.llm_provider,
+            "llm_model": cfg.llm_model,
+            "embedding_provider": cfg.embedding_provider,
+            "embedding_model": cfg.embedding_model,
+            "reranker_model": cfg.reranker_model,
         }
         return hashlib.md5(json.dumps(key_data, sort_keys=True).encode()).hexdigest()
 
     def _log_query_metrics(self, query: str, vector_count: int, bm25_count: int,
                             filtered_count: int, final_count: int, top_score: float,
-                            latency_ms: float, transformations: Dict = None):
+                            latency_ms: float, transformations: Dict = None,
+                            cfg=None):
         """Log structured metrics for a query."""
+        active = cfg if cfg is not None else self.config
         logger.info({
             "event": "query_complete",
             "query_preview": query[:80],
@@ -1137,8 +1275,8 @@ Your primary goal is to help the user by answering questions based on the provid
                 "final": final_count,
             },
             "top_score": round(top_score, 4) if top_score else None,
-            "hybrid": self.config.hybrid_search,
-            "rerank": self.config.rerank,
+            "hybrid": active.hybrid_search,
+            "rerank": active.rerank,
             "transformations": transformations or {}
         })
 
@@ -1515,7 +1653,8 @@ Your primary goal is to help the user by answering questions based on the provid
         if cfg.cite_sources:
             base = base + (
                 "\n\n**Citation requirement**: When using information from the context, "
-                "cite it inline using the document label from the context block, e.g. [Doc 1], [Doc 2]. "
+                "cite it inline using the document label from the context block exactly as shown, "
+                "e.g. [Document 1 (ID: ...)], [Document 2 (ID: ...)]. "
                 "Place the citation immediately after the relevant sentence or fact."
             )
         if not cfg.truth_grounding:
@@ -1550,18 +1689,19 @@ Your primary goal is to help the user by answering questions based on the provid
         cache_key = None
         if cfg.query_cache and not chat_history and cfg.query_cache_size >= 1:
             cache_key = self._make_cache_key(query, filters, cfg)
-            if cache_key in self._query_cache:
-                logger.info(f"💾 Cache hit for query: {query[:60]}")
-                # Move to end so this entry is treated as most-recently-used (LRU)
-                self._query_cache.move_to_end(cache_key)
-                return self._query_cache[cache_key]
+            with self._cache_lock:
+                if cache_key in self._query_cache:
+                    logger.info(f"💾 Cache hit for query: {query[:60]}")
+                    # Move to end so this entry is treated as most-recently-used (LRU)
+                    self._query_cache.move_to_end(cache_key)
+                    return self._query_cache[cache_key]
 
         retrieval = self._execute_retrieval(query, filters, cfg=cfg)
         results = retrieval['results']
 
         if not results:
             self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'],
-                                    retrieval['filtered_count'], 0, 0.0, (time.time() - t0) * 1000, retrieval['transforms'])
+                                    retrieval['filtered_count'], 0, 0.0, (time.time() - t0) * 1000, retrieval['transforms'], cfg=cfg)
 
             if cfg.discussion_fallback:
                 # Send plain query as user message so multi-turn history stays consistent
@@ -1582,14 +1722,15 @@ Your primary goal is to help the user by answering questions based on the provid
         system_prompt = self._build_system_prompt(has_web, cfg=cfg) + f"\n\n**Relevant context from documents:**\n{context}"
         response = self.llm.complete(query, system_prompt, chat_history=chat_history)
         self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'],
-                                retrieval['filtered_count'], final_count, top_score, (time.time() - t0) * 1000, retrieval['transforms'])
+                                retrieval['filtered_count'], final_count, top_score, (time.time() - t0) * 1000, retrieval['transforms'], cfg=cfg)
 
         if cache_key is not None:
-            # Evict least-recently-used entry when cache is at capacity
-            if len(self._query_cache) >= cfg.query_cache_size:
-                self._query_cache.popitem(last=False)  # pop LRU (front of OrderedDict)
-            self._query_cache[cache_key] = response
-            self._query_cache.move_to_end(cache_key)  # mark as most-recently-used
+            with self._cache_lock:
+                # Evict least-recently-used entry when cache is at capacity
+                if len(self._query_cache) >= cfg.query_cache_size and self._query_cache:
+                    self._query_cache.popitem(last=False)  # pop LRU (front of OrderedDict)
+                self._query_cache[cache_key] = response
+                self._query_cache.move_to_end(cache_key)  # mark as most-recently-used
 
         return response
 
@@ -2705,7 +2846,7 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                                              display_meta=f"{turns} turns")
                 # ── /rag <option> ─────────────────────────────────────────
                 elif text.startswith("/rag "):
-                    opts = ["topk ", "threshold ", "hybrid", "rerank", "rerank-model ", "hyde", "multi", "step-back", "decompose", "compress", "cite"]
+                    opts = ["topk ", "threshold ", "hybrid", "rerank", "rerank-model ", "hyde", "multi", "step-back", "decompose", "compress", "cite", "raptor", "graph-rag"]
                     prefix = text[len("/rag "):]
                     for o in opts:
                         if o.startswith(prefix):
@@ -2916,7 +3057,9 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                                     "  /rag step-back               toggle step-back prompting\n"
                                     "  /rag decompose               toggle query decomposition\n"
                                     "  /rag compress                toggle LLM context compression\n"
-                                    "  /rag cite                    toggle inline [Doc N] citations",
+                                    "  /rag cite                    toggle inline [Document N] citations\n"
+                                    "  /rag raptor                  toggle RAPTOR hierarchical indexing\n"
+                                    "  /rag graph-rag               toggle GraphRAG entity retrieval",
                         "sessions": "  /sessions                    list recent saved sessions\n"
                                     "  /resume <id>                 load a session by ID\n"
                                     "  Sessions auto-save after each turn.",
@@ -3141,6 +3284,8 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                         f"  decompose    · {'ON' if brain.config.query_decompose else 'OFF'}\n"
                         f"  compress     · {'ON' if brain.config.compress_context else 'OFF'}\n"
                         f"  cite         · {'ON' if brain.config.cite_sources else 'OFF'}\n"
+                        f"  raptor       · {'ON' if brain.config.raptor else 'OFF'}\n"
+                        f"  graph-rag    · {'ON' if brain.config.graph_rag else 'OFF'}\n"
                         f"\n  /help rag   for usage details\n"
                     )
                 else:
@@ -3187,6 +3332,12 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                     elif rag_opt == "cite":
                         brain.config.cite_sources = not brain.config.cite_sources
                         print(f"  ✅ Inline citations {'ON' if brain.config.cite_sources else 'OFF'}")
+                    elif rag_opt == "raptor":
+                        brain.config.raptor = not brain.config.raptor
+                        print(f"  ✅ RAPTOR hierarchical indexing {'ON' if brain.config.raptor else 'OFF'}")
+                    elif rag_opt in ("graph-rag", "graph_rag", "graphrag"):
+                        brain.config.graph_rag = not brain.config.graph_rag
+                        print(f"  ✅ GraphRAG entity retrieval {'ON' if brain.config.graph_rag else 'OFF'}")
                     elif rag_opt == "rerank-model":
                         if not rag_val:
                             print(f"  Current reranker: {brain.config.reranker_model}")
@@ -3207,7 +3358,7 @@ def _interactive_repl(brain: 'OpenStudioBrain', stream: bool = True,
                                 brain.config.rerank = False
                                 print(f"  ❌ Failed to load reranker: {e}")
                     else:
-                        print(f"  Unknown option '{rag_opt}'. Try: topk, threshold, hybrid, rerank, rerank-model, hyde, multi, step-back, decompose, compress, cite")
+                        print(f"  Unknown option '{rag_opt}'. Try: topk, threshold, hybrid, rerank, rerank-model, hyde, multi, step-back, decompose, compress, cite, raptor, graph-rag")
 
             elif cmd == "/compact":
                 _do_compact(brain, chat_history)

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -97,11 +97,19 @@ class OpenStudioConfig:
     # Query Transformations
     multi_query: bool = False
     hyde: bool = False
+    step_back: bool = False
     discussion_fallback: bool = True
 
     # Web Search / Truth Grounding
     truth_grounding: bool = False
     brave_api_key: str = ""
+
+    # Query Result Caching
+    query_cache: bool = False
+    query_cache_size: int = 128
+
+    # Ingest Deduplication
+    dedup_on_ingest: bool = True
 
     # Offline Mode
     offline_mode: bool = False
@@ -797,7 +805,13 @@ Your primary goal is to help the user by answering questions based on the provid
             self.splitter = RecursiveCharacterTextSplitter(chunk_size=self.config.chunk_size, chunk_overlap=self.config.chunk_overlap)
         except ImportError:
             self.splitter = None
-        
+
+        # In-memory query result cache (keyed by hash of query + filters + active flags)
+        self._query_cache: Dict[str, str] = {}
+
+        # Content hash store for ingest deduplication
+        self._ingested_hashes: set = self._load_hash_store()
+
         logger.info("✅ Local RAG Brain ready!")
 
     def switch_project(self, name: str) -> None:
@@ -840,6 +854,43 @@ Your primary goal is to help the user by answering questions based on the provid
         set_active_project(name)
         logger.info(f"📂 Switched to project '{name}'")
     
+    def _load_hash_store(self) -> set:
+        """Load persisted content hashes for ingest deduplication."""
+        import pathlib
+        path = pathlib.Path(self.config.bm25_path) / ".content_hashes"
+        if path.exists():
+            return set(path.read_text(encoding="utf-8").splitlines())
+        return set()
+
+    def _save_hash_store(self) -> None:
+        """Persist content hashes to disk."""
+        import pathlib
+        path = pathlib.Path(self.config.bm25_path) / ".content_hashes"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join(self._ingested_hashes), encoding="utf-8")
+
+    def _doc_hash(self, doc: Dict) -> str:
+        """Return an MD5 hex digest of the document's text content."""
+        import hashlib
+        return hashlib.md5(doc.get("text", "").encode("utf-8", errors="replace")).hexdigest()
+
+    def _make_cache_key(self, query: str, filters, cfg) -> str:
+        """Return a stable cache key for the given query + active config."""
+        import hashlib, json
+        key_data = {
+            "q": query,
+            "f": filters or {},
+            "top_k": cfg.top_k,
+            "hybrid": cfg.hybrid_search,
+            "rerank": cfg.rerank,
+            "hyde": cfg.hyde,
+            "multi_query": cfg.multi_query,
+            "step_back": cfg.step_back,
+            "threshold": cfg.similarity_threshold,
+            "discuss": cfg.discussion_fallback,
+        }
+        return hashlib.md5(json.dumps(key_data, sort_keys=True).encode()).hexdigest()
+
     def _log_query_metrics(self, query: str, vector_count: int, bm25_count: int,
                             filtered_count: int, final_count: int, top_score: float,
                             latency_ms: float, transformations: Dict = None):
@@ -866,6 +917,24 @@ Your primary goal is to help the user by answering questions based on the provid
         from tqdm import tqdm
         logger.info(f"📥 Ingesting {len(documents)} documents...")
         if self.splitter: documents = self.splitter.transform_documents(documents)
+
+        if self.config.dedup_on_ingest:
+            before = len(documents)
+            new_docs = []
+            new_hashes = []
+            for doc in documents:
+                h = self._doc_hash(doc)
+                if h not in self._ingested_hashes:
+                    new_docs.append(doc)
+                    new_hashes.append(h)
+            skipped = before - len(new_docs)
+            if skipped:
+                logger.info(f"   Dedup: skipped {skipped} already-seen chunk(s), ingesting {len(new_docs)} new.")
+            documents = new_docs
+            if not documents:
+                return
+            self._ingested_hashes.update(new_hashes)
+            self._save_hash_store()
         n_chunks = len(documents)
         if self.bm25: self.bm25.add_documents(documents)
 
@@ -892,6 +961,15 @@ Your primary goal is to help the user by answering questions based on the provid
             "store_ms": round(store_ms, 1),
             "total_ms": round((time.time() - t0) * 1000, 1),
         })
+
+    def _get_step_back_query(self, query: str) -> str:
+        """Generate a more abstract, step-back version of the query for retrieval."""
+        prompt = (
+            "Given the following specific question, generate a more general, abstract version "
+            "of it that would help retrieve relevant background knowledge. Output only the "
+            "abstract question, nothing else.\n\nSpecific question: " + query
+        )
+        return self.llm.complete(prompt, system_prompt="You are an expert at abstracting questions to their core concepts.")
 
     def _get_hyde_document(self, query: str) -> str:
         """Generate a Hypothetical Document Embedding (HyDE) passage."""
@@ -940,30 +1018,39 @@ Your primary goal is to help the user by answering questions based on the provid
             logger.warning(f"🌐 Web search failed: {e}")
             return []
 
-    def _execute_retrieval(self, query: str, filters: Dict = None) -> Dict:
+    def _execute_retrieval(self, query: str, filters: Dict = None, cfg=None) -> Dict:
         """Central retrieval execution logic supporting HyDE, Multi-Query, and Web Search."""
-        transforms = {"hyde_applied": False, "multi_query_applied": False, "web_search_applied": False, "queries": [query]}
-        
+        if cfg is None:
+            cfg = self.config
+        transforms = {"hyde_applied": False, "multi_query_applied": False, "step_back_applied": False, "web_search_applied": False, "queries": [query]}
+
         search_queries = [query]
         vector_query = query
-        
-        if self.config.multi_query:
+
+        if cfg.multi_query:
             search_queries = self._get_multi_queries(query)
             transforms['multi_query_applied'] = True
             transforms['queries'] = search_queries
-            
-        if self.config.hyde:
+
+        if cfg.step_back:
+            abstract_query = self._get_step_back_query(query)
+            if abstract_query not in search_queries:
+                search_queries = search_queries + [abstract_query]
+            transforms['step_back_applied'] = True
+            transforms['queries'] = search_queries
+
+        if cfg.hyde:
             # We construct a single hypothetical document based on the primary query
             vector_query = self._get_hyde_document(query)
             transforms['hyde_applied'] = True
 
-        fetch_k = self.config.top_k * 3 if (self.config.rerank or self.config.hybrid_search) else self.config.top_k
-        
+        fetch_k = cfg.top_k * 3 if (cfg.rerank or cfg.hybrid_search) else cfg.top_k
+
         all_vector_results = []
         all_bm25_results = []
-        
+
         # Vector Search
-        if self.config.hyde:
+        if cfg.hyde:
              # HyDE uses a single hypothetical document as the vector query
              all_vector_results.extend(self.vector_store.search(self.embedding.embed_query(vector_query), top_k=fetch_k, filter_dict=filters))
         else:
@@ -976,7 +1063,7 @@ Your primary goal is to help the user by answering questions based on the provid
                  embeddings = self.embedding.embed(search_queries)
                  for emb in embeddings:
                      all_vector_results.extend(self.vector_store.search(emb, top_k=fetch_k, filter_dict=filters))
-        
+
         # Dedupe vector store results based on ID
         dedup_vector = {}
         for r in all_vector_results:
@@ -987,35 +1074,35 @@ Your primary goal is to help the user by answering questions based on the provid
 
         # Hybrid Search
         bm25_count = 0
-        if self.config.hybrid_search and self.bm25:
+        if cfg.hybrid_search and self.bm25:
             for sq in search_queries:
                 all_bm25_results.extend(self.bm25.search(sq, top_k=fetch_k))
-                
+
             dedup_bm25 = {}
             for r in all_bm25_results:
                 if r['id'] not in dedup_bm25 or r['score'] > dedup_bm25[r['id']]['score']:
                     dedup_bm25[r['id']] = r
             bm25_results = list(dedup_bm25.values())
             bm25_count = len(bm25_results)
-            
+
             from rag_brain.retrievers import reciprocal_rank_fusion
             results = reciprocal_rank_fusion(vector_results, bm25_results)
         else:
             results = vector_results
 
-        results = [r for r in results if r.get('score', 1.0) >= self.config.similarity_threshold or 'fused_only' in r]
+        results = [r for r in results if r.get('score', 1.0) >= cfg.similarity_threshold or 'fused_only' in r]
 
         # Web Search (Truth Grounding)
         # Trigger when the best cosine similarity from vector search is below the threshold,
         # meaning local knowledge is genuinely insufficient (even if BM25 returned fused_only docs).
         web_count = 0
-        if self.config.truth_grounding and self.config.brave_api_key:
+        if cfg.truth_grounding and cfg.brave_api_key:
             max_vector_score = max((r['score'] for r in vector_results), default=0.0)
-            local_sufficient = max_vector_score >= self.config.similarity_threshold
+            local_sufficient = max_vector_score >= cfg.similarity_threshold
             if not local_sufficient:
                 logger.info(
                     f"🌐 Local knowledge insufficient (best vector score {max_vector_score:.3f} < "
-                    f"threshold {self.config.similarity_threshold}) — falling back to Brave web search"
+                    f"threshold {cfg.similarity_threshold}) — falling back to Brave web search"
                 )
                 web_results = self._execute_web_search(query)
                 web_count = len(web_results)
@@ -1049,7 +1136,7 @@ Your primary goal is to help the user by answering questions based on the provid
                 parts.append(f"[Document {i+1} (ID: {r['id']})]\n{r['text']}")
         return "\n\n".join(parts), has_web
 
-    def _build_system_prompt(self, has_web: bool) -> str:
+    def _build_system_prompt(self, has_web: bool, cfg=None) -> str:
         """Return the system prompt based on discussion_fallback and web search state.
 
         When discussion_fallback is False, uses a strict context-only prompt so
@@ -1057,8 +1144,10 @@ Your primary goal is to help the user by answering questions based on the provid
         irrelevant. When True, uses the permissive prompt that encourages general
         knowledge fallback when context is insufficient.
         """
-        base = self.SYSTEM_PROMPT if self.config.discussion_fallback else self.SYSTEM_PROMPT_STRICT
-        if not self.config.truth_grounding:
+        if cfg is None:
+            cfg = self.config
+        base = self.SYSTEM_PROMPT if cfg.discussion_fallback else self.SYSTEM_PROMPT_STRICT
+        if not cfg.truth_grounding:
             return base
         if has_web:
             return base + (
@@ -1071,56 +1160,83 @@ Your primary goal is to help the user by answering questions based on the provid
             "you have access to live Brave Search as a fallback tool. It was not needed for this query."
         )
 
-    def query(self, query: str, filters: Dict = None, chat_history: List[Dict[str, str]] = None) -> str:
-        t0 = time.time()
-        
-        retrieval = self._execute_retrieval(query, filters)
-        results = retrieval['results']
-        
-        if not results:
-            self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'], 
-                                    retrieval['filtered_count'], 0, 0.0, (time.time() - t0) * 1000, retrieval['transforms'])
-            
-            if self.config.discussion_fallback:
-                # Send plain query as user message so multi-turn history stays consistent
-                return self.llm.complete(query, self._build_system_prompt(False), chat_history=chat_history)
-            
-            return "I don't have any relevant information to answer that question."
-            
-        if self.config.rerank: results = self.reranker.rerank(query, results)
+    def _apply_overrides(self, overrides: Optional[Dict]) -> 'OpenStudioConfig':
+        """Return a config copy with per-request overrides applied (thread-safe)."""
+        if not overrides:
+            return self.config
+        import copy
+        cfg = copy.copy(self.config)
+        for k, v in overrides.items():
+            if v is not None and hasattr(cfg, k):
+                setattr(cfg, k, v)
+        return cfg
 
-        results = results[:self.config.top_k]
+    def query(self, query: str, filters: Dict = None, chat_history: List[Dict[str, str]] = None, overrides: Dict = None) -> str:
+        t0 = time.time()
+        cfg = self._apply_overrides(overrides)
+
+        # Cache lookup (only when chat_history is empty — cached responses don't track turns)
+        if cfg.query_cache and not chat_history:
+            cache_key = self._make_cache_key(query, filters, cfg)
+            if cache_key in self._query_cache:
+                logger.info(f"💾 Cache hit for query: {query[:60]}")
+                return self._query_cache[cache_key]
+
+        retrieval = self._execute_retrieval(query, filters, cfg=cfg)
+        results = retrieval['results']
+
+        if not results:
+            self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'],
+                                    retrieval['filtered_count'], 0, 0.0, (time.time() - t0) * 1000, retrieval['transforms'])
+
+            if cfg.discussion_fallback:
+                # Send plain query as user message so multi-turn history stays consistent
+                return self.llm.complete(query, self._build_system_prompt(False, cfg=cfg), chat_history=chat_history)
+
+            return "I don't have any relevant information to answer that question."
+
+        if cfg.rerank: results = self.reranker.rerank(query, results)
+
+        results = results[:cfg.top_k]
         final_count = len(results)
         top_score = results[0].get('score', 0) if results else 0
         context, has_web = self._build_context(results)
         # Inject RAG context into system prompt so the user message stays as the plain
         # question — this keeps multi-turn chat_history consistent across turns.
-        system_prompt = self._build_system_prompt(has_web) + f"\n\n**Relevant context from documents:**\n{context}"
+        system_prompt = self._build_system_prompt(has_web, cfg=cfg) + f"\n\n**Relevant context from documents:**\n{context}"
         response = self.llm.complete(query, system_prompt, chat_history=chat_history)
-        self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'], 
+        self._log_query_metrics(query, retrieval['vector_count'], retrieval['bm25_count'],
                                 retrieval['filtered_count'], final_count, top_score, (time.time() - t0) * 1000, retrieval['transforms'])
+
+        if cfg.query_cache and not chat_history:
+            # Evict oldest entry if cache is full
+            if len(self._query_cache) >= cfg.query_cache_size:
+                self._query_cache.pop(next(iter(self._query_cache)))
+            self._query_cache[cache_key] = response
+
         return response
 
-    def query_stream(self, query: str, filters: Dict = None, chat_history: List[Dict[str, str]] = None):
-        retrieval = self._execute_retrieval(query, filters)
+    def query_stream(self, query: str, filters: Dict = None, chat_history: List[Dict[str, str]] = None, overrides: Dict = None):
+        cfg = self._apply_overrides(overrides)
+        retrieval = self._execute_retrieval(query, filters, cfg=cfg)
         results = retrieval['results']
-        
+
         if not results:
-            if self.config.discussion_fallback:
+            if cfg.discussion_fallback:
                 # Send plain query as user message so multi-turn history stays consistent
-                yield from self.llm.stream(query, self._build_system_prompt(False), chat_history=chat_history)
+                yield from self.llm.stream(query, self._build_system_prompt(False, cfg=cfg), chat_history=chat_history)
                 return
             yield "I don't have any relevant information to answer that question."
             return
-            
-        if self.config.rerank: results = self.reranker.rerank(query, results)
-        
-        results = results[:self.config.top_k]
+
+        if cfg.rerank: results = self.reranker.rerank(query, results)
+
+        results = results[:cfg.top_k]
         context, has_web = self._build_context(results)
         # Inject RAG context into system prompt so the user message stays as the plain
         # question — this keeps multi-turn chat_history consistent across turns.
-        system_prompt = self._build_system_prompt(has_web) + f"\n\n**Relevant context from documents:**\n{context}"
-        
+        system_prompt = self._build_system_prompt(has_web, cfg=cfg) + f"\n\n**Relevant context from documents:**\n{context}"
+
         # Yield a marker object so UI can optionally reconstruct sources
         yield {"type": "sources", "sources": results}
 
@@ -1201,6 +1317,12 @@ def main():
                         help='Enable/disable HyDE (hypothetical document embedding)')
     parser.add_argument('--multi-query', action=argparse.BooleanOptionalAction, default=None,
                         help='Enable/disable multi-query retrieval')
+    parser.add_argument('--step-back', action=argparse.BooleanOptionalAction, default=None,
+                        help='Enable/disable step-back prompting (abstracts query before retrieval)')
+    parser.add_argument('--cache', action=argparse.BooleanOptionalAction, default=None,
+                        help='Enable/disable in-memory query result caching')
+    parser.add_argument('--no-dedup', action='store_true',
+                        help='Disable ingest deduplication (allow re-ingesting identical content)')
     parser.add_argument('--quiet', '-q', action='store_true',
                         help='Suppress spinners and progress (auto-enabled when stdin is not a TTY)')
     args = parser.parse_args()
@@ -1256,6 +1378,12 @@ def main():
         config.hyde = args.hyde
     if args.multi_query is not None:
         config.multi_query = args.multi_query
+    if args.step_back is not None:
+        config.step_back = args.step_back
+    if args.cache is not None:
+        config.query_cache = args.cache
+    if args.no_dedup:
+        config.dedup_on_ingest = False
 
     if args.list_models:
         print("\n🤖 Supported LLM providers and example models:\n")

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -129,6 +129,25 @@ class OpenStudioConfig:
     offline_mode: bool = False
     local_models_dir: str = ""
 
+    # Inline Source Citations
+    # When enabled, the LLM is instructed to cite [Doc N] inline in its answer
+    # matching the document labels injected into the context block.
+    cite_sources: bool = False
+
+    # RAPTOR Hierarchical Indexing
+    # During ingest, groups every raptor_chunk_group_size consecutive chunks per source
+    # and generates a summarisation node that is indexed alongside the leaf chunks.
+    # At retrieval time these summary nodes surface high-level context for multi-hop
+    # questions that no single leaf chunk can answer.
+    raptor: bool = False
+    raptor_chunk_group_size: int = 5
+
+    # GraphRAG Entity-Centric Retrieval
+    # During ingest, named entities are extracted from each chunk via the LLM and
+    # stored in an entity→doc_id map.  At retrieval time, entities found in the
+    # query are used to expand the result set with graph-connected documents.
+    graph_rag: bool = False
+
     @classmethod
     def load(cls, path: str = "config.yaml") -> 'OpenStudioConfig':
         """Load configuration from a YAML file."""
@@ -724,6 +743,26 @@ class OpenVectorStore:
             results = self.client.search(collection_name="rag_brain", query_vector=query_embedding, limit=top_k)
             return [{"id": str(r.id), "text": r.payload.get("text", ""), "score": r.score, "metadata": {k: v for k, v in r.payload.items() if k != "text"}} for r in results]
 
+    def get_by_ids(self, ids: List[str]) -> List[Dict]:
+        """Fetch stored documents by their IDs (used by GraphRAG expansion).
+
+        Returns a list of result dicts in the same format as search(), with score=1.0
+        since these docs are fetched by exact ID (not scored).
+        """
+        if not ids:
+            return []
+        if self.provider == "chroma":
+            result = self.collection.get(ids=ids, include=["documents", "metadatas"])
+            docs = []
+            for doc_id, text, meta in zip(
+                result.get("ids", []),
+                result.get("documents", []),
+                result.get("metadatas", []) or [],
+            ):
+                docs.append({"id": doc_id, "text": text or "", "score": 1.0, "metadata": meta or {}})
+            return docs
+        return []
+
 
 class OpenStudioBrain:
     """
@@ -825,6 +864,9 @@ Your primary goal is to help the user by answering questions based on the provid
         # Content hash store for ingest deduplication
         self._ingested_hashes: set = self._load_hash_store()
 
+        # GraphRAG entity → doc_id mapping (entity name -> list of chunk IDs)
+        self._entity_graph: Dict[str, List[str]] = self._load_entity_graph()
+
         logger.info("✅ Local RAG Brain ready!")
 
     def switch_project(self, name: str) -> None:
@@ -881,6 +923,133 @@ Your primary goal is to help the user by answering questions based on the provid
         path = pathlib.Path(self.config.bm25_path) / ".content_hashes"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("\n".join(self._ingested_hashes), encoding="utf-8")
+
+    def _load_entity_graph(self) -> Dict[str, List[str]]:
+        """Load persisted entity→doc_id graph from disk."""
+        import json, pathlib
+        path = pathlib.Path(self.config.bm25_path) / ".entity_graph.json"
+        if path.exists():
+            try:
+                return json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        return {}
+
+    def _save_entity_graph(self) -> None:
+        """Persist entity graph to disk."""
+        import json, pathlib
+        path = pathlib.Path(self.config.bm25_path) / ".entity_graph.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self._entity_graph), encoding="utf-8")
+
+    def _extract_entities(self, text: str) -> List[str]:
+        """Extract named entities from text using the LLM.
+
+        Returns a list of entity strings (people, organisations, places, concepts).
+        Returns an empty list on failure.
+        """
+        prompt = (
+            "Extract the key named entities (people, organisations, places, products, "
+            "technical concepts) from the following text. "
+            "Output one entity per line, no bullets or numbering. "
+            "If there are no entities, output nothing.\n\n"
+            + text[:1500]  # cap to avoid huge prompts
+        )
+        try:
+            raw = self.llm.complete(prompt, system_prompt="You are a named entity extraction specialist.")
+            return [e.strip() for e in raw.splitlines() if e.strip()][:20]
+        except Exception:
+            return []
+
+    def _generate_raptor_summaries(self, documents: List[Dict]) -> List[Dict]:
+        """Generate RAPTOR summary nodes for a list of already-split chunks.
+
+        Groups consecutive chunks by source in windows of raptor_chunk_group_size,
+        then calls the LLM to produce a summary passage.  Each summary is returned
+        as a new synthetic document (raptor_level=1 in metadata) that will be
+        embedded and stored alongside the leaf chunks.
+        """
+        from itertools import groupby
+
+        n = self.config.raptor_chunk_group_size
+        summaries = []
+
+        # Group chunks by their source file so we only summarise within one document
+        def _source(doc):
+            return doc.get("metadata", {}).get("source", doc["id"])
+
+        sorted_docs = sorted(documents, key=_source)
+        for source, group in groupby(sorted_docs, key=_source):
+            chunks = list(group)
+            for i in range(0, len(chunks), n):
+                window = chunks[i:i + n]
+                combined = "\n\n".join(c["text"] for c in window)
+                prompt = (
+                    "Summarise the following passage into a concise but comprehensive paragraph "
+                    "that captures all key facts and concepts. "
+                    "Output only the summary paragraph.\n\n" + combined[:4000]
+                )
+                try:
+                    summary_text = self.llm.complete(
+                        prompt,
+                        system_prompt="You are an expert at summarising technical documents."
+                    )
+                    if not summary_text or not summary_text.strip():
+                        continue
+                    # Build a deterministic ID from source + window position
+                    import hashlib
+                    uid = hashlib.md5(f"{source}|raptor|{i}".encode()).hexdigest()[:12]
+                    summaries.append({
+                        "id": f"raptor_{uid}",
+                        "text": summary_text.strip(),
+                        "metadata": {
+                            "source": source,
+                            "raptor_level": 1,
+                            "window_start": i,
+                            "window_end": i + len(window) - 1,
+                        },
+                    })
+                except Exception as e:
+                    logger.debug(f"RAPTOR summary failed for {source}[{i}]: {e}")
+
+        if summaries:
+            logger.info(f"   RAPTOR: generated {len(summaries)} summary node(s)")
+        return summaries
+
+    def _expand_with_entity_graph(self, query: str, results: List[Dict]) -> List[Dict]:
+        """Expand retrieval results using GraphRAG entity linkage.
+
+        1. Extract entities from the query.
+        2. Look up all chunk IDs linked to those entities in the entity graph.
+        3. Fetch any chunks not already in results from the vector store.
+        4. Append them (capped to avoid bloat), returning the expanded list.
+        """
+        query_entities = self._extract_entities(query)
+        if not query_entities:
+            return results
+
+        existing_ids = {r["id"] for r in results}
+        extra_ids: List[str] = []
+        for entity in query_entities:
+            for eid, doc_ids in self._entity_graph.items():
+                if entity.lower() in eid.lower() or eid.lower() in entity.lower():
+                    for did in doc_ids:
+                        if did not in existing_ids and did not in extra_ids:
+                            extra_ids.append(did)
+
+        if not extra_ids:
+            return results
+
+        # Fetch the extra chunks from the vector store (up to top_k worth)
+        try:
+            extra_results = self.vector_store.get_by_ids(extra_ids[: self.config.top_k])
+            if extra_results:
+                logger.info(f"   GraphRAG: expanded results by {len(extra_results)} entity-linked doc(s)")
+                results = list(results) + extra_results
+        except Exception as e:
+            logger.debug(f"GraphRAG expansion failed: {e}")
+
+        return results
 
     def _doc_hash(self, doc: Dict) -> str:
         """Return an MD5 hex digest of the document's text content."""
@@ -980,6 +1149,29 @@ Your primary goal is to help the user by answering questions based on the provid
                 return
             self._ingested_hashes.update(new_hashes)
             self._save_hash_store()
+
+        # RAPTOR: generate summarisation nodes for the deduplicated leaf chunks
+        if self.config.raptor:
+            raptor_docs = self._generate_raptor_summaries(documents)
+            documents = documents + raptor_docs
+
+        # GraphRAG: extract entities from new chunks and update entity graph
+        if self.config.graph_rag:
+            updated = False
+            for doc in documents:
+                if doc.get("metadata", {}).get("raptor_level"):
+                    continue  # skip synthetic RAPTOR nodes
+                entities = self._extract_entities(doc["text"])
+                for entity in entities:
+                    key = entity.lower()
+                    if key not in self._entity_graph:
+                        self._entity_graph[key] = []
+                    if doc["id"] not in self._entity_graph[key]:
+                        self._entity_graph[key].append(doc["id"])
+                        updated = True
+            if updated:
+                self._save_entity_graph()
+
         n_chunks = len(documents)
         if self.bm25: self.bm25.add_documents(documents)
 
@@ -1207,6 +1399,10 @@ Your primary goal is to help the user by answering questions based on the provid
 
         results = [r for r in results if r.get('score', 1.0) >= cfg.similarity_threshold or 'fused_only' in r]
 
+        # GraphRAG: expand results with entity-linked documents
+        if cfg.graph_rag and self._entity_graph:
+            results = self._expand_with_entity_graph(query, results)
+
         # Web Search (Truth Grounding)
         # Trigger when the best cosine similarity from vector search is below the threshold,
         # meaning local knowledge is genuinely insufficient (even if BM25 returned fused_only docs).
@@ -1264,6 +1460,12 @@ Your primary goal is to help the user by answering questions based on the provid
         if cfg is None:
             cfg = self.config
         base = self.SYSTEM_PROMPT if cfg.discussion_fallback else self.SYSTEM_PROMPT_STRICT
+        if cfg.cite_sources:
+            base = base + (
+                "\n\n**Citation requirement**: When using information from the context, "
+                "cite it inline using the document label from the context block, e.g. [Doc 1], [Doc 2]. "
+                "Place the citation immediately after the relevant sentence or fact."
+            )
         if not cfg.truth_grounding:
             return base
         if has_web:
@@ -1449,6 +1651,14 @@ def main():
                         help='Enable/disable LLM context compression (extracts only relevant sentences before generation)')
     parser.add_argument('--cache', action=argparse.BooleanOptionalAction, default=None,
                         help='Enable/disable in-memory query result caching')
+    parser.add_argument('--cite', action=argparse.BooleanOptionalAction, default=None,
+                        help='Enable/disable inline source citations ([Doc N]) in LLM answers')
+    parser.add_argument('--raptor', action=argparse.BooleanOptionalAction, default=None,
+                        help='Enable/disable RAPTOR hierarchical summarisation nodes during ingest')
+    parser.add_argument('--raptor-group-size', type=int, metavar='N',
+                        help='Number of consecutive chunks to group per RAPTOR summary (default: 5)')
+    parser.add_argument('--graph-rag', action=argparse.BooleanOptionalAction, default=None,
+                        help='Enable/disable GraphRAG entity-centric retrieval expansion')
     parser.add_argument('--no-dedup', action='store_true',
                         help='Disable ingest deduplication (allow re-ingesting identical content)')
     parser.add_argument('--parent-chunk-size', type=int, metavar='N',
@@ -1523,6 +1733,14 @@ def main():
         config.query_cache = args.cache
     if args.no_dedup:
         config.dedup_on_ingest = False
+    if args.cite is not None:
+        config.cite_sources = args.cite
+    if args.raptor is not None:
+        config.raptor = args.raptor
+    if args.raptor_group_size is not None:
+        config.raptor_chunk_group_size = args.raptor_group_size
+    if args.graph_rag is not None:
+        config.graph_rag = args.graph_rag
 
     if args.list_models:
         print("\n🤖 Supported LLM providers and example models:\n")

--- a/src/rag_brain/main.py
+++ b/src/rag_brain/main.py
@@ -92,7 +92,15 @@ class OpenStudioConfig:
     # Re-ranking
     rerank: bool = False
     reranker_provider: Literal["cross-encoder", "llm"] = "cross-encoder"
+    # Default: fast ms-marco model (small, already commonly cached).
+    # Upgrade to "BAAI/bge-reranker-v2-m3" for SOTA multilingual accuracy.
     reranker_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    # Parent-Document / Small-to-Big Retrieval
+    # Set parent_chunk_size > chunk_size to enable. Child chunks (chunk_size)
+    # are indexed for precise retrieval; parent chunks are returned as context.
+    # 0 = disabled (use retrieval chunks directly).
+    parent_chunk_size: int = 0
 
     # Query Transformations
     multi_query: bool = False
@@ -151,12 +159,9 @@ class OpenStudioConfig:
                 config_dict['reranker_model'] = data['rerank']['model']
                 
         if 'query_transformations' in data:
-            if 'multi_query' in data['query_transformations']:
-                config_dict['multi_query'] = data['query_transformations']['multi_query']
-            if 'hyde' in data['query_transformations']:
-                config_dict['hyde'] = data['query_transformations']['hyde']
-            if 'discussion_fallback' in data['query_transformations']:
-                config_dict['discussion_fallback'] = data['query_transformations']['discussion_fallback']
+            for key in ('multi_query', 'hyde', 'step_back', 'discussion_fallback'):
+                if key in data['query_transformations']:
+                    config_dict[key] = data['query_transformations'][key]
         if 'web_search' in data:
             ws = data['web_search']
             config_dict['truth_grounding'] = ws.get('enabled', False)
@@ -911,12 +916,44 @@ Your primary goal is to help the user by answering questions based on the provid
             "transformations": transformations or {}
         })
 
+    def _split_with_parents(self, documents: List[Dict]) -> List[Dict]:
+        """Split documents using parent-document (small-to-big) strategy.
+
+        1. Split each raw document into large parent chunks (parent_chunk_size).
+        2. Split each parent into small child chunks (chunk_size) for indexing.
+        3. Store the parent text in every child's metadata so that at generation
+           time _build_context() can return the richer parent passage instead of
+           the small retrieval chunk.
+        """
+        from rag_brain.splitters import RecursiveCharacterTextSplitter
+        parent_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=self.config.parent_chunk_size,
+            chunk_overlap=self.config.chunk_overlap,
+        )
+        all_chunks = []
+        for doc in documents:
+            parent_texts = parent_splitter.split(doc["text"])
+            for p_idx, parent_text in enumerate(parent_texts):
+                p_doc = {
+                    "id": f"{doc['id']}_p{p_idx}",
+                    "text": parent_text,
+                    "metadata": doc.get("metadata", {}).copy(),
+                }
+                child_chunks = self.splitter.transform_documents([p_doc])
+                for child in child_chunks:
+                    child["metadata"]["parent_text"] = parent_text
+                all_chunks.extend(child_chunks)
+        return all_chunks
+
     def ingest(self, documents: List[Dict[str, Any]]):
         if not documents: return
         t0 = time.time()
         from tqdm import tqdm
         logger.info(f"📥 Ingesting {len(documents)} documents...")
-        if self.splitter: documents = self.splitter.transform_documents(documents)
+        if self.splitter and self.config.parent_chunk_size > 0:
+            documents = self._split_with_parents(documents)
+        elif self.splitter:
+            documents = self.splitter.transform_documents(documents)
 
         if self.config.dedup_on_ingest:
             before = len(documents)
@@ -1133,7 +1170,9 @@ Your primary goal is to help the user by answering questions based on the provid
                 title = r.get("metadata", {}).get("title", r["id"])
                 parts.append(f"[Web Result {i+1} — {title} ({r['id']})]\n{r['text']}")
             else:
-                parts.append(f"[Document {i+1} (ID: {r['id']})]\n{r['text']}")
+                # Small-to-big: prefer parent passage for richer LLM context
+                context_text = r.get("metadata", {}).get("parent_text") or r["text"]
+                parts.append(f"[Document {i+1} (ID: {r['id']})]\n{context_text}")
         return "\n\n".join(parts), has_web
 
     def _build_system_prompt(self, has_web: bool, cfg=None) -> str:
@@ -1313,6 +1352,9 @@ def main():
                         help='Enable/disable hybrid BM25+vector search')
     parser.add_argument('--rerank', action=argparse.BooleanOptionalAction, default=None,
                         help='Enable/disable cross-encoder reranking')
+    parser.add_argument('--reranker-model', metavar='MODEL',
+                        help='Re-ranker model to use (e.g. BAAI/bge-reranker-v2-m3 for SOTA accuracy, '
+                             'default: cross-encoder/ms-marco-MiniLM-L-6-v2)')
     parser.add_argument('--hyde', action=argparse.BooleanOptionalAction, default=None,
                         help='Enable/disable HyDE (hypothetical document embedding)')
     parser.add_argument('--multi-query', action=argparse.BooleanOptionalAction, default=None,
@@ -1323,6 +1365,9 @@ def main():
                         help='Enable/disable in-memory query result caching')
     parser.add_argument('--no-dedup', action='store_true',
                         help='Disable ingest deduplication (allow re-ingesting identical content)')
+    parser.add_argument('--parent-chunk-size', type=int, metavar='N',
+                        help='Enable small-to-big retrieval: index child chunks of --chunk-size tokens '
+                             'but return parent passages of N tokens as LLM context. 0 = disabled.')
     parser.add_argument('--quiet', '-q', action='store_true',
                         help='Suppress spinners and progress (auto-enabled when stdin is not a TTY)')
     args = parser.parse_args()
@@ -1374,6 +1419,10 @@ def main():
         config.hybrid_search = args.hybrid
     if args.rerank is not None:
         config.rerank = args.rerank
+    if args.reranker_model:
+        config.reranker_model = args.reranker_model
+    if args.parent_chunk_size is not None:
+        config.parent_chunk_size = args.parent_chunk_size
     if args.hyde is not None:
         config.hyde = args.hyde
     if args.multi_query is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -410,6 +410,26 @@ def test_query_override_compress():
     assert call_kwargs["overrides"]["compress_context"] is True
 
 
+def test_query_override_cite():
+    """cite=true override is forwarded to brain.query overrides dict as cite_sources."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Cited answer [Doc 1]"
+    resp = client.post("/query", json={"query": "test", "cite": True})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query.call_args[1]
+    assert call_kwargs["overrides"]["cite_sources"] is True
+
+
+def test_query_response_includes_cite_in_settings():
+    """Response settings dict includes 'cite' key reflecting applied config."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Answer"
+    resp = client.post("/query", json={"query": "test", "cite": True})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "cite" in data["settings"]
+
+
 def test_concurrent_requests_no_cross_contamination():
     """Different override values in concurrent requests do not bleed into each other."""
     import threading

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,8 @@ def _make_brain(provider="chroma"):
     brain.config.discussion_fallback = True
     brain.config.similarity_threshold = 0.3
     brain.config.step_back = False
+    brain.config.query_decompose = False
+    brain.config.compress_context = False
     # _apply_overrides returns a copy of config with overrides applied
     brain._apply_overrides.return_value = brain.config
     return brain
@@ -386,6 +388,26 @@ def test_query_stream_override_forwarded():
     call_kwargs = api_module.brain.query_stream.call_args[1]
     assert call_kwargs["overrides"]["hyde"] is True
     assert call_kwargs["overrides"]["multi_query"] is True
+
+
+def test_query_override_decompose():
+    """decompose=true override is forwarded to brain.query overrides dict."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Decomposed answer"
+    resp = client.post("/query", json={"query": "complex multi-part question", "decompose": True})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query.call_args[1]
+    assert call_kwargs["overrides"]["query_decompose"] is True
+
+
+def test_query_override_compress():
+    """compress=true override is forwarded to brain.query overrides dict."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Compressed answer"
+    resp = client.post("/query", json={"query": "test", "compress": True})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query.call_args[1]
+    assert call_kwargs["overrides"]["compress_context"] is True
 
 
 def test_concurrent_requests_no_cross_contamination():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,15 @@ def _make_brain(provider="chroma"):
     brain.vector_store.provider = provider
     brain.bm25 = MagicMock()
     brain.config.top_k = 5
+    brain.config.hybrid_search = True
+    brain.config.rerank = False
+    brain.config.hyde = False
+    brain.config.multi_query = False
+    brain.config.discussion_fallback = True
+    brain.config.similarity_threshold = 0.3
+    brain.config.step_back = False
+    # _apply_overrides returns a copy of config with overrides applied
+    brain._apply_overrides.return_value = brain.config
     return brain
 
 
@@ -163,7 +172,8 @@ def test_query_passes_filters():
     filters = {"type": "text", "source": "manual"}
     resp = client.post("/query", json={"query": "What?", "filters": filters})
     assert resp.status_code == 200
-    api_module.brain.query.assert_called_once_with("What?", filters=filters)
+    call_kwargs = api_module.brain.query.call_args
+    assert call_kwargs[1]["filters"] == filters or call_kwargs[0][1] == filters
 
 
 # ---------------------------------------------------------------------------
@@ -296,3 +306,106 @@ def test_collection_propagates_error():
     api_module.brain.list_documents.side_effect = RuntimeError("chroma down")
     resp = client.get("/collection")
     assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /query — per-request RAG overrides
+# ---------------------------------------------------------------------------
+
+
+def test_query_override_hyde():
+    """hyde=true override is forwarded to brain.query as overrides dict."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "HyDE answer"
+    resp = client.post("/query", json={"query": "What is RAG?", "hyde": True})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query.call_args[1]
+    assert call_kwargs["overrides"]["hyde"] is True
+
+
+def test_query_override_multi_query():
+    """multi_query=true override is forwarded to brain.query."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Multi-query answer"
+    resp = client.post("/query", json={"query": "Explain RAG", "multi_query": True})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query.call_args[1]
+    assert call_kwargs["overrides"]["multi_query"] is True
+
+
+def test_query_override_top_k():
+    """top_k override is forwarded to brain.query."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Answer"
+    resp = client.post("/query", json={"query": "test", "top_k": 3})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query.call_args[1]
+    assert call_kwargs["overrides"]["top_k"] == 3
+
+
+def test_query_override_rerank():
+    """rerank=true override is forwarded to brain.query."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Reranked answer"
+    resp = client.post("/query", json={"query": "test", "rerank": True})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query.call_args[1]
+    assert call_kwargs["overrides"]["rerank"] is True
+
+
+def test_query_response_includes_settings():
+    """Response body includes a 'settings' key with active flag values."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Answer"
+    resp = client.post("/query", json={"query": "test", "hyde": True, "top_k": 7})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "settings" in data
+    assert "top_k" in data["settings"]
+    assert "hyde" in data["settings"]
+    assert "multi_query" in data["settings"]
+
+
+def test_query_no_override_does_not_mutate_config():
+    """Requests without overrides do not change brain.config (thread safety)."""
+    api_module.brain = _make_brain()
+    api_module.brain.query.return_value = "Answer"
+    original_top_k = api_module.brain.config.top_k
+
+    resp = client.post("/query", json={"query": "test"})
+    assert resp.status_code == 200
+    assert api_module.brain.config.top_k == original_top_k
+
+
+def test_query_stream_override_forwarded():
+    """Overrides are forwarded to brain.query_stream."""
+    api_module.brain = _make_brain()
+    api_module.brain.query_stream = MagicMock(return_value=iter(["chunk"]))
+    resp = client.post("/query/stream", json={"query": "test", "hyde": True, "multi_query": True})
+    assert resp.status_code == 200
+    call_kwargs = api_module.brain.query_stream.call_args[1]
+    assert call_kwargs["overrides"]["hyde"] is True
+    assert call_kwargs["overrides"]["multi_query"] is True
+
+
+def test_concurrent_requests_no_cross_contamination():
+    """Different override values in concurrent requests do not bleed into each other."""
+    import threading
+
+    api_module.brain = _make_brain()
+    results = {}
+
+    def make_request(name, hyde_val):
+        api_module.brain.query.return_value = f"answer-{name}"
+        r = client.post("/query", json={"query": f"q-{name}", "hyde": hyde_val})
+        results[name] = r
+
+    t1 = threading.Thread(target=make_request, args=("a", True))
+    t2 = threading.Thread(target=make_request, args=("b", False))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    assert results["a"].status_code == 200
+    assert results["b"].status_code == 200
+    # The global config must remain unchanged after both requests
+    assert api_module.brain.config.top_k == 5

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,17 +124,27 @@ def test_delete_success():
     assert data["status"] == "success"
     assert data["deleted"] == 2
     assert set(data["doc_ids"]) == {"doc1", "doc2"}
-    # Verify ChromaDB delete was called
-    api_module.brain.vector_store.collection.delete.assert_called_once_with(ids=["doc1", "doc2"])
+    # Verify delete_by_ids was called on the vector store
+    api_module.brain.vector_store.delete_by_ids.assert_called_once_with(["doc1", "doc2"])
     # Verify BM25 delete was called
     api_module.brain.bm25.delete_documents.assert_called_once_with(["doc1", "doc2"])
 
 
 def test_delete_propagates_error():
     api_module.brain = _make_brain()
-    api_module.brain.vector_store.collection.delete.side_effect = RuntimeError("chroma down")
+    api_module.brain.vector_store.delete_by_ids.side_effect = RuntimeError("store down")
     resp = client.post("/delete", json={"doc_ids": ["x"]})
     assert resp.status_code == 500
+
+
+def test_delete_calls_delete_by_ids_not_collection_delete():
+    """Endpoint must use delete_by_ids (works for all providers) not collection.delete."""
+    api_module.brain = _make_brain()
+    resp = client.post("/delete", json={"doc_ids": ["id1"]})
+    assert resp.status_code == 200
+    api_module.brain.vector_store.delete_by_ids.assert_called_once_with(["id1"])
+    # collection.delete should NOT be called directly by the endpoint
+    api_module.brain.vector_store.collection.delete.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -174,8 +184,8 @@ def test_query_passes_filters():
     filters = {"type": "text", "source": "manual"}
     resp = client.post("/query", json={"query": "What?", "filters": filters})
     assert resp.status_code == 200
-    call_kwargs = api_module.brain.query.call_args
-    assert call_kwargs[1]["filters"] == filters or call_kwargs[0][1] == filters
+    call = api_module.brain.query.call_args
+    assert call.kwargs.get("filters") == filters or (call.args and call.args[1] == filters)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,3 +55,40 @@ class TestOpenStudioConfig:
 
         assert isinstance(config, OpenStudioConfig)
         assert config.embedding_provider == "sentence_transformers"
+
+    def test_yaml_query_transformations_step_back(self):
+        """step_back is loaded from query_transformations section in YAML."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump({"query_transformations": {"step_back": True, "hyde": True}}, f)
+            f.flush()
+            config = OpenStudioConfig.load(f.name)
+        assert config.step_back is True
+        assert config.hyde is True
+
+    def test_yaml_rag_section_parent_chunk_size(self):
+        """parent_chunk_size is loaded from rag section in YAML."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump({"rag": {"parent_chunk_size": 2000, "top_k": 5}}, f)
+            f.flush()
+            config = OpenStudioConfig.load(f.name)
+        assert config.parent_chunk_size == 2000
+        assert config.top_k == 5
+
+    def test_yaml_rag_section_caching_and_dedup(self):
+        """query_cache and dedup_on_ingest are loaded from rag section in YAML."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump({"rag": {"query_cache": True, "query_cache_size": 64, "dedup_on_ingest": False}}, f)
+            f.flush()
+            config = OpenStudioConfig.load(f.name)
+        assert config.query_cache is True
+        assert config.query_cache_size == 64
+        assert config.dedup_on_ingest is False
+
+    def test_yaml_rerank_model_bge(self):
+        """reranker_model is loaded from rerank.model in YAML."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump({"rerank": {"enabled": True, "model": "BAAI/bge-reranker-v2-m3"}}, f)
+            f.flush()
+            config = OpenStudioConfig.load(f.name)
+        assert config.rerank is True
+        assert config.reranker_model == "BAAI/bge-reranker-v2-m3"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,6 +84,18 @@ class TestOpenStudioConfig:
         assert config.query_cache_size == 64
         assert config.dedup_on_ingest is False
 
+    def test_yaml_query_decompose_and_compress(self):
+        """query_decompose and compress_context are loaded from their YAML sections."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump({
+                "query_transformations": {"query_decompose": True},
+                "context_compression": {"enabled": True},
+            }, f)
+            f.flush()
+            config = OpenStudioConfig.load(f.name)
+        assert config.query_decompose is True
+        assert config.compress_context is True
+
     def test_yaml_rerank_model_bge(self):
         """reranker_model is loaded from rerank.model in YAML."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:

--- a/tests/test_eval_smoke.py
+++ b/tests/test_eval_smoke.py
@@ -1,0 +1,311 @@
+"""
+tests/test_eval_smoke.py
+
+Evaluation smoke tests for the RAG pipeline.
+
+These tests use a tiny, fully-mocked corpus to verify that key RAG quality
+metrics are *computable* and produce sensible values.  They are marked with
+``@pytest.mark.eval`` so the CI eval job can target them independently:
+
+    pytest -m eval tests/test_eval_smoke.py
+
+Metrics covered
+---------------
+- Precision@k   — fraction of retrieved chunks that are relevant
+- Context relevance — retrieved context contains expected keywords
+- Answer faithfulness — final answer is grounded in the retrieved context
+- Retrieval recall@k — all relevant docs are returned within top-k
+"""
+
+from __future__ import annotations
+
+from typing import List, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pytest marker registration (also in pyproject.toml/pytest.ini)
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.eval
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides):
+    from rag_brain.main import OpenStudioConfig
+    cfg = OpenStudioConfig()
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _relevant_ids(corpus: List[Dict], keyword: str) -> List[str]:
+    """Return IDs of corpus docs whose text contains keyword (ground truth)."""
+    return [d["id"] for d in corpus if keyword.lower() in d["text"].lower()]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CORPUS = [
+    {"id": "doc1", "text": "The transformer architecture uses attention mechanisms for NLP tasks.", "score": 0.95, "metadata": {"source": "ml_guide.txt"}},
+    {"id": "doc2", "text": "BERT is a bidirectional transformer pre-trained on masked language modelling.", "score": 0.87, "metadata": {"source": "ml_guide.txt"}},
+    {"id": "doc3", "text": "Python is a high-level programming language popular for data science.", "score": 0.42, "metadata": {"source": "prog_guide.txt"}},
+    {"id": "doc4", "text": "Attention mechanisms allow the model to focus on different parts of the input.", "score": 0.91, "metadata": {"source": "ml_guide.txt"}},
+    {"id": "doc5", "text": "pip is the package installer for Python.", "score": 0.30, "metadata": {"source": "prog_guide.txt"}},
+]
+
+
+# ---------------------------------------------------------------------------
+# Precision@k
+# ---------------------------------------------------------------------------
+
+class TestPrecisionAtK:
+    """Fraction of top-k retrieved results that are actually relevant."""
+
+    def _precision(self, retrieved_ids: List[str], relevant_ids: List[str]) -> float:
+        if not retrieved_ids:
+            return 0.0
+        hits = sum(1 for rid in retrieved_ids if rid in relevant_ids)
+        return hits / len(retrieved_ids)
+
+    def test_perfect_retrieval(self):
+        """All retrieved docs are relevant → precision = 1.0."""
+        relevant = _relevant_ids(CORPUS, "transformer")
+        retrieved = [d["id"] for d in CORPUS if "transformer" in d["text"].lower()]
+        assert self._precision(retrieved, relevant) == 1.0
+
+    def test_partial_retrieval(self):
+        """Mix of relevant and irrelevant → precision between 0 and 1."""
+        relevant = _relevant_ids(CORPUS, "transformer")
+        # Retrieve all 5 docs (only 3 are transformer-related)
+        retrieved = [d["id"] for d in CORPUS]
+        p = self._precision(retrieved, relevant)
+        assert 0.0 < p < 1.0, f"Expected 0 < precision < 1, got {p}"
+
+    def test_top_k_3_precision(self):
+        """Top-3 by score — verify precision is computed correctly."""
+        sorted_docs = sorted(CORPUS, key=lambda x: x["score"], reverse=True)[:3]
+        relevant = _relevant_ids(CORPUS, "attention")
+        p = self._precision([d["id"] for d in sorted_docs], relevant)
+        # doc1 (0.95), doc4 (0.91), doc2 (0.87) — doc1 and doc4 mention "attention"
+        assert p >= 0.6
+
+    def test_empty_retrieval(self):
+        """Empty result set → precision = 0."""
+        assert self._precision([], ["doc1"]) == 0.0
+
+    def test_no_relevant_docs(self):
+        """No relevant docs in corpus for the query term → precision = 0."""
+        relevant = _relevant_ids(CORPUS, "quantum_computing_xyz")
+        retrieved = [d["id"] for d in CORPUS[:3]]
+        assert self._precision(retrieved, relevant) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Context Relevance
+# ---------------------------------------------------------------------------
+
+class TestContextRelevance:
+    """Retrieved context should contain keywords expected for the query."""
+
+    def _context_relevance(self, context: str, expected_keywords: List[str]) -> float:
+        """Fraction of expected keywords found in context (simple keyword overlap)."""
+        if not expected_keywords:
+            return 0.0
+        found = sum(1 for kw in expected_keywords if kw.lower() in context.lower())
+        return found / len(expected_keywords)
+
+    def _build_context(self, docs: List[Dict]) -> str:
+        return "\n\n".join(f"[Document {i+1}]\n{d['text']}" for i, d in enumerate(docs))
+
+    def test_relevant_context_high_score(self):
+        """Context built from transformer-related docs scores > 0.7 for expected keywords."""
+        query_keywords = ["transformer", "attention", "bert"]
+        relevant_docs = [d for d in CORPUS if any(kw in d["text"].lower() for kw in query_keywords)]
+        context = self._build_context(relevant_docs)
+        score = self._context_relevance(context, query_keywords)
+        assert score >= 0.6, f"Expected relevance >= 0.6, got {score}"
+
+    def test_irrelevant_context_low_score(self):
+        """Context built from Python docs scores low for ML-specific keywords."""
+        python_docs = [d for d in CORPUS if "python" in d["text"].lower() or "pip" in d["text"].lower()]
+        context = self._build_context(python_docs)
+        ml_keywords = ["transformer", "bert", "attention"]
+        score = self._context_relevance(context, ml_keywords)
+        assert score < 0.4, f"Expected relevance < 0.4, got {score}"
+
+    def test_full_context_has_all_docs(self):
+        """Context with all docs in corpus has 1.0 relevance (trivially)."""
+        context = self._build_context(CORPUS)
+        score = self._context_relevance(context, ["transformer", "python", "attention"])
+        assert score == 1.0
+
+    def test_empty_context(self):
+        assert self._context_relevance("", ["transformer"]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Answer Faithfulness
+# ---------------------------------------------------------------------------
+
+class TestAnswerFaithfulness:
+    """Final answer should be grounded in (entailed by) the retrieved context."""
+
+    def _faithfulness_score(self, answer: str, context: str) -> float:
+        """Simplified faithfulness: fraction of answer sentences whose key noun
+        phrase appears in the context.  Not a real NLI model — just a keyword heuristic
+        suitable for a smoke test without external dependencies.
+        """
+        sentences = [s.strip() for s in answer.split(".") if s.strip()]
+        if not sentences:
+            return 0.0
+        grounded = sum(
+            1 for s in sentences
+            if any(word.lower() in context.lower() for word in s.split() if len(word) > 4)
+        )
+        return grounded / len(sentences)
+
+    def test_faithful_answer(self):
+        """Answer drawn from context has high faithfulness score."""
+        context = "Transformers use attention mechanisms. BERT is bidirectional."
+        answer = "Transformers rely on attention mechanisms. BERT uses a bidirectional approach."
+        score = self._faithfulness_score(answer, context)
+        assert score >= 0.8, f"Expected faithfulness >= 0.8, got {score}"
+
+    def test_hallucinated_answer(self):
+        """Answer that introduces completely new information scores low."""
+        context = "Python is a programming language."
+        answer = "Quantum circuits leverage superposition and entanglement principles."
+        score = self._faithfulness_score(answer, context)
+        assert score < 0.5, f"Expected faithfulness < 0.5 for hallucinated answer, got {score}"
+
+    def test_empty_answer(self):
+        assert self._faithfulness_score("", "some context") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Recall@k
+# ---------------------------------------------------------------------------
+
+class TestRecallAtK:
+    """All truly relevant documents should appear in the top-k results."""
+
+    def _recall(self, retrieved_ids: List[str], relevant_ids: List[str]) -> float:
+        if not relevant_ids:
+            return 1.0  # nothing to recall
+        hits = sum(1 for rid in relevant_ids if rid in retrieved_ids)
+        return hits / len(relevant_ids)
+
+    def test_perfect_recall(self):
+        """Retrieving all docs gives recall = 1.0."""
+        relevant = _relevant_ids(CORPUS, "attention")
+        all_ids = [d["id"] for d in CORPUS]
+        assert self._recall(all_ids, relevant) == 1.0
+
+    def test_recall_at_1_misses_some(self):
+        """Top-1 retrieval will miss some relevant docs if there are multiple."""
+        relevant = _relevant_ids(CORPUS, "transformer")
+        top1 = [CORPUS[0]["id"]]  # only 1 doc
+        recall = self._recall(top1, relevant)
+        # At least one relevant doc exists — recall should be < 1 unless top1 is the only relevant
+        assert recall <= 1.0
+
+    def test_recall_improves_with_k(self):
+        """More retrieved docs → equal or better recall."""
+        relevant = _relevant_ids(CORPUS, "transformer")
+        top1_ids = [d["id"] for d in sorted(CORPUS, key=lambda x: x["score"], reverse=True)[:1]]
+        top3_ids = [d["id"] for d in sorted(CORPUS, key=lambda x: x["score"], reverse=True)[:3]]
+        recall1 = self._recall(top1_ids, relevant)
+        recall3 = self._recall(top3_ids, relevant)
+        assert recall3 >= recall1
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke: pipeline produces non-empty answers for known queries
+# ---------------------------------------------------------------------------
+
+class TestPipelineIntegrationSmoke:
+    """End-to-end pipeline smoke test with fully mocked dependencies."""
+
+    def _make_brain(self):
+        """Construct a mocked OpenStudioBrain that uses CORPUS for retrieval."""
+        import rag_brain.main as m
+
+        cfg = _make_config(
+            top_k=3,
+            hybrid_search=False,
+            rerank=False,
+            hyde=False,
+            multi_query=False,
+            discussion_fallback=True,
+            similarity_threshold=0.0,
+        )
+
+        with (
+            patch.object(m, "OpenEmbedding"),
+            patch.object(m, "OpenLLM"),
+            patch.object(m, "OpenVectorStore"),
+            patch.object(m, "OpenReranker"),
+            patch("rag_brain.retrievers.BM25Retriever"),
+        ):
+            brain = m.OpenStudioBrain.__new__(m.OpenStudioBrain)
+            brain.config = cfg
+            brain.embedding = MagicMock()
+            brain.embedding.embed_query.return_value = [0.1] * 384
+            brain.llm = MagicMock()
+            brain.llm.complete.return_value = "Transformers use attention mechanisms."
+            brain.vector_store = MagicMock()
+            brain.vector_store.search.return_value = CORPUS[:3]
+            brain.reranker = MagicMock()
+            brain.reranker.rerank.side_effect = lambda q, docs: docs
+            brain.bm25 = None
+            brain._query_cache = {}
+            brain._ingested_hashes = set()
+            brain._entity_graph = {}
+            brain._apply_overrides = m.OpenStudioBrain._apply_overrides.__get__(brain)
+            brain._execute_retrieval = m.OpenStudioBrain._execute_retrieval.__get__(brain)
+            brain._build_context = m.OpenStudioBrain._build_context.__get__(brain)
+            brain._build_system_prompt = m.OpenStudioBrain._build_system_prompt.__get__(brain)
+            brain._make_cache_key = m.OpenStudioBrain._make_cache_key.__get__(brain)
+            brain._log_query_metrics = m.OpenStudioBrain._log_query_metrics.__get__(brain)
+            brain._compress_context = m.OpenStudioBrain._compress_context.__get__(brain)
+            return brain
+
+    def test_pipeline_returns_non_empty_answer(self):
+        brain = self._make_brain()
+        answer = brain.query("What is a transformer?")
+        assert isinstance(answer, str)
+        assert len(answer) > 0
+
+    def test_pipeline_context_contains_corpus_text(self):
+        """The LLM receives a system prompt containing corpus text."""
+        brain = self._make_brain()
+        brain.query("What is a transformer?")
+        call_args = brain.llm.complete.call_args
+        system_prompt = call_args[0][1] if call_args[0] else call_args[1].get("system_prompt", "")
+        assert "transformer" in system_prompt.lower() or "attention" in system_prompt.lower()
+
+    def test_cite_sources_flag_injects_citation_instruction(self):
+        """cite_sources=True causes the system prompt to contain citation instruction."""
+        brain = self._make_brain()
+        brain.config.cite_sources = True
+        brain.query("What is a transformer?")
+        call_args = brain.llm.complete.call_args
+        system_prompt = call_args[0][1] if call_args[0] else call_args[1].get("system_prompt", "")
+        assert "[Doc" in system_prompt or "citation" in system_prompt.lower() or "cite" in system_prompt.lower()
+
+    def test_precision_of_pipeline_results(self):
+        """The mocked pipeline returns docs 1-3; compute precision for 'attention'."""
+        retrieved_ids = [d["id"] for d in CORPUS[:3]]
+        relevant_ids = _relevant_ids(CORPUS, "attention")
+        hits = sum(1 for rid in retrieved_ids if rid in relevant_ids)
+        precision = hits / len(retrieved_ids) if retrieved_ids else 0.0
+        # doc1, doc2, doc3 in top-3; doc1 and doc4 have "attention" — doc4 not in top-3
+        # doc1 is in top-3 and relevant → at least 1 hit → precision > 0
+        assert precision > 0.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1425,3 +1425,93 @@ class TestSwitchProjectState:
         assert brain._ingested_hashes == {"newhash1", "newhash2", "newhash3"}
         assert "oldhash1" not in brain._ingested_hashes
 
+
+# ---------------------------------------------------------------------------
+# LanceDB vector store
+# ---------------------------------------------------------------------------
+
+import sys
+import types as _types
+
+
+def _make_lancedb_mock():
+    """Create and register a minimal lancedb mock module in sys.modules."""
+    mock_lancedb = _types.ModuleType("lancedb")
+    mock_lancedb.connect = MagicMock()
+    sys.modules["lancedb"] = mock_lancedb
+    return mock_lancedb
+
+
+class TestOpenVectorStoreLanceDB:
+    def _make_store(self, mock_lancedb):
+        """Helper: returns (store, mock_table) with lancedb already mocked."""
+        from rag_brain.main import OpenVectorStore, OpenStudioConfig
+        config = OpenStudioConfig(vector_store="lancedb", vector_store_path="./lancedb_test")
+        mock_table = MagicMock()
+        mock_lancedb.connect.return_value.open_table.side_effect = Exception("not found")
+        mock_lancedb.connect.return_value.create_table.return_value = mock_table
+        store = OpenVectorStore(config)
+        return store, mock_table
+
+    def test_init_no_existing_table(self):
+        mock_lancedb = _make_lancedb_mock()
+        store, _ = self._make_store(mock_lancedb)
+        assert store.collection is None   # lazy until first add
+
+    def test_add_creates_table_on_first_call(self):
+        mock_lancedb = _make_lancedb_mock()
+        store, mock_table = self._make_store(mock_lancedb)
+        store.add(["id1"], ["hello"], [[0.1, 0.2]], [{"source": "a.txt"}])
+        mock_lancedb.connect.return_value.create_table.assert_called_once()
+        assert store.collection is mock_table
+
+    def test_search_returns_empty_when_no_table(self):
+        mock_lancedb = _make_lancedb_mock()
+        store, _ = self._make_store(mock_lancedb)
+        results = store.search([0.1, 0.2], top_k=5)
+        assert results == []
+
+    def test_search_converts_distance_to_score(self):
+        mock_lancedb = _make_lancedb_mock()
+        store, mock_table = self._make_store(mock_lancedb)
+        store.collection = mock_table   # simulate existing table
+        mock_table.search.return_value.limit.return_value.to_list.return_value = [
+            {"id": "d1", "text": "foo", "_distance": 0.2, "metadata_json": "{}"}
+        ]
+        results = store.search([0.1, 0.2], top_k=5)
+        assert len(results) == 1
+        assert abs(results[0]["score"] - 0.8) < 1e-6
+
+    def test_list_documents_groups_by_source(self):
+        mock_lancedb = _make_lancedb_mock()
+        store, mock_table = self._make_store(mock_lancedb)
+        store.collection = mock_table
+        mock_table.to_arrow.return_value.to_pydict.return_value = {
+            "id": ["c1", "c2", "c3"],
+            "source": ["notes.txt", "notes.txt", "report.pdf"],
+        }
+        result = store.list_documents()
+        assert len(result) == 2
+        by_src = {d["source"]: d for d in result}
+        assert by_src["notes.txt"]["chunks"] == 2
+
+    def test_get_by_ids(self):
+        mock_lancedb = _make_lancedb_mock()
+        store, mock_table = self._make_store(mock_lancedb)
+        store.collection = mock_table
+        mock_table.search.return_value.where.return_value.to_list.return_value = [
+            {"id": "id1", "text": "hello", "metadata_json": '{"source": "x.txt"}'}
+        ]
+        results = store.get_by_ids(["id1"])
+        assert results[0]["id"] == "id1"
+        assert results[0]["metadata"]["source"] == "x.txt"
+
+    def test_delete_by_ids(self):
+        mock_lancedb = _make_lancedb_mock()
+        store, mock_table = self._make_store(mock_lancedb)
+        store.collection = mock_table
+        store.delete_by_ids(["id1", "id2"])
+        mock_table.delete.assert_called_once()
+        call_arg = mock_table.delete.call_args[0][0]
+        assert "id1" in call_arg and "id2" in call_arg
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -610,6 +610,168 @@ class TestQueryTransformations:
 @patch("rag_brain.main.OpenLLM")
 @patch("rag_brain.main.OpenEmbedding")
 @patch("rag_brain.main.OpenReranker")
+class TestQueryDecomposeAndCompress:
+    """Tests for query decomposition and context compression."""
+
+    def _make_brain(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, **kwargs):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0, **kwargs)
+        brain = OpenStudioBrain(config)
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[])
+        return brain
+
+    # ------------------------------------------------------------------
+    # Query Decomposition
+    # ------------------------------------------------------------------
+
+    def test_decompose_breaks_query_into_sub_questions(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, query_decompose=True)
+        brain.llm.complete = MagicMock(return_value="What is X?\nHow does X work?\nWhy is X useful?")
+
+        sub_qs = brain._decompose_query("Tell me everything about X")
+
+        assert sub_qs[0] == "Tell me everything about X"  # original always first
+        assert len(sub_qs) >= 2
+        assert "What is X?" in sub_qs
+
+    def test_decompose_strips_numbering_and_bullets(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        brain.llm.complete = MagicMock(return_value="1. Sub one\n2. Sub two\n- Sub three")
+
+        sub_qs = brain._decompose_query("complex question")
+
+        assert all(not q[0].isdigit() for q in sub_qs[1:])
+        assert all(not q.startswith("-") for q in sub_qs[1:])
+
+    def test_decompose_deduplicates_sub_questions(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        brain.llm.complete = MagicMock(return_value="original question\noriginal question\nNew sub")
+
+        sub_qs = brain._decompose_query("original question")
+
+        assert sub_qs.count("original question") == 1
+
+    def test_decompose_applied_in_execute_retrieval(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, query_decompose=True)
+        brain._decompose_query = MagicMock(return_value=["original", "sub-q1", "sub-q2"])
+
+        retrieval = brain._execute_retrieval("original")
+
+        brain._decompose_query.assert_called_once_with("original")
+        assert retrieval['transforms']['decompose_applied'] is True
+        assert "sub-q1" in retrieval['transforms']['queries']
+
+    def test_decompose_disabled_by_default(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        brain._decompose_query = MagicMock()
+
+        brain._execute_retrieval("any question")
+
+        brain._decompose_query.assert_not_called()
+
+    def test_decompose_combines_with_multi_query(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """multi_query and query_decompose can run together; queries are deduplicated."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                  multi_query=True, query_decompose=True)
+        brain._get_multi_queries = MagicMock(return_value=["q", "alt1", "alt2"])
+        brain._decompose_query = MagicMock(return_value=["q", "sub1"])
+
+        retrieval = brain._execute_retrieval("q")
+
+        assert retrieval['transforms']['multi_query_applied'] is True
+        assert retrieval['transforms']['decompose_applied'] is True
+        queries = retrieval['transforms']['queries']
+        assert queries.count("q") == 1  # no duplicates
+
+    # ------------------------------------------------------------------
+    # Context Compression
+    # ------------------------------------------------------------------
+
+    def test_compress_context_shortens_chunks(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, compress_context=True)
+        long_text = "irrelevant sentence. " * 20 + "The answer is 42."
+        brain.llm.complete = MagicMock(return_value="The answer is 42.")
+
+        results = [{"id": "d1", "text": long_text, "score": 0.9, "metadata": {}}]
+        compressed = brain._compress_context("What is the answer?", results)
+
+        assert compressed[0]["text"] == "The answer is 42."
+
+    def test_compress_context_skips_web_results(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        brain.llm.complete = MagicMock(return_value="compressed")
+
+        web_result = {"id": "http://ex.com", "text": "web content", "score": 1.0,
+                      "metadata": {}, "is_web": True}
+        results = brain._compress_context("q", [web_result])
+
+        # Web results must pass through unchanged; LLM must not be called
+        brain.llm.complete.assert_not_called()
+        assert results[0]["text"] == "web content"
+
+    def test_compress_context_falls_back_on_failure(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """If LLM compression raises, the original result is returned unchanged."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        brain.llm.complete = MagicMock(side_effect=RuntimeError("llm down"))
+
+        original_text = "original chunk text"
+        results = [{"id": "d1", "text": original_text, "score": 0.9, "metadata": {}}]
+        compressed = brain._compress_context("q", results)
+
+        assert compressed[0]["text"] == original_text
+
+    def test_compress_context_does_not_expand_chunk(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """If LLM returns something longer than the original, keep the original."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        short_text = "short"
+        brain.llm.complete = MagicMock(return_value="much longer text that exceeds original length significantly")
+
+        results = [{"id": "d1", "text": short_text, "score": 0.9, "metadata": {}}]
+        compressed = brain._compress_context("q", results)
+
+        assert compressed[0]["text"] == short_text
+
+    def test_compress_context_uses_parent_text_as_source(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """When parent_text is in metadata, that is compressed (not the small child chunk)."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        brain.llm.complete = MagicMock(return_value="compressed parent")
+
+        results = [{
+            "id": "d1_p0_chunk_0",
+            "text": "small child chunk",
+            "score": 0.9,
+            "metadata": {"parent_text": "large parent passage " * 10},
+        }]
+        compressed = brain._compress_context("q", results)
+
+        # Compression prompt should have used parent_text, result stored back in parent_text
+        call_prompt = brain.llm.complete.call_args[0][0]
+        assert "large parent passage" in call_prompt
+        assert compressed[0]["metadata"]["parent_text"] == "compressed parent"
+
+    def test_compress_context_disabled_by_default(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """compress_context=False (default): _compress_context is never called during query."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0)
+        brain = OpenStudioBrain(config)
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[
+            {"id": "d1", "text": "ctx", "score": 0.9}
+        ])
+        brain.llm.complete = MagicMock(return_value="answer")
+        brain._compress_context = MagicMock(wraps=brain._compress_context)
+
+        brain.query("test?")
+
+        brain._compress_context.assert_not_called()
+
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
 class TestLogQueryMetrics:
     def test_metrics_logged_without_exception(
         self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -281,6 +281,92 @@ class TestOpenStudioBrain:
         brain._execute_retrieval("any question")
         brain._get_step_back_query.assert_not_called()
 
+    # ------------------------------------------------------------------
+    # Parent-document / small-to-big retrieval
+    # ------------------------------------------------------------------
+
+    def test_parent_chunk_size_zero_uses_standard_split(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """parent_chunk_size=0 (default) uses the normal splitter path."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(parent_chunk_size=0)
+        brain = OpenStudioBrain(config)
+        brain._save_hash_store = MagicMock()
+        brain._ingested_hashes = set()
+        brain.vector_store.add = MagicMock()
+        brain.embedding.embed = MagicMock(return_value=[[0.1]])
+
+        docs = [{"id": "d1", "text": "short text"}]
+        brain.ingest(docs)
+        # Standard split: no parent_text in metadata
+        call_args = brain.vector_store.add.call_args
+        metadatas = call_args[0][3]
+        assert all("parent_text" not in m for m in metadatas)
+
+    def test_parent_chunk_creates_child_chunks_with_parent_text(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """parent_chunk_size > chunk_size embeds child chunks that carry parent_text in metadata."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(chunk_size=50, chunk_overlap=10, parent_chunk_size=200)
+        brain = OpenStudioBrain(config)
+        brain._save_hash_store = MagicMock()
+        brain._ingested_hashes = set()
+        brain.vector_store.add = MagicMock()
+        brain.embedding.embed = MagicMock(return_value=[[0.1]] * 20)
+
+        # Create a document long enough to produce multiple child chunks
+        long_text = "word " * 80  # ~400 chars, will split into multiple 50-char child chunks
+        docs = [{"id": "d1", "text": long_text}]
+        brain.ingest(docs)
+
+        assert brain.vector_store.add.called
+        metadatas = brain.vector_store.add.call_args[0][3]
+        # Every indexed child chunk must carry parent_text
+        assert all("parent_text" in m for m in metadatas)
+
+    def test_build_context_uses_parent_text_when_present(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """_build_context returns parent_text (not chunk text) for small-to-big results."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig()
+        brain = OpenStudioBrain(config)
+
+        results = [{
+            "id": "d1_p0_chunk_0",
+            "text": "small retrieval chunk",
+            "score": 0.9,
+            "metadata": {"parent_text": "large parent passage with much more context"},
+        }]
+        context, _ = brain._build_context(results)
+        assert "large parent passage with much more context" in context
+        assert "small retrieval chunk" not in context
+
+    def test_build_context_falls_back_to_chunk_text_without_parent(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """_build_context falls back to chunk text when parent_text is absent."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig()
+        brain = OpenStudioBrain(config)
+
+        results = [{"id": "d1", "text": "normal chunk text", "score": 0.9, "metadata": {}}]
+        context, _ = brain._build_context(results)
+        assert "normal chunk text" in context
+
+    def test_reranker_model_cli_sets_config(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """--reranker-model CLI arg updates config.reranker_model before brain init."""
+        from rag_brain.main import OpenStudioConfig
+        config = OpenStudioConfig()
+        config.reranker_model = "BAAI/bge-reranker-v2-m3"
+        assert config.reranker_model == "BAAI/bge-reranker-v2-m3"
+
+    def test_reranker_default_model(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Default reranker model is the lightweight ms-marco cross-encoder."""
+        from rag_brain.main import OpenStudioConfig
+        config = OpenStudioConfig()
+        assert config.reranker_model == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    def test_parent_chunk_size_config_defaults_zero(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """parent_chunk_size defaults to 0 (feature disabled by default)."""
+        from rag_brain.main import OpenStudioConfig
+        config = OpenStudioConfig()
+        assert config.parent_chunk_size == 0
+
 
 class TestOpenReranker:
     def test_llm_reranker(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1239,3 +1239,189 @@ class TestGraphRAG:
             call_ids = brain.vector_store.get_by_ids.call_args[0][0]
             assert "d1" not in call_ids
 
+
+# ---------------------------------------------------------------------------
+# Cache: LRU eviction & make_cache_key completeness
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestCacheFixes:
+    def _make_brain(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, **cfg_kwargs):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False,
+                                  similarity_threshold=0.0, **cfg_kwargs)
+        brain = OpenStudioBrain(config)
+        brain._ingested_hashes = set()
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[
+            {"id": "d1", "text": "ctx", "score": 0.9, "metadata": {}}
+        ])
+        return brain
+
+    def test_lru_hit_moves_to_end(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Cache hit moves the entry to the end (most-recently-used position)."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 query_cache=True, query_cache_size=3)
+        brain.llm.complete = MagicMock(side_effect=["A", "B", "A_again"])
+        brain.query("q1")  # inserts key1
+        brain.query("q2")  # inserts key2
+        # Hit q1 — should move key1 to end so key2 would be evicted next
+        brain.llm.complete.side_effect = ["A"]
+        brain.query("q1")  # cache hit; key1 moved to end
+        # Now insert q3 — cache is at size 3 (q1, q2, both present + q3 = need evict q2 = LRU)
+        brain.llm.complete.side_effect = ["C"]
+        brain.query("q3")
+        keys = list(brain._query_cache.keys())
+        # q2 should have been evicted (it was LRU after q1 was accessed)
+        # q1 and q3 should still be present
+        assert len(brain._query_cache) == 3  # size=3, nothing evicted yet
+        # With size=3 nothing evicted, but verify ordering: q1 was moved to end after hit
+        # so in the OrderedDict q2 should be earlier than q1
+        key_q2 = [k for k in keys if brain._query_cache.get(k) == "B"]
+        key_q1 = [k for k in keys if brain._query_cache.get(k) == "A"]
+        if key_q1 and key_q2:
+            assert keys.index(key_q2[0]) < keys.index(key_q1[0])
+
+    def test_lru_evicts_least_recently_used(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """When cache is full the LRU entry (front of OrderedDict) is evicted."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 query_cache=True, query_cache_size=2)
+        brain.llm.complete = MagicMock(side_effect=["A", "B"])
+        brain.query("q1")
+        brain.query("q2")
+        # Access q1 to make q2 LRU
+        brain.llm.complete.side_effect = ["A"]  # would be skipped (cache hit)
+        brain.query("q1")  # cache hit; q1 now MRU
+        # q3 insert should evict q2 (LRU)
+        brain.llm.complete.side_effect = ["C"]
+        brain.query("q3")
+        assert len(brain._query_cache) == 2
+        cached_values = list(brain._query_cache.values())
+        assert "B" not in cached_values, "q2 (LRU) should have been evicted"
+        assert "A" in cached_values
+        assert "C" in cached_values
+
+    def test_cache_size_zero_does_not_cache(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """query_cache_size=0 disables caching (guard against StopIteration on empty cache)."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 query_cache=True, query_cache_size=0)
+        brain.llm.complete = MagicMock(return_value="answer")
+        brain.query("q1")
+        brain.query("q1")  # second call — should NOT raise and should call LLM again
+        assert brain.llm.complete.call_count == 2  # no caching when size=0
+
+    def test_cache_key_includes_cite_sources(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Two requests differing only in cite_sources get distinct cache keys."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        from rag_brain.main import OpenStudioConfig
+        cfg_no_cite = OpenStudioConfig(cite_sources=False)
+        cfg_cite = OpenStudioConfig(cite_sources=True)
+        key1 = brain._make_cache_key("q", None, cfg_no_cite)
+        key2 = brain._make_cache_key("q", None, cfg_cite)
+        assert key1 != key2
+
+    def test_cache_key_includes_compress_context(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Two requests differing only in compress_context get distinct cache keys."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        from rag_brain.main import OpenStudioConfig
+        key1 = brain._make_cache_key("q", None, OpenStudioConfig(compress_context=False))
+        key2 = brain._make_cache_key("q", None, OpenStudioConfig(compress_context=True))
+        assert key1 != key2
+
+    def test_cache_key_filter_serialisation_is_stable(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Same filters in different insertion order produce the same cache key."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        from rag_brain.main import OpenStudioConfig
+        cfg = OpenStudioConfig()
+        key1 = brain._make_cache_key("q", {"b": 2, "a": 1}, cfg)
+        key2 = brain._make_cache_key("q", {"a": 1, "b": 2}, cfg)
+        assert key1 == key2
+
+
+# ---------------------------------------------------------------------------
+# _compress_context empty-results guard
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestCompressContextGuard:
+    def test_compress_context_empty_list_returns_empty(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """_compress_context([]) must not raise ValueError from ThreadPoolExecutor(max_workers=0)."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        brain = OpenStudioBrain(OpenStudioConfig())
+        result = brain._compress_context("any query", [])
+        assert result == []
+
+    def test_compress_context_single_item(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Single-item list compresses without error."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        brain = OpenStudioBrain(OpenStudioConfig())
+        brain.llm.complete = MagicMock(return_value="short")
+        doc = {"id": "d1", "text": "this is a longer original text for the test", "metadata": {}}
+        result = brain._compress_context("query", [doc])
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# switch_project reloads project-scoped state
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestSwitchProjectState:
+    def test_switch_project_clears_query_cache(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, tmp_path):
+        """Switching project empties the query cache to prevent cross-project bleed."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        from rag_brain.projects import ensure_project
+        config = OpenStudioConfig(
+            query_cache=True, query_cache_size=128,
+            vector_store_path=str(tmp_path / "chroma"),
+            bm25_path=str(tmp_path / "bm25"),
+        )
+        brain = OpenStudioBrain(config)
+        # Prime the cache with a fake entry
+        brain._query_cache["fake_key"] = "cached_answer"
+        # Create a real project dir so switch_project doesn't raise
+        proj_path = tmp_path / ".rag_brain" / "projects" / "myproject"
+        proj_path.mkdir(parents=True, exist_ok=True)
+        with patch("rag_brain.projects.project_dir", return_value=proj_path), \
+             patch("rag_brain.projects.project_vector_path", return_value=str(tmp_path / "proj_chroma")), \
+             patch("rag_brain.projects.project_bm25_path", return_value=str(tmp_path / "proj_bm25")), \
+             patch("rag_brain.projects.set_active_project"):
+            brain.switch_project("myproject")
+        assert len(brain._query_cache) == 0
+
+    def test_switch_project_reloads_ingested_hashes(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, tmp_path):
+        """Switching project loads the new project's content hashes."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(
+            vector_store_path=str(tmp_path / "chroma"),
+            bm25_path=str(tmp_path / "bm25"),
+        )
+        brain = OpenStudioBrain(config)
+        # Seed some hashes so we can confirm they get replaced
+        brain._ingested_hashes = {"oldhash1", "oldhash2"}
+        # Write new project's hash store
+        new_bm25 = tmp_path / "proj_bm25"
+        new_bm25.mkdir(parents=True)
+        (new_bm25 / ".content_hashes").write_text("newhash1\nnewhash2\nnewhash3", encoding="utf-8")
+        proj_path = tmp_path / ".rag_brain" / "projects" / "proj2"
+        proj_path.mkdir(parents=True, exist_ok=True)
+        with patch("rag_brain.projects.project_dir", return_value=proj_path), \
+             patch("rag_brain.projects.project_vector_path", return_value=str(tmp_path / "proj_chroma")), \
+             patch("rag_brain.projects.project_bm25_path", return_value=str(new_bm25)), \
+             patch("rag_brain.projects.set_active_project"):
+            brain.switch_project("proj2")
+        assert brain._ingested_hashes == {"newhash1", "newhash2", "newhash3"}
+        assert "oldhash1" not in brain._ingested_hashes
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,6 +108,8 @@ class TestOpenStudioBrain:
         config = OpenStudioConfig(chunk_size=1000)
         brain = OpenStudioBrain(config)
         brain.splitter = None
+        brain._save_hash_store = MagicMock()
+        brain._ingested_hashes = set()  # isolate from real on-disk hash store
 
         docs = [{"id": "d1", "text": "t1"}, {"id": "d2", "text": "t2"}]
         brain.embedding.embed = MagicMock(return_value=[[0.1], [0.1]])
@@ -124,10 +126,160 @@ class TestOpenStudioBrain:
         brain.embedding.embed_query = MagicMock(return_value=[0.1])
         brain.vector_store.search = MagicMock(return_value=[])
         brain._execute_web_search = MagicMock(return_value=[{"id": "w1", "text": "web", "score": 1.0, "is_web": True}])
-        
+
         retrieval = brain._execute_retrieval("query")
         assert retrieval['web_count'] == 1
         assert retrieval['results'][0]['is_web'] is True
+
+    # ------------------------------------------------------------------
+    # Query caching
+    # ------------------------------------------------------------------
+
+    def test_query_cache_returns_cached_response(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Second identical query hits cache; LLM called only once."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0, query_cache=True)
+        brain = OpenStudioBrain(config)
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[{"id": "d1", "text": "ctx", "score": 0.9}])
+        brain.llm.complete = MagicMock(return_value="Cached answer")
+
+        r1 = brain.query("What is RAG?")
+        r2 = brain.query("What is RAG?")
+
+        assert r1 == r2 == "Cached answer"
+        assert brain.llm.complete.call_count == 1
+
+    def test_query_cache_disabled_by_default(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """With query_cache=False (default), LLM is called every time."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0)
+        brain = OpenStudioBrain(config)
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[{"id": "d1", "text": "ctx", "score": 0.9}])
+        brain.llm.complete = MagicMock(return_value="Fresh answer")
+
+        brain.query("What is RAG?")
+        brain.query("What is RAG?")
+
+        assert brain.llm.complete.call_count == 2
+
+    def test_query_cache_not_used_with_chat_history(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Cache is bypassed when chat_history is present (multi-turn context varies)."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0, query_cache=True)
+        brain = OpenStudioBrain(config)
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[{"id": "d1", "text": "ctx", "score": 0.9}])
+        brain.llm.complete = MagicMock(return_value="Contextual answer")
+
+        history = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+        brain.query("What is RAG?", chat_history=history)
+        brain.query("What is RAG?", chat_history=history)
+
+        assert brain.llm.complete.call_count == 2
+
+    def test_query_cache_evicts_oldest_when_full(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Cache evicts oldest entry when query_cache_size is reached."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0,
+                                  query_cache=True, query_cache_size=2)
+        brain = OpenStudioBrain(config)
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[{"id": "d1", "text": "ctx", "score": 0.9}])
+        brain.llm.complete = MagicMock(side_effect=["A", "B", "C"])
+
+        brain.query("q1")
+        brain.query("q2")
+        # q1 should be evicted now
+        brain.query("q3")
+        assert len(brain._query_cache) == 2
+
+    # ------------------------------------------------------------------
+    # Ingest deduplication
+    # ------------------------------------------------------------------
+
+    def test_ingest_dedup_skips_duplicate_chunks(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Re-ingesting the same text is skipped when dedup_on_ingest=True."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(dedup_on_ingest=True)
+        brain = OpenStudioBrain(config)
+        brain.splitter = None
+        brain._ingested_hashes = set()
+        brain._save_hash_store = MagicMock()
+        brain.embedding.embed = MagicMock(return_value=[[0.1]])
+        brain.vector_store.add = MagicMock()
+
+        docs = [{"id": "d1", "text": "unique text"}]
+        brain.ingest(docs)
+        brain.ingest(docs)  # second call — should be skipped
+
+        assert brain.vector_store.add.call_count == 1
+
+    def test_ingest_dedup_allows_new_content(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Different text content passes dedup check and is ingested."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(dedup_on_ingest=True)
+        brain = OpenStudioBrain(config)
+        brain.splitter = None
+        brain._ingested_hashes = set()
+        brain._save_hash_store = MagicMock()
+        brain.embedding.embed = MagicMock(side_effect=[[[0.1]], [[0.2]]])
+        brain.vector_store.add = MagicMock()
+
+        brain.ingest([{"id": "d1", "text": "first doc"}])
+        brain.ingest([{"id": "d2", "text": "second doc"}])
+
+        assert brain.vector_store.add.call_count == 2
+
+    def test_ingest_dedup_disabled(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """With dedup_on_ingest=False, identical content is ingested again."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(dedup_on_ingest=False)
+        brain = OpenStudioBrain(config)
+        brain.splitter = None
+        brain._ingested_hashes = set()
+        brain.embedding.embed = MagicMock(side_effect=[[[0.1]], [[0.1]]])
+        brain.vector_store.add = MagicMock()
+
+        docs = [{"id": "d1", "text": "same text"}]
+        brain.ingest(docs)
+        brain.ingest(docs)
+
+        assert brain.vector_store.add.call_count == 2
+
+    # ------------------------------------------------------------------
+    # Step-back prompting
+    # ------------------------------------------------------------------
+
+    def test_step_back_adds_abstract_query_to_retrieval(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Step-back generates an abstract query and includes it in search_queries."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, similarity_threshold=0.0, step_back=True)
+        brain = OpenStudioBrain(config)
+        brain._get_step_back_query = MagicMock(return_value="abstract concept query")
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.embedding.embed = MagicMock(return_value=[[0.1], [0.2]])
+        brain.vector_store.search = MagicMock(return_value=[])
+        brain.llm.complete = MagicMock(return_value="Step-back answer")
+
+        retrieval = brain._execute_retrieval("specific detailed question")
+
+        brain._get_step_back_query.assert_called_once_with("specific detailed question")
+        assert retrieval['transforms']['step_back_applied'] is True
+        assert "abstract concept query" in retrieval['transforms']['queries']
+
+    def test_step_back_disabled_by_default(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """step_back is False by default — no extra LLM call for abstraction."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False)
+        brain = OpenStudioBrain(config)
+        brain._get_step_back_query = MagicMock()
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[])
+
+        brain._execute_retrieval("any question")
+        brain._get_step_back_query.assert_not_called()
 
 
 class TestOpenReranker:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1015,3 +1015,227 @@ class TestInferProvider:
         assert _infer_provider("GEMINI-2.0-FLASH") == "gemini"
         assert _infer_provider("GPT-4O") == "openai"
 
+
+# ---------------------------------------------------------------------------
+# Inline citations
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestCiteSources:
+    def test_cite_sources_injects_instruction_in_system_prompt(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """When cite_sources=True the system prompt must contain a citation directive."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, cite_sources=True, similarity_threshold=0.0)
+        brain = OpenStudioBrain(config)
+        brain._ingested_hashes = set()
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[
+            {"id": "d1", "text": "Transformers use attention.", "score": 0.9, "metadata": {}}
+        ])
+        brain.llm.complete = MagicMock(return_value="Answer [Doc 1]")
+
+        brain.query("What is a transformer?")
+
+        call_args = brain.llm.complete.call_args
+        system_prompt = call_args[0][1]
+        assert "cite" in system_prompt.lower() or "[Doc" in system_prompt
+
+    def test_cite_sources_disabled_by_default(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Without cite_sources the system prompt must NOT contain the citation directive."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, cite_sources=False, similarity_threshold=0.0)
+        brain = OpenStudioBrain(config)
+        brain._ingested_hashes = set()
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[
+            {"id": "d1", "text": "Transformers use attention.", "score": 0.9, "metadata": {}}
+        ])
+        brain.llm.complete = MagicMock(return_value="Answer")
+
+        brain.query("What is a transformer?")
+
+        call_args = brain.llm.complete.call_args
+        system_prompt = call_args[0][1]
+        assert "Citation requirement" not in system_prompt
+
+    def test_cite_override_applies_via_apply_overrides(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Per-request cite_sources override is applied via _apply_overrides."""
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, cite_sources=False, similarity_threshold=0.0)
+        brain = OpenStudioBrain(config)
+        brain._ingested_hashes = set()
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[
+            {"id": "d1", "text": "Transformers use attention.", "score": 0.9, "metadata": {}}
+        ])
+        brain.llm.complete = MagicMock(return_value="Answer [Doc 1]")
+
+        # Pass override at query time
+        brain.query("What is a transformer?", overrides={"cite_sources": True})
+
+        call_args = brain.llm.complete.call_args
+        system_prompt = call_args[0][1]
+        assert "cite" in system_prompt.lower() or "[Doc" in system_prompt
+        # Ensure original config was not mutated
+        assert brain.config.cite_sources is False
+
+
+# ---------------------------------------------------------------------------
+# RAPTOR hierarchical indexing
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestRaptor:
+    def _make_brain(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, **cfg_kwargs):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, **cfg_kwargs)
+        brain = OpenStudioBrain(config)
+        brain._ingested_hashes = set()
+        brain._save_hash_store = MagicMock()
+        brain._save_entity_graph = MagicMock()
+        brain.embedding.embed = MagicMock(return_value=[[0.1] * 384])
+        brain.vector_store.add = MagicMock()
+        return brain
+
+    def test_raptor_disabled_by_default(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        docs = [{"id": "d1", "text": "chunk one", "metadata": {"source": "a.txt"}},
+                {"id": "d2", "text": "chunk two", "metadata": {"source": "a.txt"}}]
+        # No LLM call for summaries when raptor=False
+        brain.llm.complete = MagicMock(return_value="summary")
+        brain.ingest(docs)
+        brain.llm.complete.assert_not_called()
+
+    def test_raptor_generates_summary_nodes(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 raptor=True, raptor_chunk_group_size=2)
+        docs = [{"id": f"d{i}", "text": f"chunk text {i}", "metadata": {"source": "a.txt"}} for i in range(4)]
+        brain.llm.complete = MagicMock(return_value="This is a raptor summary.")
+        brain.embedding.embed = MagicMock(side_effect=lambda texts: [[0.1] * 384] * len(texts))
+        brain.ingest(docs)
+        # 4 chunks / group_size=2 → 2 summary nodes + 4 leaf = 6 total
+        add_calls = brain.vector_store.add.call_args_list
+        total_ingested = sum(len(c[0][0]) for c in add_calls)  # first positional arg = ids list
+        assert total_ingested >= 5, f"Expected at least 5 docs (4 leaves + ≥1 summary), got {total_ingested}"
+        # LLM was called to produce summaries
+        assert brain.llm.complete.call_count >= 1
+
+    def test_raptor_summary_metadata_has_raptor_level(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 raptor=True, raptor_chunk_group_size=3)
+        docs = [{"id": f"d{i}", "text": f"text {i}", "metadata": {"source": "b.txt"}} for i in range(3)]
+        brain.llm.complete = MagicMock(return_value="Summary content")
+        brain.embedding.embed = MagicMock(side_effect=lambda texts: [[0.1] * 384] * len(texts))
+        brain.ingest(docs)
+
+        add_calls = brain.vector_store.add.call_args_list
+        all_metadatas = []
+        for call in add_calls:
+            all_metadatas.extend(call[0][3])  # 4th positional arg = metadatas
+        raptor_meta = [m for m in all_metadatas if m.get("raptor_level") == 1]
+        assert len(raptor_meta) >= 1
+
+    def test_raptor_failure_silently_skipped(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """If LLM fails for a group, RAPTOR skips that group without crashing."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 raptor=True, raptor_chunk_group_size=2)
+        docs = [{"id": f"d{i}", "text": f"text {i}", "metadata": {"source": "c.txt"}} for i in range(2)]
+        brain.llm.complete = MagicMock(side_effect=RuntimeError("LLM down"))
+        brain.embedding.embed = MagicMock(return_value=[[0.1] * 384] * 2)
+        brain.ingest(docs)  # should not raise
+        # Only the 2 leaf chunks ingested (no summary added)
+        add_calls = brain.vector_store.add.call_args_list
+        total_ingested = sum(len(c[0][0]) for c in add_calls)
+        assert total_ingested == 2
+
+
+# ---------------------------------------------------------------------------
+# GraphRAG entity-centric retrieval
+# ---------------------------------------------------------------------------
+
+@patch("rag_brain.retrievers.BM25Retriever")
+@patch("rag_brain.main.OpenVectorStore")
+@patch("rag_brain.main.OpenLLM")
+@patch("rag_brain.main.OpenEmbedding")
+@patch("rag_brain.main.OpenReranker")
+class TestGraphRAG:
+    def _make_brain(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, **cfg_kwargs):
+        from rag_brain.main import OpenStudioBrain, OpenStudioConfig
+        config = OpenStudioConfig(hybrid_search=False, rerank=False, **cfg_kwargs)
+        brain = OpenStudioBrain(config)
+        brain._ingested_hashes = set()
+        brain._save_hash_store = MagicMock()
+        brain._save_entity_graph = MagicMock()
+        return brain
+
+    def test_graph_rag_disabled_by_default(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25)
+        docs = [{"id": "d1", "text": "Attention is all you need.", "metadata": {"source": "a.txt"}}]
+        brain.embedding.embed = MagicMock(return_value=[[0.1] * 384])
+        brain.vector_store.add = MagicMock()
+        brain.llm.complete = MagicMock(return_value="Attention")
+        brain.ingest(docs)
+        # Entity graph should remain empty since graph_rag=False
+        assert brain._entity_graph == {}
+
+    def test_graph_rag_populates_entity_graph_on_ingest(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25, graph_rag=True)
+        docs = [{"id": "d1", "text": "BERT is a transformer model.", "metadata": {"source": "ml.txt"}}]
+        brain.embedding.embed = MagicMock(return_value=[[0.1] * 384])
+        brain.vector_store.add = MagicMock()
+        brain.llm.complete = MagicMock(return_value="BERT\ntransformer")
+        brain.ingest(docs)
+        # At least one entity should be in the graph
+        assert len(brain._entity_graph) >= 1
+        # doc id (possibly with chunk suffix from splitter) should appear under at least one entity
+        all_ids = {doc_id for ids in brain._entity_graph.values() for doc_id in ids}
+        assert any(doc_id.startswith("d1") for doc_id in all_ids)
+
+    def test_graph_rag_expands_results_at_query_time(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """Entity graph expansion fetches related docs not in original results."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 graph_rag=True, similarity_threshold=0.0)
+        # Pre-populate entity graph
+        brain._entity_graph = {"transformer": ["d2"]}
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        # Primary retrieval returns only d1
+        brain.vector_store.search = MagicMock(return_value=[
+            {"id": "d1", "text": "Attention mechanisms", "score": 0.9, "metadata": {}}
+        ])
+        # get_by_ids returns d2 for GraphRAG expansion
+        brain.vector_store.get_by_ids = MagicMock(return_value=[
+            {"id": "d2", "text": "BERT is a transformer.", "score": 1.0, "metadata": {}}
+        ])
+        brain.llm.complete = MagicMock(return_value="transformer")  # entity extraction
+        brain.llm.complete.side_effect = ["transformer", "Answer"]
+        # Answer
+        brain.llm.complete = MagicMock(side_effect=["transformer", "final answer"])
+        result = brain.query("What is a transformer?")
+        # get_by_ids should have been called for graph expansion
+        brain.vector_store.get_by_ids.assert_called()
+
+    def test_graph_rag_does_not_duplicate_already_retrieved(self, MockReranker, MockEmbed, MockLLM, MockStore, MockBM25):
+        """GraphRAG expansion skips doc IDs already in primary results."""
+        brain = self._make_brain(MockReranker, MockEmbed, MockLLM, MockStore, MockBM25,
+                                 graph_rag=True, similarity_threshold=0.0)
+        brain._entity_graph = {"transformer": ["d1"]}  # d1 already in primary results
+        brain.embedding.embed_query = MagicMock(return_value=[0.1])
+        brain.vector_store.search = MagicMock(return_value=[
+            {"id": "d1", "text": "Attention", "score": 0.9, "metadata": {}}
+        ])
+        brain.vector_store.get_by_ids = MagicMock(return_value=[])
+        brain.llm.complete = MagicMock(side_effect=["transformer", "answer"])
+        brain.query("What is a transformer?")
+        # get_by_ids called but with empty list (d1 already present)
+        if brain.vector_store.get_by_ids.called:
+            call_ids = brain.vector_store.get_by_ids.call_args[0][0]
+            assert "d1" not in call_ids
+


### PR DESCRIPTION
## Summary

This PR closes all remaining SOTA RAG gaps on the roadmap. All 10 items are now shipped.

- **Inline Source Citations** (`cite_sources`): LLM instructed to cite `[Doc N]` inline in answers. `--cite` CLI flag, `"cite": true` API override, `rag.cite_sources` YAML.
- **RAPTOR Hierarchical Indexing** (`raptor`): Groups consecutive chunks per source, LLM-summarises each window into `raptor_level=1` nodes indexed alongside leaf chunks. `--raptor` / `--raptor-group-size` CLI, `rag.raptor` YAML.
- **GraphRAG Entity-Centric Retrieval** (`graph_rag`): Extracts named entities from chunks during ingest; persists entity→doc_id graph to `.entity_graph.json`; expands query results with graph-linked documents at retrieval time. `--graph-rag` CLI, `rag.graph_rag` YAML.
- **Evaluation in CI**: 19 eval smoke tests (`test_eval_smoke.py`) covering precision@k, context relevance, answer faithfulness, and recall@k. `@pytest.mark.eval` marker. Dedicated eval step in `ci.yml`.

## Changes

| File | What changed |
|---|---|
| `src/rag_brain/main.py` | `cite_sources`, `raptor`, `raptor_chunk_group_size`, `graph_rag` config fields; `_generate_raptor_summaries()`, `_extract_entities()`, `_expand_with_entity_graph()`, `_load/save_entity_graph()`; `OpenVectorStore.get_by_ids()`; citation injection in `_build_system_prompt()`; RAPTOR+GraphRAG hooks in `ingest()`; GraphRAG expansion in `_execute_retrieval()`; CLI args wired |
| `src/rag_brain/api.py` | `cite` field on `QueryRequest`; `cite_sources` in overrides dict; `cite` in settings response |
| `tests/test_eval_smoke.py` | New — 19 eval smoke tests |
| `tests/test_main.py` | `TestCiteSources`, `TestRaptor`, `TestGraphRAG` test classes (+13 tests) |
| `tests/test_api.py` | `test_query_override_cite`, `test_query_response_includes_cite_in_settings` (+2 tests) |
| `pyproject.toml` | `eval` marker registered |
| `.github/workflows/ci.yml` | Dedicated eval smoke test step added |
| `SOTA_ANALYSIS.md` | All 10 roadmap items marked ✅ shipped |

## Test plan

- [x] `pytest tests/ -v` — 267 tests passing (was 235, +32 new)
- [x] `pytest tests/test_eval_smoke.py -m eval -v` — 19/19 eval tests pass
- [x] `python -m py_compile src/rag_brain/main.py src/rag_brain/api.py` — syntax clean
- [ ] Merge into master after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)