### PR TITLE
docs: doc audit — fix inaccuracies, duplication, and stale references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, master]  # only PRs targeting main/master trigger CI
+    branches: [main]  # only PRs targeting main trigger CI
 
 jobs:
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,27 +11,12 @@ Thank you for your interest in contributing to Axon! This document provides guid
 
 ### Setting Up Your Development Environment
 
-1. **Fork and clone the repository**
-   ```bash
-   git clone https://github.com/jyunming/Axon.git
-   cd Axon
-   ```
+See [SETUP.md](SETUP.md) for platform-specific installation steps. Quick start:
 
-2. **Create a virtual environment**
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   ```
-
-3. **Install development dependencies**
-   ```bash
-   pip install -e ".[dev]"
-   ```
-
-4. **Install pre-commit hooks**
-   ```bash
-   pre-commit install
-   ```
+```bash
+git clone https://github.com/jyunming/Axon.git && cd Axon
+pip install -e ".[dev]"
+```
 
 ## Development Workflow
 
@@ -159,10 +144,10 @@ def test_add_and_search():
 
 ## Pull Request Process
 
-1. **Create a feature branch from `master`**
-   > ⚠️ **Never commit directly to `master`.** All changes go through PRs.
+1. **Create a feature branch from `main`**
+   > ⚠️ **Never commit directly to `main`.** All changes go through PRs.
    ```bash
-   git checkout master && git pull
+   git checkout main && git pull
    git checkout -b feature/your-feature-name
    ```
 
@@ -184,7 +169,7 @@ def test_add_and_search():
    git commit -m "Add feature: description"
    ```
 
-5. **Push to your fork and open a PR targeting `master`**
+5. **Push to your fork and open a PR targeting `main`**
    ```bash
    git push origin feature/your-feature-name
    ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,18 +3,12 @@
 ## Quick Start for Developers
 
 ### 1. Setup Environment
+
+See [SETUP.md](SETUP.md) for platform-specific installation steps. Quick start:
+
 ```bash
-# Clone the repository
-git clone https://github.com/jyunming/Axon.git
-cd Axon
-
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# Install with dev dependencies
-make install-dev
-# Or: pip install -e ".[dev]"
+git clone https://github.com/jyunming/Axon.git && cd Axon
+pip install -e ".[dev]"
 ```
 
 ### 2. Common Development Tasks
@@ -58,7 +52,10 @@ Axon/
 │   ├── loaders.py          # Document loaders
 │   ├── retrievers.py       # Search implementations
 │   ├── splitters.py        # Text chunking
-│   └── tools.py            # Agent tool definitions
+│   ├── tools.py            # Agent tool definitions
+│   ├── projects.py         # Multi-user project namespace management
+│   ├── shares.py           # HMAC share key generation and redemption
+│   └── mcp_server.py       # MCP stdio server for Copilot agent mode
 ├── tests/                  # Test suite
 │   ├── conftest.py         # Shared fixtures (overrides tmp_path for Windows compat)
 │   ├── test_api.py         # FastAPI endpoint tests
@@ -79,10 +76,10 @@ Axon/
 
 ### 4. Development Workflow
 
-1. **Create a feature branch from `master`:**
-   > ⚠️ **Never commit directly to `master`.** Always branch first.
+1. **Create a feature branch from `main`:**
+   > ⚠️ **Never commit directly to `main`.** Always branch first.
    ```bash
-   git checkout master && git pull
+   git checkout main && git pull
    git checkout -b feature/your-feature
    ```
 
@@ -100,10 +97,10 @@ Axon/
    # Pre-commit hooks will run automatically
    ```
 
-4. **Push and create PR targeting `master`:**
+4. **Push and create PR targeting `main`:**
    ```bash
    git push origin feature/your-feature
-   # Create pull request on GitHub targeting master
+   # Create pull request on GitHub targeting main
    ```
 
 ### 5. Testing Guidelines

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,14 +19,9 @@ ollama pull phi3:mini     # minimal  — 2.3 GB, ~4 GB RAM
 
 ## Install the VS Code Extension
 
-The VSIX ships with the repo — no download needed:
+Install the bundled extension: open Extensions panel (`Ctrl+Shift+X`) → `···` → **Install from VSIX** → select `integrations/vscode-axon/axon-copilot-1.0.0.vsix` → reload VS Code.
 
-```
-1. Open Extensions panel  (Ctrl+Shift+X)
-2. Click  "..."  →  "Install from VSIX..."
-3. Select  integrations/vscode-axon/axon-copilot-1.0.0.vsix
-4. Reload VS Code  (Ctrl+Shift+P → "Reload Window")
-```
+> Full setup guide including Python discovery, settings, and troubleshooting: [SETUP.md § 11](SETUP.md#11-vs-code-extension-github-copilot-integration)
 
 **How the extension finds Python** (for `autoStart` — starting `axon-api` automatically):
 
@@ -189,6 +184,8 @@ axon-api   # must be running
 Reload VS Code → Copilot agent mode → Axon tools appear automatically.
 
 > **Windows:** if `axon-mcp` is not on PATH, use the full path: `C:\Users\<you>\AppData\Local\Programs\Python\Python313\Scripts\axon-mcp.exe`
+
+> Full MCP setup including Linux/WSL paths, team sharing, and Windows workarounds: [SETUP.md § 10](SETUP.md#10-mcp-setup-copilot-agent-mode)
 
 ---
 

--- a/MODEL_GUIDE.md
+++ b/MODEL_GUIDE.md
@@ -124,6 +124,7 @@ The system supports cloud providers in addition to local Ollama models. Set `llm
 | **OpenAI** | `openai` | `gpt-4o`, `gpt-3.5-turbo` | Requires `OPENAI_API_KEY` |
 | **Ollama Cloud** | `ollama_cloud` | Any Ollama-hosted model | Requires `OLLAMA_CLOUD_URL` + `OLLAMA_CLOUD_KEY` |
 | **vLLM** | `vllm` | Any vLLM-served model | Self-hosted OpenAI-compatible endpoint; set `vllm_base_url` in `config.yaml` |
+| **GitHub Copilot** | `copilot` | Any active Copilot model | VS Code only — routes LLM calls through the Copilot extension bridge; no Ollama required. Enable via `axon.useCopilotLlm: true` in VS Code settings or `provider: copilot` in `config.yaml`. |
 
 Example `config.yaml` for Gemini:
 ```yaml
@@ -375,7 +376,7 @@ ollama pull nomic-embed-text  # Optional, for better quality
 
 3. **Import and test:**
 ```python
-from axon import AxonBrain, AxonConfig
+from axon.main import AxonBrain, AxonConfig
 
 config = AxonConfig(
     embedding_provider="sentence_transformers",

--- a/QUICKREF.md
+++ b/QUICKREF.md
@@ -173,9 +173,9 @@ git commit -m "feat: add new feature"
 # Push
 git push origin feature/new-feature
 
-# Update from master
+# Update from main
 git fetch origin
-git rebase origin/master
+git rebase origin/main
 ```
 
 ## Configuration
@@ -319,12 +319,12 @@ curl -X POST http://localhost:8000/store/init \
 # Generate a share key
 curl -X POST http://localhost:8000/share/generate \
   -H "Content-Type: application/json" \
-  -d '{"project": "my-project", "expires_in_hours": 48}'
+  -d '{"project": "my-project", "grantee": "<os-username>", "write_access": false}'
 
 # Redeem a share key
 curl -X POST http://localhost:8000/share/redeem \
   -H "Content-Type: application/json" \
-  -d '{"key": "axon-share-..."}'
+  -d '{"share_string": "axon-share-..."}'
 
 # List active shares
 curl http://localhost:8000/share/list
@@ -332,7 +332,7 @@ curl http://localhost:8000/share/list
 # Revoke a share
 curl -X POST http://localhost:8000/share/revoke \
   -H "Content-Type: application/json" \
-  -d '{"key": "axon-share-..."}'
+  -d '{"key_id": "sk_a1b2c3d4"}'
 ```
 
 ### OpenAPI / Swagger UI
@@ -343,66 +343,7 @@ http://localhost:8000/docs
 
 ## Troubleshooting
 
-### Common Issues
-
-**Issue: Import errors**
-```bash
-# Solution
-pip install -e .
-# Or reinstall
-pip uninstall axon
-pip install -e .
-```
-
-**Issue: Tests fail**
-```bash
-# Solution
-pip install -e ".[dev]"
-pytest -v  # Verbose mode to see details
-```
-
-**Issue: Ollama connection failed**
-```bash
-# Check Ollama is running
-ollama list
-
-# Start Ollama service
-# On Linux/Mac: ollama serve
-# On Windows: Start Ollama application
-
-# Test connection
-curl http://localhost:11434/api/tags
-```
-
-**Issue: ChromaDB errors**
-```bash
-# Clear and rebuild
-rm -rf chroma_data/
-rm -rf bm25_index/
-# Re-ingest documents
-```
-
-**Issue: Port already in use**
-```bash
-# Find process using port
-lsof -i :8000  # Mac/Linux
-netstat -ano | findstr :8000  # Windows
-
-# Change port
-export AXON_PORT=8001
-axon-api
-```
-
-### Debug Mode
-```bash
-# Enable debug logging
-export LOG_LEVEL=DEBUG
-axon-api
-
-# Or in Python
-import logging
-logging.basicConfig(level=logging.DEBUG)
-```
+For common errors and fixes, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ## Code Examples
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -117,9 +117,9 @@ cursor.execute(query, (user_id,))
 - Path validation for file operations
 - YAML safe loading (no arbitrary code execution)
 - Dependency pinning with version ranges
+- **Optional API key authentication** — set the `RAG_API_KEY` environment variable to enable. When set, every request to `axon-api` must include the header `X-API-Key: <your-value>`. Axon does not generate the key; you choose and set it yourself (treat it like a password). Unset by default — suitable for local/LAN use without auth.
 
 ### Planned Improvements
-- [ ] Add authentication to API endpoints
 - [ ] Implement rate limiting
 - [ ] Add input validation middleware
 - [ ] Security audit of file operations

--- a/SETUP.md
+++ b/SETUP.md
@@ -420,7 +420,7 @@ bm25:
 
 rag:
   top_k: 10
-  similarity_threshold: 0.5
+  similarity_threshold: 0.3
   hybrid_search: true
 
 chunk:
@@ -454,7 +454,7 @@ bm25:
 
 rag:
   top_k: 10
-  similarity_threshold: 0.5
+  similarity_threshold: 0.3
   hybrid_search: true
 
 chunk:
@@ -470,7 +470,8 @@ rerank:
 ```yaml
 embedding:
   provider: ollama
-  model: nomic-embed-text  # Ollama uses the OLLAMA_HOST env var, not base_url
+  model: nomic-embed-text
+  base_url: http://localhost:11434
 
 llm:
   provider: ollama
@@ -785,7 +786,7 @@ For a team where one person owns ingestion and others query:
 3. Each user's VS Code spawns its own lightweight `axon-mcp` proxy; the shared
    API handles all retrieval. The owner ingests; everyone else queries.
 
-### Available MCP tools (12 total)
+### Available MCP tools (23 total)
 
 | Tool | Purpose |
 |---|---|
@@ -801,6 +802,17 @@ For a team where one person owns ingestion and others query:
 | `delete_documents` | Remove documents by ID |
 | `list_projects` | List all project namespaces |
 | `get_stale_docs` | Find docs not re-ingested within N days |
+| `create_project` | Create a new project namespace |
+| `delete_project` | Delete a project and all its data |
+| `clear_knowledge` | Clear all vectors and BM25 index |
+| `get_current_settings` | Return current RAG configuration |
+| `update_settings` | Update RAG flags (top_k, rerank, hyde, etc.) |
+| `list_sessions` | List saved conversation sessions |
+| `get_session` | Retrieve a saved conversation session |
+| `share_project` | Generate a share key for a project |
+| `redeem_share` | Redeem a share key to mount a shared project |
+| `list_shares` | List active outbound shares |
+| `init_store` | Initialise AxonStore multi-user mode |
 
 > **Recommended:** use `search_knowledge` (not `query_knowledge`) in agent mode.
 > Copilot's LLM synthesises the answer from raw chunks — no Ollama required,
@@ -989,137 +1001,7 @@ Access via Ctrl+Shift+P:
 
 ## 12. Troubleshooting
 
-### Ollama not running
-
-**Symptom:** `ConnectionRefusedError` or `httpx.ConnectError` when starting the API.
-
-```bash
-# Check if Ollama is running
-curl http://localhost:11434/api/tags
-
-# If not running, start it:
-ollama serve
-```
-
----
-
-### Model not found
-
-**Symptom:** `model 'llama3.1' not found` error.
-
-```bash
-# List pulled models
-ollama list
-
-# Pull the model
-ollama pull llama3.1:8b
-
-# Make sure config.yaml model name matches exactly
-# e.g., use "llama3.1:8b" not "llama3.1"
-```
-
----
-
-### Port already in use
-
-**Symptom:** `Address already in use` on port 8000 or 8501.
-
-```bash
-# Find what's using the port
-lsof -i :8000       # Linux / macOS
-netstat -ano | findstr :8000  # Windows
-
-# Change the port in .env
-AXON_PORT=8001
-```
-
----
-
-### ChromaDB errors / corrupted index
-
-**Symptom:** `chromadb.errors.InvalidCollectionException` or similar.
-
-```bash
-# Clear and rebuild the index (you will need to re-ingest documents)
-rm -rf chroma_data/
-rm -rf bm25_index/
-```
-
----
-
-### Embedding shape mismatch
-
-**Symptom:** Error about vector dimension mismatch after changing the embedding model.
-
-This happens when you change embedding providers/models after already ingesting documents. The existing vectors in ChromaDB have different dimensions than what the new model produces.
-
-**Fix:** Clear the vector store and re-ingest:
-```bash
-rm -rf chroma_data/
-rm -rf bm25_index/
-# Then re-ingest your documents
-axon --ingest ./your_documents/
-```
-
----
-
-### sentence-transformers model download fails
-
-**Symptom:** Timeout or SSL error when downloading `all-MiniLM-L6-v2`.
-
-```bash
-# Pre-download with explicit cache dir
-python -c "
-from sentence_transformers import SentenceTransformer
-model = SentenceTransformer('all-MiniLM-L6-v2')
-print('Downloaded successfully')
-"
-
-# If behind a proxy, set environment variables:
-export HTTPS_PROXY=http://your-proxy:port
-export HTTP_PROXY=http://your-proxy:port
-```
-
----
-
-### FastEmbed import error
-
-**Symptom:** `ModuleNotFoundError: No module named 'fastembed'`
-
-```bash
-pip install fastembed
-# Or reinstall with extras:
-pip install -e ".[fastembed]"
-```
-
----
-
-### Memory error / OOM when running LLM
-
-**Symptom:** Process killed, OOM error, or system becomes unresponsive.
-
-Options:
-1. Use a smaller LLM (e.g., `phi3:mini` instead of `llama3.1:8b`)
-2. Reduce `max_tokens` in `config.yaml`
-3. Enable GPU if available (Ollama detects it automatically)
-4. Close other applications to free RAM
-
----
-
-### Docker setup
-
-If using Docker Compose, Ollama runs as a separate service. The `docker-compose.yml` handles networking automatically:
-
-```bash
-docker-compose up --build
-```
-
-Check that all services are healthy:
-```bash
-docker-compose ps
-```
-
-If the API service can't reach Ollama, check the `OLLAMA_HOST` environment variable in `docker-compose.yml` — it should reference the Ollama service name, not `localhost`.
+For common errors and step-by-step fixes, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -471,7 +471,8 @@ rerank:
 embedding:
   provider: ollama
   model: nomic-embed-text
-  base_url: http://localhost:11434
+  # Ollama endpoint is shared with the LLM — set base_url under llm: below,
+  # or set the OLLAMA_HOST env var to override globally.
 
 llm:
   provider: ollama

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axon"
-version = "2.0.0"
+version = "1.0.0"
 description = "General-purpose open-source RAG and embedding interface"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="axon",
-    version="2.0.0",
+    version="1.0.0",
     author="Open Source Contributor",
     description="General-purpose open-source RAG and embedding interface",
     long_description=long_description,

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -23,7 +23,7 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__version__ = "2.0.0"
+__version__ = "1.0.0"
 __all__ = [
     "AxonBrain",
     "AxonConfig",

--- a/src/axon/__init__.py
+++ b/src/axon/__init__.py
@@ -29,7 +29,7 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__version__ = "2.0.0"
+__version__ = "1.0.0"
 __all__ = [
     "AxonBrain",
     "AxonConfig",

--- a/src/axon/api.py
+++ b/src/axon/api.py
@@ -94,7 +94,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Axon API",
     description="REST API for agent orchestration and document retrieval",
-    version="2.0.0",
+    version="1.0.0",
     lifespan=lifespan,
 )
 


### PR DESCRIPTION
## Summary

- **Version aligned** to 1.0.0 across `pyproject.toml`, `setup.py`, `api.py`
- **QUICKREF.md** — fixed wrong share API payloads (`grantee`, `share_string`, `key_id`)
- **SETUP.md** — MCP tool count corrected 12→23 with 11 missing tools added; `similarity_threshold` default 0.5→0.3; Ollama embedding `base_url` comment fixed
- **CONTRIBUTING.md + ci.yml** — `master` → `main` throughout; CI now only triggers on PRs to `main`
- **DEVELOPMENT.md** — added `projects.py`, `shares.py`, `mcp_server.py` to module tree
- **MODEL_GUIDE.md** — fixed import path (`from axon.main import`); added `copilot` LLM provider row
- **SECURITY.md** — moved API key auth (`RAG_API_KEY` / `X-API-Key`) from Planned → Current Protections with full description
- **Duplication consolidated** — VSIX install steps, MCP setup, troubleshooting sections, and install commands now cross-reference `SETUP.md` as single source of truth

## Test plan

- [ ] Verify all links in updated docs resolve correctly
- [ ] Confirm version 1.0.0 in `pyproject.toml`, `setup.py`, `api.py`, and `GET /config` response
- [ ] Confirm share API curl examples work against a running `axon-api`
- [ ] Confirm CI passes (no code changes, only docs + version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)