### PR TITLE
docs: add Getting Started link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ This project provides a fully open-source, local-first retrieval-augmented gener
 
 ## 📚 Documentation
 
+- **[Getting Started](GETTING_STARTED.md)** - New here? Start with this
 - **[Setup Guide](SETUP.md)** - Detailed step-by-step setup for LLM and embedding models
-- **[SOTA Analysis](SOTA_ANALYSIS.md)** - Gap analysis vs. state-of-the-art RAG systems and roadmap
 - **[Quick Reference](QUICKREF.md)** - Common commands and examples
+- **[Model Guide](MODEL_GUIDE.md)** - Supported models and configuration
+- **[Troubleshooting](TROUBLESHOOTING.md)** - Common issues and fixes
 - **[Development Guide](DEVELOPMENT.md)** - Setup and development workflow
 - **[Contributing](CONTRIBUTING.md)** - How to contribute
 - **[Security Policy](SECURITY.md)** - Security best practices
+- **[SOTA Analysis](SOTA_ANALYSIS.md)** - Gap analysis vs. state-of-the-art RAG systems and roadmap
 - **[Improvements Summary](IMPROVEMENTS.md)** - Recent enhancements
-- **[Model Guide](MODEL_GUIDE.md)** - Supported models and configuration
-- **[Troubleshooting](TROUBLESHOOTING.md)** - Common issues and fixes
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `GETTING_STARTED.md` link to the Documentation section at the top of the list — new users now land there first
- Reorders remaining doc links by usefulness: setup → quickref → model guide → troubleshooting → dev/contributing → misc

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `GETTING_STARTED.md` link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)