### PR TITLE
fix: release notes, PyPI README, and agent publishing docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -382,3 +382,24 @@ aborted with a `RuntimeError` if any active model is `[remote]` or `[MISSING]`.
 - **Do** use `query_router: heuristic` (the default) for most deployments —
   it requires no LLM calls and selects the right retrieval strategy
   automatically.
+
+---
+
+## PyPI Publishing
+
+- Package name on PyPI: `axon-rag` — install with `pip install axon-rag`
+- Publishing is tag-triggered, NOT merge-triggered — merging to main does nothing to PyPI
+- Full release sequence: bump `pyproject.toml` version → bump `integrations/vscode-axon/package.json` → rebuild VSIX (`npm run package`) → commit → PR → merge → `git tag vX.Y.Z && git push origin vX.Y.Z`
+- NEVER bump version without a functional reason — packaging/doc/readme fixes alone do not justify a bump
+- PyPI releases are immutable — description cannot be updated after upload; always verify `PYPI_README.md` renders correctly before tagging
+- `PYPI_README.md` is the PyPI description (NOT `README.md`) — uses absolute URLs (`https://raw.githubusercontent.com/jyunming/Axon/main/...`) because PyPI cannot resolve relative paths or repo-relative images
+- GitHub release notes use `generate_notes: true` in `release.yml` — do NOT replace with custom git-log scripts (they dump entire history on first tag and misattribute authorship)
+
+---
+
+## Packaging Rules
+
+- `src/__init__.py` must NOT exist — `packages.find where=["src"]` would ship a bare `src` namespace package into user environments
+- Files imported by `axon/__init__.py` (e.g. `llm.py`) cannot do `from axon import __version__` — circular import; use `importlib.metadata.version("axon-rag")` directly instead
+- When moving a dep from base to an optional extra, guard its top-level import — e.g. `try: import streamlit as st; _AVAIL=True` / `except ImportError: _AVAIL=False`
+- Windows mypy outputs backslash paths; `_is_allowed()` in `test_lint.py` normalises with `.replace("\\", "/")` before matching the allowlist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # full history needed for changelog
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -38,47 +38,11 @@ jobs:
       - name: Build distributions
         run: python -m build
 
-      - name: Generate changelog from git log
-        id: changelog
-        run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            RANGE="$PREV_TAG..HEAD"
-          else
-            RANGE="HEAD"
-          fi
-
-          echo "## What's Changed" > CHANGELOG_RELEASE.md
-          echo "" >> CHANGELOG_RELEASE.md
-
-          # Features (commits with feat:)
-          FEATURES=$(git log $RANGE --oneline --no-merges --grep="^feat" 2>/dev/null || true)
-          if [ -n "$FEATURES" ]; then
-            echo "### New Features" >> CHANGELOG_RELEASE.md
-            git log $RANGE --oneline --no-merges --grep="^feat" | sed 's/^/- /' >> CHANGELOG_RELEASE.md
-            echo "" >> CHANGELOG_RELEASE.md
-          fi
-
-          # Fixes (commits with fix:)
-          FIXES=$(git log $RANGE --oneline --no-merges --grep="^fix" 2>/dev/null || true)
-          if [ -n "$FIXES" ]; then
-            echo "### Bug Fixes" >> CHANGELOG_RELEASE.md
-            git log $RANGE --oneline --no-merges --grep="^fix" | sed 's/^/- /' >> CHANGELOG_RELEASE.md
-            echo "" >> CHANGELOG_RELEASE.md
-          fi
-
-          # Everything else
-          echo "### All Changes" >> CHANGELOG_RELEASE.md
-          git log $RANGE --oneline --no-merges | sed 's/^/- /' >> CHANGELOG_RELEASE.md
-
-          echo "Generated changelog:"
-          cat CHANGELOG_RELEASE.md
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: "Axon v${{ steps.version.outputs.VERSION }}"
-          body_path: CHANGELOG_RELEASE.md
+          generate_notes: true
           files: |
             dist/*.tar.gz
             dist/*.whl

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,0 +1,150 @@
+# axon-rag
+
+**Your documents, answerable. On your hardware.**
+
+Drop in PDFs, code, spreadsheets, or URLs — ask anything, get cited answers from a local LLM. Nothing leaves your machine.
+
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/jyunming/Axon/blob/main/LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/axon-rag.svg)](https://pypi.org/project/axon-rag/)
+
+---
+
+![Axon REPL](https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/repl-animation.gif)
+
+---
+
+## Why Axon?
+
+Most RAG tools make you choose between cloud power and data privacy. Axon runs entirely on your hardware — full capability, zero egress.
+
+- **Private by default** — all inference runs locally via Ollama. No API key required, no upload, no telemetry.
+- **Ingest anything** — 54 file formats (PDF, DOCX, PPTX, Jupyter, code, images, URLs) with SHA-256 dedup.
+- **Works in your tools** — `@axon` in Copilot Chat, MCP server for Claude Code / Codex / Gemini CLI / Cursor, Graph panel in VS Code.
+- **Built for teams** — share your knowledge base with signed, revocable read-only keys.
+- **Production-grade retrieval** — hybrid search, reranking, HyDE, multi-query expansion, RAPTOR, GraphRAG.
+
+---
+
+## Install
+
+```bash
+pip install axon-rag
+```
+
+Requires Python 3.10+ and [Ollama](https://ollama.com) running locally.
+
+### Optional extras
+
+```bash
+pip install axon-rag[ui]        # Streamlit web UI (axon-ui)
+pip install axon-rag[chroma]    # ChromaDB vector store
+pip install axon-rag[qdrant]    # Qdrant vector store
+pip install axon-rag[graphrag]  # GraphRAG (networkx + leidenalg)
+pip install axon-rag[loaders]   # Extra file loaders (EPUB, RTF, email)
+pip install axon-rag[all]       # Everything above
+```
+
+---
+
+## Quick Start
+
+```bash
+# Pull a model (first time only)
+ollama pull llama3.2
+
+# Launch the interactive REPL
+axon
+
+# Ingest a file or folder
+axon ingest ~/docs/myreport.pdf
+axon ingest ~/projects/myrepo/
+
+# Ask a question
+axon query "What are the key findings?"
+```
+
+---
+
+## Entry Points
+
+| Command | What it does |
+|---------|-------------|
+| `axon` | Interactive REPL — day-to-day exploration |
+| `axon-api` | FastAPI REST server on port 8000 |
+| `axon-mcp` | MCP stdio server — 30 tools for Claude Code, Codex, Gemini CLI, Cursor |
+| `axon-ui` | Streamlit web UI on port 8501 (requires `[ui]` extra) |
+| `axon-ext` | Install the bundled VS Code extension |
+
+---
+
+## VS Code Extension
+
+![Axon Copilot](https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/AxonCopilot.gif)
+
+Install the bundled extension to get the `@axon` chat participant, Knowledge Graph panel, Code Graph panel, and Governance dashboard directly inside VS Code alongside GitHub Copilot:
+
+```bash
+axon-ext
+```
+
+![Axon VS Code Graph Panel](https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/vscode-graph-panel.png)
+
+---
+
+## MCP Server
+
+Connect any MCP-compatible agent to your local knowledge base:
+
+```json
+{
+  "servers": {
+    "axon": {
+      "command": "axon-mcp"
+    }
+  }
+}
+```
+
+30 tools available: ingest, query, search, project management, graph operations, sharing, and more.
+
+---
+
+## Configuration
+
+On first run, Axon creates `~/.config/axon/config.yaml`. Key settings:
+
+```yaml
+llm:
+  provider: ollama          # ollama | openai | gemini | grok | copilot
+  model: llama3.2
+  base_url: http://localhost:11434
+
+embedding:
+  provider: sentence_transformers
+  model: BAAI/bge-small-en-v1.5
+
+rag:
+  top_k: 5
+  hybrid: true
+  rerank: false
+  hyde: false
+```
+
+---
+
+## Documentation
+
+Full documentation is available on GitHub:
+
+- [Getting Started](https://github.com/jyunming/Axon/blob/main/docs/GETTING_STARTED.md) — first-time walkthrough
+- [Setup Guide](https://github.com/jyunming/Axon/blob/main/docs/SETUP.md) — install, models, VS Code, MCP
+- [Admin Reference](https://github.com/jyunming/Axon/blob/main/docs/ADMIN_REFERENCE.md) — every endpoint, command, and config option
+- [Advanced RAG](https://github.com/jyunming/Axon/blob/main/docs/ADVANCED_RAG.md) — HyDE, RAPTOR, GraphRAG, CRAG-Lite
+- [Troubleshooting](https://github.com/jyunming/Axon/blob/main/docs/TROUBLESHOOTING.md) — common errors and fixes
+
+---
+
+## License
+
+MIT — see [LICENSE](https://github.com/jyunming/Axon/blob/main/LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "axon-rag"
 version = "0.1.0"
 description = "General-purpose open-source RAG engine with multi-LLM, hybrid retrieval, GraphRAG, and MCP support"
-readme = "README.md"
+readme = "PYPI_README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [


### PR DESCRIPTION
## Summary

- `release.yml`: replace custom git-log changelog with `generate_notes: true` (custom script dumped all of history on first tag and misattributed authors)
- `PYPI_README.md`: dedicated PyPI description with absolute image/doc URLs (PyPI cannot resolve relative paths; images were broken on the PyPI page)
- `pyproject.toml`: set `readme = "PYPI_README.md"`
- `.github/copilot-instructions.md`: add PyPI Publishing + Packaging Rules sections

## Test plan

- [ ] No Python code changed — CI tests are sufficient
- [ ] Verify `PYPI_README.md` renders correctly at next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)