### PR TITLE
sealed-mount Phase 1: crypto + keyring primitives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,14 @@ loaders = [
 eval = [
     "deepeval>=0.21.0",
 ]
+sealed = [
+    # Phase 1 of the sealed-mount design (docs/SHARE_MOUNT_SEALED.md):
+    # cryptography ships AES-256-GCM, AES-KW (RFC 3394/5649), and HKDF-SHA256
+    # natively and is well-audited. keyring abstracts DPAPI / Keychain /
+    # Secret Service for the owner master key + grantee per-share DEK.
+    "cryptography>=42.0.0",
+    "keyring>=24.0.0",
+]
 dev = [
     "pytest>=7.4.0,<8.0.0",
     "pytest-asyncio>=0.21.0,<1.0.0",

--- a/src/axon/security/__init__.py
+++ b/src/axon/security/__init__.py
@@ -1,12 +1,51 @@
-"""Minimal security stub for sealed-store / passphrase management."""
+"""Security primitives for Axon — sealed shares + (Phase 1) crypto foundations.
+
+Top-level package keeps the **existing public stub interface** intact so
+every caller that imports from ``axon.security`` continues to work
+exactly as before. New cryptographic primitives live in
+:mod:`axon.security.crypto` and are imported lazily so users on minimal
+installs (no ``cryptography``/``keyring`` packages) keep the existing
+behaviour — the sealed-share helpers in this file still raise
+``SecurityError("not configured")``.
+
+The plan landing this work in phases is in
+``docs/SHARE_MOUNT_SEALED.md``. **Phase 1 (this commit) ships the
+crypto + keyring primitives only — no code outside this package uses
+them yet.** Behaviour for existing projects is unchanged.
+"""
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 
+__all__ = [
+    "SecurityError",
+    "store_status",
+    "bootstrap_store",
+    "unlock_store",
+    "lock_store",
+    "change_passphrase",
+    "is_unlocked",
+    "get_sealed_project_record",
+    "generate_sealed_share",
+    "redeem_sealed_share",
+    "validate_received_sealed_shares",
+    "list_sealed_shares",
+    "resolve_owned_sealed_project_path",
+    "project_rotate_keys",
+    "project_seal",
+]
+
 
 class SecurityError(Exception):
     """Raised for security operation failures."""
+
+
+# ---------------------------------------------------------------------------
+# Existing stub interface — preserved verbatim from the previous
+# axon/security.py module so every existing caller continues to work.
+# Real implementations land in later phases per docs/SHARE_MOUNT_SEALED.md.
+# ---------------------------------------------------------------------------
 
 
 def store_status(user_dir: Path) -> dict[str, Any]:

--- a/src/axon/security/crypto.py
+++ b/src/axon/security/crypto.py
@@ -10,7 +10,7 @@ Two primitive layers:
 
 2. **Envelope keys** — :func:`derive_kek` (HKDF-SHA256) derives a Key
    Encryption Key from a share token; :func:`wrap_key` /
-   :func:`unwrap_key` (AES-256-KW, RFC 5649) wrap/unwrap a Data
+   :func:`unwrap_key` (AES-256-KW, RFC 3394) wrap/unwrap a Data
    Encryption Key for transport. :func:`generate_dek` produces a fresh
    256-bit DEK from the OS CSPRNG.
 

--- a/src/axon/security/crypto.py
+++ b/src/axon/security/crypto.py
@@ -1,0 +1,321 @@
+"""Cryptographic primitives for sealed Axon projects (Phase 1 of #SEALED).
+
+Two primitive layers:
+
+1. :class:`SealedFile` — wraps any byte payload with AES-256-GCM. File
+   format: 16-byte ``AXSL`` header + 12-byte nonce + ciphertext +
+   16-byte authentication tag. Tampering (header, nonce, ciphertext, or
+   tag) raises :class:`cryptography.exceptions.InvalidTag` — never
+   silently succeeds.
+
+2. **Envelope keys** — :func:`derive_kek` (HKDF-SHA256) derives a Key
+   Encryption Key from a share token; :func:`wrap_key` /
+   :func:`unwrap_key` (AES-256-KW, RFC 5649) wrap/unwrap a Data
+   Encryption Key for transport. :func:`generate_dek` produces a fresh
+   256-bit DEK from the OS CSPRNG.
+
+This module **only** provides the primitives — no code outside the
+package consumes them yet. Wiring into project-seal / generate-sealed-
+share / redeem-sealed-share lands in Phases 2–4 per
+``docs/SHARE_MOUNT_SEALED.md``.
+
+Dependencies: ``cryptography`` (PyPI) — installed via the ``sealed``
+extra (``pip install axon-rag[sealed]``). Importing this module on a
+minimal install raises a friendly ``ImportError`` with the install
+hint.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import struct
+from pathlib import Path
+from typing import Any
+
+try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+    from cryptography.hazmat.primitives.keywrap import (
+        aes_key_unwrap,
+        aes_key_wrap,
+    )
+except ImportError as exc:  # pragma: no cover — import-time guard
+    raise ImportError(
+        "axon.security.crypto requires the 'cryptography' package. "
+        "Install with: pip install axon-rag[sealed]"
+    ) from exc
+
+__all__ = [
+    "MAGIC",
+    "SCHEMA_VERSION",
+    "CIPHER_AES_256_GCM",
+    "HEADER_LEN",
+    "NONCE_LEN",
+    "TAG_LEN",
+    "DEK_LEN",
+    "SealedFormatError",
+    "SealedFile",
+    "generate_dek",
+    "derive_kek",
+    "wrap_key",
+    "unwrap_key",
+]
+
+# ---------------------------------------------------------------------------
+# File-format constants
+# ---------------------------------------------------------------------------
+
+MAGIC: bytes = b"AXSL"
+SCHEMA_VERSION: int = 1
+CIPHER_AES_256_GCM: int = 0
+
+HEADER_LEN: int = 16  # 4 magic + 1 version + 1 cipher_id + 10 reserved/zero
+NONCE_LEN: int = 12  # AES-GCM standard nonce length
+TAG_LEN: int = 16  # AES-GCM authentication tag length
+DEK_LEN: int = 32  # 256-bit Data Encryption Key
+
+# 4-byte magic | 1-byte version | 1-byte cipher_id | 10-byte reserved (zero)
+_HEADER_STRUCT = struct.Struct(">4sBB10x")
+
+
+class SealedFormatError(Exception):
+    """Raised when a sealed file's header is malformed, has the wrong
+    magic, an unsupported schema version, or an unknown cipher ID.
+
+    Distinct from :class:`cryptography.exceptions.InvalidTag` — that
+    indicates the bytes were AES-GCM-validated against the wrong key
+    (tamper / wrong-key), whereas ``SealedFormatError`` indicates the
+    file isn't a sealed Axon file at all (or is from a future schema we
+    don't support).
+    """
+
+
+# ---------------------------------------------------------------------------
+# Header helpers
+# ---------------------------------------------------------------------------
+
+
+def _pack_header(*, version: int = SCHEMA_VERSION, cipher_id: int = CIPHER_AES_256_GCM) -> bytes:
+    return _HEADER_STRUCT.pack(MAGIC, version, cipher_id)
+
+
+def _unpack_header(header: bytes) -> tuple[int, int]:
+    """Return ``(version, cipher_id)``; raise SealedFormatError on mismatch."""
+    if len(header) != HEADER_LEN:
+        raise SealedFormatError(f"Header must be {HEADER_LEN} bytes, got {len(header)}")
+    try:
+        magic, version, cipher_id = _HEADER_STRUCT.unpack(header)
+    except struct.error as exc:
+        raise SealedFormatError(f"Could not unpack header: {exc}") from exc
+    if magic != MAGIC:
+        raise SealedFormatError(
+            f"Bad magic: expected {MAGIC!r}, got {magic!r} — not an AXSL sealed file"
+        )
+    if version != SCHEMA_VERSION:
+        # Forward-compat policy: refuse to read newer schemas rather than
+        # silently misinterpret. v1 readers don't know what v2 will do.
+        raise SealedFormatError(
+            f"Unsupported schema version {version} (this build understands {SCHEMA_VERSION})"
+        )
+    if cipher_id != CIPHER_AES_256_GCM:
+        raise SealedFormatError(
+            f"Unsupported cipher_id {cipher_id} (only AES-256-GCM = {CIPHER_AES_256_GCM})"
+        )
+    return version, cipher_id
+
+
+# ---------------------------------------------------------------------------
+# SealedFile — one-call seal / unseal
+# ---------------------------------------------------------------------------
+
+
+class SealedFile:
+    """Atomic AES-256-GCM file wrapper.
+
+    Both :meth:`write` and :meth:`read` operate on whole-file
+    plaintext: there is no streaming API in v1 (decrypt-into-memory
+    policy per the plan doc). Adding streaming is straightforward later
+    — the on-disk format already records everything needed.
+    """
+
+    @staticmethod
+    def write(
+        path: Path | str,
+        plaintext: bytes,
+        key: bytes,
+        *,
+        aad: bytes = b"",
+    ) -> None:
+        """Encrypt *plaintext* with *key* and write to *path* atomically.
+
+        Args:
+            path: Destination file path.
+            plaintext: Bytes to encrypt.
+            key: 32-byte AES-256 key.
+            aad: Additional Authenticated Data — bound into the GCM tag
+                but NOT stored in the file. Callers must supply the
+                same AAD on read or :class:`InvalidTag` will be raised.
+                Recommended: ``key_id || file_relpath`` to prevent files
+                from being swapped between projects.
+
+        The write is atomic — encrypted bytes are written to a sibling
+        ``<name>.sealing`` file then renamed via :func:`os.replace` so a
+        crash mid-write never leaves a half-sealed file at the live
+        path.
+        """
+        if len(key) != 32:
+            raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
+        path = Path(path)
+        nonce = os.urandom(NONCE_LEN)
+        # AESGCM.encrypt returns ciphertext || tag concatenated.
+        ct_and_tag = AESGCM(key).encrypt(nonce, plaintext, aad if aad else None)
+        body = _pack_header() + nonce + ct_and_tag
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".sealing")
+        tmp.write_bytes(body)
+        os.replace(tmp, path)
+
+    @staticmethod
+    def read(
+        path: Path | str,
+        key: bytes,
+        *,
+        aad: bytes = b"",
+    ) -> bytes:
+        """Decrypt and return the plaintext content of *path*.
+
+        Raises:
+            SealedFormatError: file doesn't have an AXSL header, or has
+                an unsupported version / cipher.
+            cryptography.exceptions.InvalidTag: bytes were tampered
+                with, the wrong key was supplied, or the AAD doesn't
+                match the value used at write time.
+            FileNotFoundError: file does not exist.
+        """
+        if len(key) != 32:
+            raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
+        path = Path(path)
+        body = path.read_bytes()
+        if len(body) < HEADER_LEN + NONCE_LEN + TAG_LEN:
+            raise SealedFormatError(f"File too short to be a sealed AXSL file ({len(body)} bytes)")
+        _unpack_header(body[:HEADER_LEN])
+        nonce = body[HEADER_LEN : HEADER_LEN + NONCE_LEN]
+        ct_and_tag = body[HEADER_LEN + NONCE_LEN :]
+        return AESGCM(key).decrypt(nonce, ct_and_tag, aad if aad else None)
+
+
+# ---------------------------------------------------------------------------
+# Key generation + envelope wrap/unwrap
+# ---------------------------------------------------------------------------
+
+
+def generate_dek() -> bytes:
+    """Return a fresh 256-bit Data Encryption Key from the OS CSPRNG."""
+    return secrets.token_bytes(DEK_LEN)
+
+
+def derive_kek(token: bytes, key_id: str, *, info: bytes = b"axon-share-v1") -> bytes:
+    """Derive a 256-bit Key Encryption Key from a share token via HKDF-SHA256.
+
+    Args:
+        token: The raw share token (32 random bytes from ``secrets``).
+            Same token Axon already issues today via
+            ``shares.generate_share_key``.
+        key_id: The share's ``key_id`` (e.g. ``sk_a1b2c3d4``). Used as
+            the HKDF salt so two shares with the same token (impossible
+            in practice but defensive) derive distinct KEKs.
+        info: HKDF info parameter — versions the KEK derivation. Bumping
+            this string breaks backwards compatibility, so it should
+            change only when the wrapping scheme changes (e.g. v2
+            switches to AES-XTS).
+
+    Returns:
+        32-byte KEK suitable for :func:`wrap_key`/:func:`unwrap_key`.
+    """
+    if not isinstance(token, bytes | bytearray):
+        raise TypeError("token must be bytes")
+    if not key_id:
+        raise ValueError("key_id must be a non-empty string")
+    salt = key_id.encode("utf-8")
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=DEK_LEN,
+        salt=salt,
+        info=info,
+    ).derive(bytes(token))
+
+
+def wrap_key(key: bytes, kek: bytes) -> bytes:
+    """AES-256 Key Wrap (RFC 3394) of *key* under *kek*.
+
+    Used to encrypt a 32-byte DEK with a 32-byte KEK; produces a
+    40-byte wrapped output (8-byte integrity check + 32-byte ciphertext).
+    """
+    if len(key) != 32 or len(kek) != 32:
+        raise ValueError(f"both key and kek must be 32 bytes; got key={len(key)}, kek={len(kek)}")
+    return aes_key_wrap(kek, key)
+
+
+def unwrap_key(wrapped: bytes, kek: bytes) -> bytes:
+    """Reverse of :func:`wrap_key`. Raises ``cryptography.exceptions.InvalidUnwrap``
+    if the wrap is invalid (wrong KEK, tampered bytes)."""
+    if len(kek) != 32:
+        raise ValueError(f"kek must be 32 bytes; got {len(kek)}")
+    return aes_key_unwrap(kek, wrapped)
+
+
+# ---------------------------------------------------------------------------
+# Convenience: build an AAD value
+# ---------------------------------------------------------------------------
+
+
+def make_aad(key_id: str, relpath: str) -> bytes:
+    """Recommended AAD for project files: ``key_id || NUL || relpath``.
+
+    Binding both the share key and the in-project relative path into
+    the GCM tag prevents a same-key attacker from swapping files
+    between projects (e.g. moving an encrypted ``meta.json`` from
+    project A onto project B and having it decrypt cleanly).
+    """
+    return key_id.encode("utf-8") + b"\x00" + relpath.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+
+def _self_check() -> dict[str, Any]:
+    """Round-trip a tiny payload to confirm the build is wired correctly.
+
+    Returned as a dict so callers (e.g. ``axon doctor`` in a later
+    phase) can include it in diagnostics output. Never raises — failures
+    are reported in the dict.
+    """
+    out: dict[str, Any] = {"ok": False, "details": ""}
+    try:
+        dek = generate_dek()
+        token = secrets.token_bytes(32)
+        kek = derive_kek(token, "sk_selfcheck")
+        wrapped = wrap_key(dek, kek)
+        unwrapped = unwrap_key(wrapped, kek)
+        if unwrapped != dek:
+            out["details"] = "wrap/unwrap roundtrip mismatch"
+            return out
+        # File round-trip in /tmp
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "selfcheck.bin"
+            payload = b"axon-sealed-selfcheck"
+            SealedFile.write(p, payload, dek, aad=b"selfcheck-aad")
+            recovered = SealedFile.read(p, dek, aad=b"selfcheck-aad")
+            if recovered != payload:
+                out["details"] = "SealedFile roundtrip mismatch"
+                return out
+        out["ok"] = True
+        out["details"] = "AES-256-GCM + AES-KW + HKDF-SHA256 OK"
+    except Exception as exc:  # pragma: no cover — self-check is defensive
+        out["details"] = f"self-check raised: {type(exc).__name__}: {exc}"
+    return out

--- a/src/axon/security/keyring.py
+++ b/src/axon/security/keyring.py
@@ -1,0 +1,189 @@
+"""Keyring helpers — owner master key + grantee per-share DEK storage.
+
+Phase 1 ships a thin wrapper around the cross-platform :mod:`keyring`
+package (DPAPI on Windows, Keychain on macOS, Secret Service on Linux).
+The wrapper:
+
+- Detects when no usable backend exists and raises
+  :class:`KeyringUnavailableError` with a clear hint, instead of
+  silently falling back to an unencrypted file.
+- Centralises the service-name convention so callers don't sprinkle
+  string literals across the codebase: ``axon.master.<owner>`` for the
+  owner's master key, ``axon.share.<key_id>`` for grantee-side wrapped
+  DEKs.
+
+The **passphrase fallback** for headless / no-keyring environments is
+out of scope for Phase 1 (per ``docs/SHARE_MOUNT_SEALED.md`` §6 phase
+list — keyring + passphrase fallback together are a Phase 2
+deliverable). For now, callers on a no-keyring machine will see a
+clear ``KeyringUnavailableError`` and can choose between installing a
+backend or waiting for Phase 2.
+
+Dependency: ``keyring`` (PyPI) — installed via the ``sealed`` extra
+(``pip install axon-rag[sealed]``).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    import keyring as _keyring
+    from keyring.errors import KeyringError as _BackendKeyringError
+except ImportError as exc:  # pragma: no cover — import-time guard
+    raise ImportError(
+        "axon.security.keyring requires the 'keyring' package. "
+        "Install with: pip install axon-rag[sealed]"
+    ) from exc
+
+logger = logging.getLogger("Axon")
+
+__all__ = [
+    "KeyringUnavailableError",
+    "MASTER_SERVICE_PREFIX",
+    "SHARE_SERVICE_PREFIX",
+    "master_service",
+    "share_service",
+    "is_available",
+    "store_secret",
+    "get_secret",
+    "delete_secret",
+]
+
+
+class KeyringUnavailableError(RuntimeError):
+    """Raised when the OS keyring backend is missing or unusable.
+
+    Common causes:
+      - Linux server with no D-Bus / Secret Service running (gnome-keyring).
+      - WSL distro that hasn't been configured for Linux Secret Service.
+      - A ``keyring`` install that defaulted to the no-op ``keyring.backends.fail``
+        backend.
+
+    The Phase 2 work in ``docs/SHARE_MOUNT_SEALED.md`` will add a
+    passphrase-protected file fallback for these cases. Until then,
+    install one of:
+      - Linux: ``apt install gnome-keyring`` (requires a D-Bus session)
+              or ``pip install keyrings.cryptfile`` for a file-based
+              alternative.
+      - macOS / Windows: built-in Keychain / DPAPI is always available.
+    """
+
+
+MASTER_SERVICE_PREFIX: str = "axon.master."
+SHARE_SERVICE_PREFIX: str = "axon.share."
+
+
+def master_service(owner: str) -> str:
+    """Service name under which the owner's master key is stored."""
+    if not owner:
+        raise ValueError("owner must be non-empty")
+    return f"{MASTER_SERVICE_PREFIX}{owner}"
+
+
+def share_service(key_id: str) -> str:
+    """Service name under which a grantee stores an unwrapped DEK."""
+    if not key_id:
+        raise ValueError("key_id must be non-empty")
+    return f"{SHARE_SERVICE_PREFIX}{key_id}"
+
+
+def _active_backend() -> Any:
+    """Return the active keyring backend; raise KeyringUnavailableError when unusable.
+
+    Detects the no-op ``keyring.backends.fail.Keyring`` stub by module
+    name (the class name itself is just ``Keyring`` — same as the base
+    class — so we cannot disambiguate on class name alone).
+    """
+    backend = _keyring.get_keyring()
+    module = type(backend).__module__ or ""
+    if module.endswith(".fail"):
+        raise KeyringUnavailableError(
+            f"Active keyring backend ({module}.{type(backend).__name__}) is a "
+            "no-op fail-stub. Install a real backend (gnome-keyring on Linux, "
+            "Keychain on macOS, DPAPI on Windows) or wait for Phase 2 "
+            "passphrase fallback."
+        )
+    return backend
+
+
+def is_available() -> bool:
+    """Return True if the OS keyring is usable.
+
+    Performs a lightweight write/read/delete round-trip on a sentinel
+    service name. Catches any exception and returns False rather than
+    propagating, so callers can branch on availability without a
+    try/except.
+    """
+    sentinel_service = "axon.__availability_check__"
+    sentinel_user = "probe"
+    try:
+        backend = _active_backend()
+        backend.set_password(sentinel_service, sentinel_user, "ok")
+        recovered = backend.get_password(sentinel_service, sentinel_user)
+        backend.delete_password(sentinel_service, sentinel_user)
+        return recovered == "ok"
+    except Exception as exc:
+        logger.debug("keyring is_available() check failed: %s", exc)
+        return False
+
+
+def store_secret(service: str, username: str, secret: str) -> None:
+    """Store *secret* under (*service*, *username*).
+
+    Raises:
+        KeyringUnavailableError: backend unavailable.
+        RuntimeError: backend present but operation failed (rare —
+            usually permissions or quota).
+    """
+    backend = _active_backend()
+    try:
+        backend.set_password(service, username, secret)
+    except _BackendKeyringError as exc:
+        raise RuntimeError(f"keyring set_password failed: {exc}") from exc
+
+
+def get_secret(service: str, username: str) -> str | None:
+    """Return the secret stored at (*service*, *username*) or ``None``.
+
+    Returns ``None`` for "not found"; raises only on backend
+    unavailability or unexpected backend errors.
+    """
+    backend = _active_backend()
+    try:
+        return backend.get_password(service, username)
+    except _BackendKeyringError as exc:
+        raise RuntimeError(f"keyring get_password failed: {exc}") from exc
+
+
+def delete_secret(service: str, username: str) -> None:
+    """Delete the secret at (*service*, *username*).
+
+    Silently no-ops on "not found" (the desired user-facing behaviour
+    for a delete) so callers can call ``delete_secret`` defensively.
+    """
+    from keyring.errors import PasswordDeleteError
+
+    backend = _active_backend()
+    try:
+        backend.delete_password(service, username)
+    except PasswordDeleteError:
+        # Canonical "secret not found" signal — desired post-condition
+        # ("secret is absent") is already satisfied.
+        pass
+    except _BackendKeyringError as exc:
+        raise RuntimeError(f"keyring delete_password failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+
+def _self_check() -> dict[str, Any]:
+    """Return a diagnostic dict — used by future ``axon doctor`` output."""
+    backend_name = type(_keyring.get_keyring()).__name__
+    return {
+        "available": is_available(),
+        "backend": backend_name,
+    }

--- a/src/axon/security/keyring.py
+++ b/src/axon/security/keyring.py
@@ -117,15 +117,25 @@ def is_available() -> bool:
     """
     sentinel_service = "axon.__availability_check__"
     sentinel_user = "probe"
+    wrote_sentinel = False
     try:
         backend = _active_backend()
         backend.set_password(sentinel_service, sentinel_user, "ok")
+        wrote_sentinel = True
         recovered = backend.get_password(sentinel_service, sentinel_user)
-        backend.delete_password(sentinel_service, sentinel_user)
-        return recovered == "ok"
+        return bool(recovered == "ok")
     except Exception as exc:
         logger.debug("keyring is_available() check failed: %s", exc)
         return False
+    finally:
+        # Best-effort cleanup of the sentinel even when the get/return
+        # path above raised — otherwise a failed probe would leak the
+        # sentinel into the user's keyring.
+        if wrote_sentinel:
+            try:
+                backend.delete_password(sentinel_service, sentinel_user)
+            except Exception as cleanup_exc:
+                logger.debug("keyring is_available() sentinel cleanup failed: %s", cleanup_exc)
 
 
 def store_secret(service: str, username: str, secret: str) -> None:
@@ -151,9 +161,13 @@ def get_secret(service: str, username: str) -> str | None:
     """
     backend = _active_backend()
     try:
-        return backend.get_password(service, username)
+        secret = backend.get_password(service, username)
     except _BackendKeyringError as exc:
         raise RuntimeError(f"keyring get_password failed: {exc}") from exc
+    # Backends return Any; narrow to str | None for mypy and runtime sanity.
+    if secret is None:
+        return None
+    return str(secret)
 
 
 def delete_secret(service: str, username: str) -> None:

--- a/tests/test_sealed_crypto.py
+++ b/tests/test_sealed_crypto.py
@@ -1,0 +1,371 @@
+"""Phase 1 of the sealed-mount design: crypto primitive tests.
+
+Covers ``axon.security.crypto`` end-to-end:
+- :class:`SealedFile` round-trip, atomic write, header parsing,
+  tamper / wrong-key / wrong-AAD detection
+- DEK generation
+- HKDF-SHA256 KEK derivation determinism + per-key_id divergence
+- AES-KW (RFC 3394) wrap/unwrap, wrong-KEK rejection
+- Built-in self-check
+
+Skips the entire module when the optional ``cryptography`` package
+isn't installed (the ``sealed`` extra hasn't been pulled in).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Skip the whole module if the sealed extra isn't installed — keeps the
+# core test suite green on minimal installs.
+pytest.importorskip("cryptography")
+
+from axon.security.crypto import (  # noqa: E402
+    CIPHER_AES_256_GCM,
+    DEK_LEN,
+    HEADER_LEN,
+    MAGIC,
+    NONCE_LEN,
+    SCHEMA_VERSION,
+    TAG_LEN,
+    SealedFile,
+    SealedFormatError,
+    _self_check,
+    derive_kek,
+    generate_dek,
+    make_aad,
+    unwrap_key,
+    wrap_key,
+)
+
+# ---------------------------------------------------------------------------
+# generate_dek
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDek:
+    def test_returns_32_bytes(self):
+        dek = generate_dek()
+        assert isinstance(dek, bytes)
+        assert len(dek) == DEK_LEN == 32
+
+    def test_distinct_calls_produce_distinct_keys(self):
+        # 1000 fresh DEKs — collision probability is ~2^-256 * 1000,
+        # i.e. astronomically zero. Catches a stuck PRNG.
+        keys = {generate_dek() for _ in range(1000)}
+        assert len(keys) == 1000
+
+
+# ---------------------------------------------------------------------------
+# derive_kek
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveKek:
+    def test_deterministic_for_same_inputs(self):
+        token = b"\x01" * 32
+        a = derive_kek(token, "sk_abc")
+        b = derive_kek(token, "sk_abc")
+        assert a == b
+        assert len(a) == 32
+
+    def test_different_key_id_yields_different_kek(self):
+        token = b"\x01" * 32
+        assert derive_kek(token, "sk_aaa") != derive_kek(token, "sk_bbb")
+
+    def test_different_token_yields_different_kek(self):
+        assert derive_kek(b"\x01" * 32, "sk_abc") != derive_kek(b"\x02" * 32, "sk_abc")
+
+    def test_different_info_yields_different_kek(self):
+        token = b"\x01" * 32
+        v1 = derive_kek(token, "sk_abc", info=b"axon-share-v1")
+        v2 = derive_kek(token, "sk_abc", info=b"axon-share-v2")
+        assert v1 != v2
+
+    def test_token_must_be_bytes(self):
+        with pytest.raises(TypeError):
+            derive_kek("not-bytes", "sk_abc")  # type: ignore[arg-type]
+
+    def test_key_id_must_be_non_empty(self):
+        with pytest.raises(ValueError):
+            derive_kek(b"\x01" * 32, "")
+
+
+# ---------------------------------------------------------------------------
+# wrap_key / unwrap_key
+# ---------------------------------------------------------------------------
+
+
+class TestKeyWrap:
+    def test_round_trip(self):
+        dek = generate_dek()
+        kek = generate_dek()
+        wrapped = wrap_key(dek, kek)
+        # AES-KW wraps a 32-byte payload into 32 + 8 = 40 bytes.
+        assert len(wrapped) == 40
+        assert unwrap_key(wrapped, kek) == dek
+
+    def test_wrong_kek_raises(self):
+        from cryptography.hazmat.primitives.keywrap import InvalidUnwrap
+
+        dek = generate_dek()
+        kek = generate_dek()
+        wrong_kek = generate_dek()
+        wrapped = wrap_key(dek, kek)
+        with pytest.raises(InvalidUnwrap):
+            unwrap_key(wrapped, wrong_kek)
+
+    def test_tampered_wrap_raises(self):
+        from cryptography.hazmat.primitives.keywrap import InvalidUnwrap
+
+        dek = generate_dek()
+        kek = generate_dek()
+        wrapped = bytearray(wrap_key(dek, kek))
+        wrapped[0] ^= 0xFF  # flip a bit in the integrity check block
+        with pytest.raises(InvalidUnwrap):
+            unwrap_key(bytes(wrapped), kek)
+
+    def test_wrong_size_key_rejected(self):
+        with pytest.raises(ValueError):
+            wrap_key(b"short", generate_dek())
+        with pytest.raises(ValueError):
+            wrap_key(generate_dek(), b"short")
+
+
+# ---------------------------------------------------------------------------
+# SealedFile — write / read happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestSealedFileRoundTrip:
+    def test_basic_round_trip(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        payload = b"hello sealed axon"
+        SealedFile.write(path, payload, key)
+        assert SealedFile.read(path, key) == payload
+
+    def test_round_trip_with_aad(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        payload = b"with aad"
+        aad = make_aad("sk_abc", "vector_store_data/manifest.json")
+        SealedFile.write(path, payload, key, aad=aad)
+        assert SealedFile.read(path, key, aad=aad) == payload
+
+    def test_round_trip_empty_plaintext(self, tmp_path):
+        # 0-byte plaintext is legal — file still has header + nonce + tag.
+        key = generate_dek()
+        path = tmp_path / "empty.bin"
+        SealedFile.write(path, b"", key)
+        assert SealedFile.read(path, key) == b""
+        # Sanity: file is exactly header + nonce + tag bytes long.
+        assert path.stat().st_size == HEADER_LEN + NONCE_LEN + TAG_LEN
+
+    def test_round_trip_large_payload(self, tmp_path):
+        # 1 MiB payload — exercises the AESGCM encrypt path on a
+        # non-trivial buffer without taking real time.
+        key = generate_dek()
+        path = tmp_path / "big.bin"
+        payload = os.urandom(1024 * 1024)
+        SealedFile.write(path, payload, key)
+        assert SealedFile.read(path, key) == payload
+
+    def test_creates_parent_dirs(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "nested" / "deep" / "secret.bin"
+        SealedFile.write(path, b"x", key)
+        assert path.is_file()
+
+
+# ---------------------------------------------------------------------------
+# SealedFile — atomic write
+# ---------------------------------------------------------------------------
+
+
+class TestSealedFileAtomicWrite:
+    def test_no_sealing_tempfile_left_after_success(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"x", key)
+        siblings = sorted(p.name for p in tmp_path.iterdir())
+        # The .sealing temp file must be replaced/removed by os.replace.
+        assert "secret.bin.sealing" not in siblings
+        assert "secret.bin" in siblings
+
+    def test_overwrites_existing_file(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"first", key)
+        SealedFile.write(path, b"second", key)
+        assert SealedFile.read(path, key) == b"second"
+
+
+# ---------------------------------------------------------------------------
+# SealedFile — header parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSealedFileHeader:
+    def test_header_magic_present_in_written_file(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"x", key)
+        body = path.read_bytes()
+        assert body[:4] == MAGIC
+        assert body[4] == SCHEMA_VERSION
+        assert body[5] == CIPHER_AES_256_GCM
+
+    def test_bad_magic_raises_format_error(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "bad.bin"
+        # Write a file with the wrong magic but otherwise plausible shape.
+        body = (
+            b"NOPE" + b"\x01" + b"\x00" + (b"\x00" * 10) + b"\x00" * NONCE_LEN + b"\x00" * TAG_LEN
+        )
+        path.write_bytes(body)
+        with pytest.raises(SealedFormatError, match="magic"):
+            SealedFile.read(path, key)
+
+    def test_unsupported_schema_version_raises_format_error(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "future.bin"
+        body = MAGIC + b"\x99" + b"\x00" + (b"\x00" * 10) + b"\x00" * NONCE_LEN + b"\x00" * TAG_LEN
+        path.write_bytes(body)
+        with pytest.raises(SealedFormatError, match="version"):
+            SealedFile.read(path, key)
+
+    def test_unknown_cipher_id_raises_format_error(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "wrong-cipher.bin"
+        body = (
+            MAGIC
+            + bytes([SCHEMA_VERSION])
+            + b"\x99"
+            + (b"\x00" * 10)
+            + b"\x00" * NONCE_LEN
+            + b"\x00" * TAG_LEN
+        )
+        path.write_bytes(body)
+        with pytest.raises(SealedFormatError, match="cipher_id"):
+            SealedFile.read(path, key)
+
+    def test_short_file_raises_format_error(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "tiny.bin"
+        path.write_bytes(b"AXSL")  # missing everything else
+        with pytest.raises(SealedFormatError, match="too short"):
+            SealedFile.read(path, key)
+
+
+# ---------------------------------------------------------------------------
+# SealedFile — tamper / wrong key / wrong AAD detection
+# ---------------------------------------------------------------------------
+
+
+class TestSealedFileIntegrity:
+    def test_wrong_key_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        wrong_key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"hello", key)
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, wrong_key)
+
+    def test_tampered_ciphertext_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"hello world this is the secret payload", key)
+        body = bytearray(path.read_bytes())
+        # Flip a bit in the ciphertext region (right after the nonce).
+        body[HEADER_LEN + NONCE_LEN + 1] ^= 0xFF
+        path.write_bytes(bytes(body))
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key)
+
+    def test_tampered_tag_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"hello", key)
+        body = bytearray(path.read_bytes())
+        body[-1] ^= 0xFF  # flip a bit in the GCM tag
+        path.write_bytes(bytes(body))
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key)
+
+    def test_wrong_aad_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"x", key, aad=b"correct-aad")
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key, aad=b"wrong-aad")
+
+    def test_aad_omitted_on_read_when_written_with_aad_raises(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "secret.bin"
+        SealedFile.write(path, b"x", key, aad=b"present")
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key)  # no AAD → mismatch
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_write_rejects_wrong_size_key(self, tmp_path):
+        with pytest.raises(ValueError, match="32 bytes"):
+            SealedFile.write(tmp_path / "x", b"data", b"short")
+
+    def test_read_rejects_wrong_size_key(self, tmp_path):
+        path = tmp_path / "x"
+        SealedFile.write(path, b"data", generate_dek())
+        with pytest.raises(ValueError, match="32 bytes"):
+            SealedFile.read(path, b"short")
+
+
+# ---------------------------------------------------------------------------
+# AAD helper
+# ---------------------------------------------------------------------------
+
+
+class TestMakeAad:
+    def test_combines_key_id_and_relpath(self):
+        aad = make_aad("sk_a", "meta.json")
+        assert b"sk_a" in aad
+        assert b"meta.json" in aad
+        # NUL separator means key_id "sk" + relpath "meta.json" doesn't
+        # collide with key_id "s" + relpath "kmeta.json".
+        assert b"\x00" in aad
+
+    def test_distinct_inputs_produce_distinct_aads(self):
+        a = make_aad("sk_a", "meta.json")
+        b = make_aad("sk_a", "vector_store_data/manifest.json")
+        c = make_aad("sk_b", "meta.json")
+        assert a != b
+        assert a != c
+        assert b != c
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+
+class TestSelfCheck:
+    def test_self_check_ok_on_healthy_install(self):
+        result = _self_check()
+        assert result["ok"] is True
+        assert "OK" in result["details"]

--- a/tests/test_sealed_keyring.py
+++ b/tests/test_sealed_keyring.py
@@ -1,0 +1,155 @@
+"""Phase 1 of the sealed-mount design: keyring helper tests.
+
+Covers ``axon.security.keyring``:
+- service-name conventions
+- store / get / delete round-trip with a mocked backend
+- KeyringUnavailableError when the active backend is the no-op fail
+  stub
+- delete_secret silently no-ops on "not found"
+
+Skips the entire module when the optional ``keyring`` package isn't
+installed (the ``sealed`` extra hasn't been pulled in).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("keyring")
+
+from axon.security.keyring import (  # noqa: E402
+    MASTER_SERVICE_PREFIX,
+    SHARE_SERVICE_PREFIX,
+    KeyringUnavailableError,
+    delete_secret,
+    get_secret,
+    is_available,
+    master_service,
+    share_service,
+    store_secret,
+)
+
+# ---------------------------------------------------------------------------
+# Fake in-memory backend used to exercise store/get/delete without
+# touching the real OS keyring (which would mutate the test machine).
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryKeyring:
+    """Minimal keyring backend for tests — exposes the same API surface
+    that ``axon.security.keyring`` uses (``set_password`` /
+    ``get_password`` / ``delete_password``)."""
+
+    priority = 1  # required by the keyring backend protocol
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service: str, username: str, secret: str) -> None:
+        self._store[(service, username)] = secret
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def delete_password(self, service: str, username: str) -> None:
+        import keyring.errors
+
+        if (service, username) not in self._store:
+            raise keyring.errors.PasswordDeleteError("not found")
+        del self._store[(service, username)]
+
+
+# ---------------------------------------------------------------------------
+# Service-name conventions
+# ---------------------------------------------------------------------------
+
+
+class TestServiceNames:
+    def test_master_service_uses_prefix(self):
+        s = master_service("alice")
+        assert s.startswith(MASTER_SERVICE_PREFIX)
+        assert s == "axon.master.alice"
+
+    def test_share_service_uses_prefix(self):
+        s = share_service("sk_a1b2c3d4")
+        assert s.startswith(SHARE_SERVICE_PREFIX)
+        assert s == "axon.share.sk_a1b2c3d4"
+
+    def test_master_service_rejects_empty_owner(self):
+        with pytest.raises(ValueError):
+            master_service("")
+
+    def test_share_service_rejects_empty_key_id(self):
+        with pytest.raises(ValueError):
+            share_service("")
+
+
+# ---------------------------------------------------------------------------
+# Store / get / delete round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    """All wrappers route through _active_backend() → backend.{set,get,delete}_password,
+    so patching get_keyring alone is enough to substitute the in-memory backend."""
+
+    def test_store_then_get_returns_secret(self):
+        backend = _InMemoryKeyring()
+        with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+            store_secret("axon.master.alice", "default", "s3cret")
+            assert get_secret("axon.master.alice", "default") == "s3cret"
+
+    def test_get_returns_none_for_missing(self):
+        backend = _InMemoryKeyring()
+        with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+            assert get_secret("axon.master.alice", "default") is None
+
+    def test_delete_then_get_returns_none(self):
+        backend = _InMemoryKeyring()
+        with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+            store_secret("svc", "u", "v")
+            delete_secret("svc", "u")
+            assert get_secret("svc", "u") is None
+
+    def test_delete_missing_key_is_silent(self):
+        """delete_secret on a key that doesn't exist must NOT raise —
+        the desired post-condition is "secret is absent", which is
+        already satisfied. Callers should be able to call delete
+        defensively."""
+        backend = _InMemoryKeyring()
+        with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+            # Should NOT raise.
+            delete_secret("svc", "absent")
+
+
+# ---------------------------------------------------------------------------
+# Backend availability detection
+# ---------------------------------------------------------------------------
+
+
+class TestBackendDetection:
+    def test_no_op_fail_backend_raises_unavailable(self):
+        """When the active backend is the keyring 'fail' stub (i.e. the
+        user has no real backend installed), every operation must raise
+        KeyringUnavailableError instead of a confusing low-level error."""
+        from keyring.backends.fail import Keyring as FailKeyring
+
+        with patch("axon.security.keyring._keyring.get_keyring", return_value=FailKeyring()):
+            with pytest.raises(KeyringUnavailableError):
+                store_secret("svc", "u", "x")
+            with pytest.raises(KeyringUnavailableError):
+                get_secret("svc", "u")
+            with pytest.raises(KeyringUnavailableError):
+                delete_secret("svc", "u")
+
+    def test_is_available_true_when_round_trip_works(self):
+        backend = _InMemoryKeyring()
+        with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+            assert is_available() is True
+
+    def test_is_available_false_when_backend_unavailable(self):
+        from keyring.backends.fail import Keyring as FailKeyring
+
+        with patch("axon.security.keyring._keyring.get_keyring", return_value=FailKeyring()):
+            assert is_available() is False


### PR DESCRIPTION
## Summary

First slice of the encrypted-at-rest sealed-mount design (`docs/SHARE_MOUNT_SEALED.md`, landed in PR for `fix/share-mount-sqlite-wal-safety`). Adds the cryptographic primitives all later phases will build on. **Zero behavior change for existing projects** — every existing `from axon import security` import keeps working, every existing test passes, no code outside the new `axon.security` package consumes the primitives yet.

## Why this lands alone

Phase 1 is the only slice of the plan whose §5 design decisions don't matter (mmap policy, backend scope, revocation cost UX, migration approach all bite at Phase 2+). Shipping the crypto + keyring primitives first lets later phases build on a reviewed foundation.

## What's in it

| Surface | What |
|---|---|
| `src/axon/security/` (new package) | Converted from `security.py`. The 12 existing stub functions (bootstrap_store, generate_sealed_share, project_seal, etc.) move verbatim into `__init__.py` so existing callers in `api_routes/shares.py` and `api_routes/projects.py` keep working unchanged. |
| `src/axon/security/crypto.py` | `SealedFile.{write,read}` (AES-256-GCM, AXSL header, atomic write), `generate_dek`, `derive_kek` (HKDF-SHA256), `wrap_key`/`unwrap_key` (AES-256-KW RFC 3394), `make_aad`, `SealedFormatError` |
| `src/axon/security/keyring.py` | `master_service`/`share_service` naming, `store_secret`/`get_secret`/`delete_secret`, `is_available()`, `KeyringUnavailableError` (loud signal when no real backend installed) |
| `pyproject.toml` | New `[sealed]` extra: `cryptography>=42`, `keyring>=24`. Phase 1 modules raise friendly ImportError with install hint on minimal installs. |
| `tests/test_sealed_crypto.py` | 34 tests — gated on `pytest.importorskip("cryptography")` |
| `tests/test_sealed_keyring.py` | 11 tests — gated on `pytest.importorskip("keyring")` |

## Test plan

- [x] Full pytest passes (Phase 1 tests + 218 regression on adjacent modules)
- [x] Pre-commit (black, ruff, py_compile, pytest, eval-smoke) green
- [x] `from axon import security` import surface preserved for all existing callers
- [x] `_self_check()` round-trip in both modules

## Decisions baked in

Per `docs/SHARE_MOUNT_SEALED.md` §5 recommendations:

- **§5.2 Crypto library** = `cryptography` PyPI package (audited, has AES-GCM + AES-KW + HKDF native; Rust route only if benchmarking shows it's needed)
- **§5.3 Grantee key storage** = OS keyring (DPAPI / Keychain / Secret Service); passphrase fallback for headless environments deferred to Phase 2

## Open questions for Phase 2+ (NOT this PR)

- §5.1 mmap policy (decrypt-into-RAM vs ephemeral cache)
- §5.4 backend scope v1 (TQDB only vs all)
- §5.5 revocation cost UX (soft + hard)
- §5.6 migration approach (in-place seal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)