### PR TITLE
feat(sealed): Phase 2 — sealed-store backend integration (#57)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,10 @@ dev = [
     "mypy>=1.5.0,<2.0.0",
     "pre-commit>=3.4.0,<4.0.0",
     "chromadb>=0.4.0",
+    # Sealed-store deps so CI exercises the real master/seal/cache paths
+    # rather than the ImportError-fallback stubs (Phase 2 of #SEALED).
+    "cryptography>=42.0.0",
+    "keyring>=24.0.0",
 ]
 all = [
     "streamlit>=1.30.0",

--- a/src/axon/api_routes/security_routes.py
+++ b/src/axon/api_routes/security_routes.py
@@ -79,7 +79,12 @@ async def security_unlock(request: SecurityUnlockRequest, req: Request):
     except _security.SecurityError as exc:
         message = str(exc)
         _unlock_failures[client_ip].append(time.time())
-        status = 401 if "unlock failed" in message.lower() else 400
+        # 401 for credential failures (wrong passphrase, legacy stub
+        # message). 400 for everything else (store not bootstrapped,
+        # malformed keyring record, etc.).
+        msg_lower = message.lower()
+        is_auth_failure = "wrong passphrase" in msg_lower or "unlock failed" in msg_lower
+        status = 401 if is_auth_failure else 400
         raise HTTPException(status_code=status, detail=message)
 
 

--- a/src/axon/cli.py
+++ b/src/axon/cli.py
@@ -588,6 +588,50 @@ def main():
         help="Initialise AxonStore multi-user mode at PATH (e.g. ~/axon_data), then exit",
     )
 
+    # ── Sealed-store (Phase 2 of #SEALED) ────────────────────────────────────
+
+    parser.add_argument(
+        "--store-status",
+        action="store_true",
+        help="Show sealed-store init/unlock state, then exit",
+    )
+
+    parser.add_argument(
+        "--store-bootstrap",
+        metavar="PASSPHRASE",
+        help="One-time sealed-store init with PASSPHRASE, then exit. "
+        "Generates the master key, wraps it, persists to OS keyring. "
+        "Lose this passphrase = lose every sealed project. No recovery.",
+    )
+
+    parser.add_argument(
+        "--store-unlock",
+        metavar="PASSPHRASE",
+        help="Unlock the sealed-store for sealed-project queries, then exit. "
+        "Required after every process restart before --project-seal works.",
+    )
+
+    parser.add_argument(
+        "--store-lock",
+        action="store_true",
+        help="Clear the in-process master cache, then exit",
+    )
+
+    parser.add_argument(
+        "--store-change-passphrase",
+        nargs=2,
+        metavar=("OLD", "NEW"),
+        help="Rotate the sealed-store passphrase, then exit. "
+        "Project DEKs are not touched (O(1) regardless of project count).",
+    )
+
+    parser.add_argument(
+        "--project-seal",
+        metavar="NAME",
+        help="Encrypt every content file in project NAME at rest, then exit. "
+        "Requires the sealed-store to be unlocked (--store-unlock first).",
+    )
+
     # ── Config validator / wizard ────────────────────────────────────────────
 
     parser.add_argument(
@@ -1030,6 +1074,12 @@ def main():
         and not getattr(args, "delete_doc", None)
         and not getattr(args, "delete_doc_id", None)
         and not getattr(args, "store_init", None)
+        and not getattr(args, "store_status", False)
+        and not getattr(args, "store_bootstrap", None)
+        and not getattr(args, "store_unlock", None)
+        and not getattr(args, "store_lock", False)
+        and not getattr(args, "store_change_passphrase", None)
+        and not getattr(args, "project_seal", None)
         and not getattr(args, "share_list", False)
         and not getattr(args, "share_generate", None)
         and not getattr(args, "share_redeem", None)
@@ -1271,6 +1321,77 @@ def main():
 
                 sys.exit(1)
 
+            return
+
+        if args.store_status:
+            from axon import security as _security
+
+            try:
+                st = _security.store_status(Path(config.projects_root))
+            except Exception as exc:
+                print(f"  Sealed-store status unavailable: {exc}")
+                sys.exit(1)
+            print(f"  Initialized:  {st.get('initialized', False)}")
+            print(f"  Unlocked:     {st.get('unlocked', False)}")
+            print(f"  Cipher suite: {st.get('cipher_suite', '') or '(none)'}")
+            return
+
+        if args.store_bootstrap:
+            from axon import security as _security
+
+            try:
+                _security.bootstrap_store(Path(config.projects_root), args.store_bootstrap)
+                print("  Sealed-store bootstrapped and unlocked.")
+            except _security.SecurityError as exc:
+                print(f"  Bootstrap failed: {exc}")
+                sys.exit(1)
+            return
+
+        if args.store_unlock:
+            from axon import security as _security
+
+            try:
+                _security.unlock_store(Path(config.projects_root), args.store_unlock)
+                print("  Sealed-store unlocked.")
+            except _security.SecurityError as exc:
+                print(f"  Unlock failed: {exc}")
+                sys.exit(1)
+            return
+
+        if args.store_lock:
+            from axon import security as _security
+
+            try:
+                _security.lock_store(Path(config.projects_root))
+                print("  Sealed-store locked.")
+            except _security.SecurityError as exc:
+                print(f"  Lock failed: {exc}")
+                sys.exit(1)
+            return
+
+        if args.store_change_passphrase:
+            from axon import security as _security
+
+            old_pp, new_pp = args.store_change_passphrase
+            try:
+                _security.change_passphrase(Path(config.projects_root), old_pp, new_pp)
+                print("  Sealed-store passphrase rotated.")
+            except _security.SecurityError as exc:
+                print(f"  Passphrase rotation failed: {exc}")
+                sys.exit(1)
+            return
+
+        if args.project_seal:
+            from axon import security as _security
+
+            try:
+                result = _security.project_seal(args.project_seal, Path(config.projects_root))
+                status = result.get("status", "sealed")
+                files = result.get("files_sealed", 0)
+                print(f"  Project '{args.project_seal}': {status} ({files} files)")
+            except _security.SecurityError as exc:
+                print(f"  Seal failed: {exc}")
+                sys.exit(1)
             return
 
         # Lightweight 'list' command: avoid full AxonBrain init by reading doc_versions metadata

--- a/src/axon/cli.py
+++ b/src/axon/cli.py
@@ -1384,11 +1384,15 @@ def main():
         if args.project_seal:
             from axon import security as _security
 
+            # Lowercase to match the validation rule used by --project /
+            # --project-new / --project-delete; project names are
+            # required to be lowercase per axon.projects._parse_name.
+            project_name = args.project_seal.lower()
             try:
-                result = _security.project_seal(args.project_seal, Path(config.projects_root))
+                result = _security.project_seal(project_name, Path(config.projects_root))
                 status = result.get("status", "sealed")
                 files = result.get("files_sealed", 0)
-                print(f"  Project '{args.project_seal}': {status} ({files} files)")
+                print(f"  Project '{project_name}': {status} ({files} files)")
             except _security.SecurityError as exc:
                 print(f"  Seal failed: {exc}")
                 sys.exit(1)

--- a/src/axon/main.py
+++ b/src/axon/main.py
@@ -763,6 +763,31 @@ Your primary goal is to help the user by answering questions based on the provid
 
         self._executor = ThreadPoolExecutor(max_workers=self.config.max_workers)
 
+        # Sealed-project cache slot. Held across switch_project calls so
+        # close() can wipe it on shutdown. None whenever the active
+        # project is plaintext (the common case).
+        self._sealed_cache: Any = None
+        # Two-phase materialisation handoff between the path-setup arm
+        # of switch_project and the post-close block.
+        self._pending_seal_mount: tuple[str, Path] | None = None
+
+        # Wipe stale sealed caches from previous crashed sessions. Cheap
+        # (just lists temp dir) and only fires when the optional
+        # [sealed] extra is installed.
+        try:
+            from axon.security.cache import cleanup_orphans as _cleanup_sealed_orphans
+
+            wiped = _cleanup_sealed_orphans()
+            if wiped:
+                logger.info(
+                    "Wiped %d orphaned sealed-cache directories from a previous session",
+                    wiped,
+                )
+        except ImportError:
+            pass  # [sealed] extra not installed — nothing to clean up
+        except Exception as _orphan_exc:
+            logger.debug("Sealed-cache orphan cleanup raised: %s", _orphan_exc)
+
         self._log_startup_summary()
 
     def __enter__(self):
@@ -801,6 +826,22 @@ Your primary goal is to help the user by answering questions based on the provid
                 store.close()
 
                 seen_stores.add(id(store))
+
+        # Force GC so Windows file handles into the sealed cache are
+        # released BEFORE we try to overwrite + unlink the cache files.
+        # Without this, wipe() may fail on Windows with PermissionError.
+        sealed_cache = getattr(self, "_sealed_cache", None)
+        if sealed_cache is not None:
+            import gc as _gc
+
+            _gc.collect()
+            try:
+                from axon.security.mount import release_cache as _release_sealed
+
+                _release_sealed(sealed_cache)
+            except Exception as _wipe_exc:
+                logger.debug("Sealed-cache wipe on close raised: %s", _wipe_exc)
+            self._sealed_cache = None
 
     def _log_startup_summary(self) -> None:
         """Log a one-line startup summary: active project, namespace ID, scope type."""
@@ -1175,6 +1216,62 @@ Your primary goal is to help the user by answering questions based on the provid
             self._is_mounted_share(),
         )
 
+    # ------------------------------------------------------------------
+    # Sealed-project routing (lazy — only fires when [sealed] installed)
+    # ------------------------------------------------------------------
+
+    def _project_is_sealed(self, project_root: Path) -> bool:
+        """Return True if *project_root* has a ``.security/.sealed`` marker.
+
+        Cheap probe — does not require an unlocked store. Returns False
+        when the optional ``[sealed]`` extra is not installed (in which
+        case sealed projects can never have been created on this
+        install anyway).
+        """
+        try:
+            from axon.security.seal import is_project_sealed
+        except ImportError:
+            return False
+        try:
+            return is_project_sealed(project_root)
+        except Exception as exc:
+            logger.debug("is_project_sealed raised on %s: %s", project_root, exc)
+            return False
+
+    def _mount_sealed_project(self, name: str, project_root: Path) -> Path:
+        """Decrypt *project_root* into an ephemeral cache; return its path.
+
+        Wipes any pre-existing sealed cache before creating the new one,
+        so back-to-back ``switch_project`` calls don't leak plaintext.
+        Stashes the new cache on ``self._sealed_cache`` so ``close()``
+        can wipe it on shutdown.
+
+        Raises:
+            SecurityError: store is locked, or sealed marker missing /
+                malformed, or cache materialisation failed (capacity,
+                I/O, or decryption error).
+        """
+        from axon.security.mount import materialize_for_read, release_cache
+
+        # Wipe stale cache from a previously-active sealed project.
+        prior = getattr(self, "_sealed_cache", None)
+        if prior is not None:
+            try:
+                release_cache(prior)
+            except Exception as exc:
+                logger.debug("Wiping prior sealed cache raised: %s", exc)
+            self._sealed_cache = None
+
+        user_dir = Path(self.config.projects_root)
+        cache = materialize_for_read(project_root, user_dir)
+        self._sealed_cache = cache
+        logger.info(
+            "Sealed project '%s' mounted at %s",
+            name,
+            cache.path,
+        )
+        return Path(cache.path)
+
     def switch_project(self, name: str) -> None:
         """Switch the active project, reinitializing vector store and BM25.
 
@@ -1203,6 +1300,10 @@ Your primary goal is to help the user by answering questions based on the provid
         """
 
         _prev_project = self._active_project  # stash for epoch bump below
+
+        # Clear any stale sealed-mount intent from a previous switch
+        # that didn't reach the post-close materialisation block.
+        self._pending_seal_mount = None
 
         if getattr(self, "_graph_rag_cache_dirty", False):
             self._save_graph_rag_extraction_cache()
@@ -1285,14 +1386,31 @@ Your primary goal is to help the user by answering questions based on the provid
 
             root = project_dir(name)
 
-            if not root.exists() or not (root / "meta.json").exists():
+            # A sealed project has every content file as AES-GCM
+            # ciphertext, so meta.json on disk is unreadable plaintext.
+            # Skip the meta.json existence check for sealed projects —
+            # the sealed marker (.security/.sealed) is the proof the
+            # project exists.
+            sealed = self._project_is_sealed(root)
+            if not root.exists() or (not sealed and not (root / "meta.json").exists()):
                 raise ValueError(
                     f"Project '{name}' does not exist. Create it first with /project new {name}"
                 )
 
-            self.config.vector_store_path = project_vector_path(name)
-
-            self.config.bm25_path = project_bm25_path(name)
+            if sealed:
+                # Defer cache materialisation until AFTER self.close()
+                # below — close() wipes self._sealed_cache, so creating
+                # the cache before close() would wipe it before any
+                # backend can read it. Stash the project root on the
+                # instance so the post-close block can pick it up.
+                self._pending_seal_mount: tuple[str, Path] | None = (name, root)
+                # Sentinel paths — overwritten right after close().
+                self.config.vector_store_path = str(root / "vector_store_data")
+                self.config.bm25_path = str(root / "bm25_index")
+            else:
+                self._pending_seal_mount = None
+                self.config.vector_store_path = project_vector_path(name)
+                self.config.bm25_path = project_bm25_path(name)
 
         # Close existing stores before replacing them; force GC to release Windows
 
@@ -1311,6 +1429,18 @@ Your primary goal is to help the user by answering questions based on the provid
         import gc as _gc
 
         _gc.collect()
+
+        # Sealed-project routing — close() wiped any prior _sealed_cache,
+        # so it's safe to materialise the new one now. The sentinel
+        # paths set in the local-project arm above are overwritten with
+        # the cache directory.
+        pending = getattr(self, "_pending_seal_mount", None)
+        if pending is not None:
+            seal_name, seal_root = pending
+            self._pending_seal_mount = None
+            cache_path = self._mount_sealed_project(seal_name, seal_root)
+            self.config.vector_store_path = str(cache_path / "vector_store_data")
+            self.config.bm25_path = str(cache_path / "bm25_index")
 
         # Recreate the executor — close() shuts it down and it cannot be reused
 

--- a/src/axon/mcp_server.py
+++ b/src/axon/mcp_server.py
@@ -739,6 +739,123 @@ async def init_store(base_path: str, persist: bool = False) -> Any:
     return await _post("/store/init", {"base_path": base_path, "persist": persist})
 
 
+# ---------------------------------------------------------------------------
+# Sealed-store tools (Phase 2 of #SEALED).
+# Mirror the /security/* REST endpoints so MCP clients can manage the
+# encryption-at-rest store without poking the HTTP API directly.
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def security_status() -> Any:
+    """Return current sealed-store status (initialized + unlocked flags).
+
+    Use this on startup to decide whether to prompt for ``security_bootstrap``
+    (first-time setup) or ``security_unlock`` (existing user). Returns
+    ``initialized: false`` on a fresh install, ``initialized: true,
+    unlocked: false`` after bootstrap until the next unlock.
+    """
+
+    return await _get("/security/status")
+
+
+@mcp.tool()
+async def security_bootstrap(passphrase: str) -> Any:
+    """Initialise the sealed-store with a passphrase (one-time setup).
+
+    Generates a fresh master key, wraps it under a passphrase-derived
+    KEK, and stores the wrapped record in the OS keyring. After this
+    succeeds the store is automatically unlocked for the rest of this
+    process; the passphrase is required for every subsequent unlock.
+
+    Args:
+        passphrase: The user's chosen passphrase. Cannot be empty.
+            There is NO recovery — losing this passphrase means losing
+            access to every project sealed under this master.
+    """
+
+    return await _post("/security/bootstrap", {"passphrase": passphrase})
+
+
+@mcp.tool()
+async def security_unlock(passphrase: str) -> Any:
+    """Unlock the sealed-store so sealed projects can be queried.
+
+    Required after every process restart before ``project_seal`` or any
+    sealed-project switch will work. Rate-limited: 5 wrong attempts
+    inside 5 minutes triggers a 429 lockout per client IP.
+
+    Args:
+        passphrase: The passphrase supplied at ``security_bootstrap``
+            time (or the current passphrase after a rotation).
+    """
+
+    return await _post("/security/unlock", {"passphrase": passphrase})
+
+
+@mcp.tool()
+async def security_lock() -> Any:
+    """Clear the in-process master key cache.
+
+    Subsequent sealed-project queries will fail with a "store is locked"
+    error until ``security_unlock`` is called again. Use before walking
+    away from the machine; the orphan-cleanup hook will wipe any
+    plaintext mount caches on next process boot.
+    """
+
+    return await _post("/security/lock", {})
+
+
+@mcp.tool()
+async def security_change_passphrase(old_passphrase: str, new_passphrase: str) -> Any:
+    """Re-wrap the master key under a new passphrase.
+
+    Project DEKs are not touched (they're wrapped under the master, not
+    the passphrase), so this is O(1) regardless of how many sealed
+    projects you have. The new passphrase is required for every future
+    ``security_unlock`` call.
+
+    Args:
+        old_passphrase: The current passphrase. Required to unwrap the
+            existing master before re-wrapping.
+        new_passphrase: The new passphrase. Cannot be empty.
+    """
+
+    return await _post(
+        "/security/change-passphrase",
+        {"old_passphrase": old_passphrase, "new_passphrase": new_passphrase},
+    )
+
+
+@mcp.tool()
+async def seal_project(project_name: str, migration_mode: str = "in_place") -> Any:
+    """Encrypt every content file in a project in place (one-shot).
+
+    Walks the project directory and rewrites ``meta.json`` plus every
+    file under ``bm25_index/`` and ``vector_store_data/`` as AXSL-sealed
+    AES-256-GCM ciphertext. Each file is replaced atomically (tempfile
+    + os.replace), so a crash mid-seal leaves the original or the new
+    sealed version on disk but never a partial write.
+
+    Idempotent — re-sealing an already-sealed project is a no-op
+    (returns ``status="already_sealed"``).
+
+    Requires the sealed-store to be unlocked (see ``security_unlock``).
+    The active project switches to "default" during the operation and
+    switches back when done.
+
+    Args:
+        project_name: Name of the open project to seal. Must exist.
+        migration_mode: Reserved for future variants; only ``"in_place"``
+            is implemented in v1.
+    """
+
+    return await _post(
+        "/project/seal",
+        {"project_name": project_name, "migration_mode": migration_mode},
+    )
+
+
 @mcp.tool()
 async def graph_status() -> Any:
     """Return current GraphRAG knowledge-graph status.

--- a/src/axon/repl.py
+++ b/src/axon/repl.py
@@ -3277,12 +3277,18 @@ def _interactive_repl(
                         "    Share strings are base64-encoded payloads; send them out-of-band.\n"
                         "    Mounted shares appear under mounts/ in your project list and can be\n"
                         "    switched to with /project switch mounts/<name>.",
-                        "store": "    /store whoami                  show store identity and active project\n"
-                        "    /store init <base_path>        change the store base path (e.g. to a shared drive)\n"
+                        "store": "    /store whoami                            show store identity and active project\n"
+                        "    /store init <base_path>                  change the store base path\n"
+                        "    /store status                            show sealed-store init/unlock state\n"
+                        "    /store bootstrap <passphrase>            one-time sealed-store init\n"
+                        "    /store unlock <passphrase>               unlock for sealed-project queries\n"
+                        "    /store lock                              clear in-process master cache\n"
+                        "    /store change-passphrase <old> <new>     rotate the sealed-store passphrase\n"
                         "\n"
                         "    Example: /store init ~/axon_data\n"
                         "    Moves data to: <base_path>/AxonStore/<username>/\n"
-                        "    Config is updated and persisted to ~/.config/axon/config.yaml.",
+                        "    Config is updated and persisted to ~/.config/axon/config.yaml.\n"
+                        "    Sealed-store sub-commands require the [sealed] extra installed.",
                         "graph": "    /graph status                  show entity count, edges, community summaries\n"
                         "    /graph finalize                trigger community detection rebuild\n"
                         "    /graph viz [path]              export graph as HTML (opens in browser)\n"
@@ -4163,8 +4169,11 @@ def _interactive_repl(
                         "    /project refresh                         re-read mount version marker"
                     )
 
+                    print("    /project folder                          open active project folder")
+
                     print(
-                        "    /project folder                          open active project folder\n"
+                        "    /project seal <name>                     encrypt at rest "
+                        "(requires /store unlock)\n"
                     )
 
                 elif sub == "new":
@@ -4335,9 +4344,39 @@ def _interactive_repl(
                         except Exception:
                             pass
 
+                elif sub == "seal":
+                    # Encrypt every content file in the project in place.
+                    # Requires the [sealed] extra and an unlocked store.
+                    if not sub_arg:
+                        print("    Usage: /project seal <name>")
+                    else:
+                        from axon import security as _security
+
+                        seal_name = sub_arg.strip().lower()
+                        previously_active = brain._active_project
+                        needs_switch_back = previously_active == seal_name
+                        if needs_switch_back:
+                            brain.switch_project("default")
+                        try:
+                            result = _security.project_seal(
+                                seal_name,
+                                Path(brain.config.projects_root),
+                                config=brain.config,
+                                embedding=brain.embedding,
+                            )
+                            status = result.get("status", "sealed")
+                            files = result.get("files_sealed", 0)
+                            print(f"    Project '{seal_name}': {status} ({files} files)")
+                        except _security.SecurityError as exc:
+                            print(f"    Seal failed: {exc}")
+                        finally:
+                            if needs_switch_back:
+                                brain.switch_project(previously_active)
+
                 else:
                     print(
-                        f"    Unknown sub-command '{sub}'. Try: list, new, switch, delete, folder"
+                        f"    Unknown sub-command '{sub}'. "
+                        "Try: list, new, switch, delete, folder, seal"
                     )
 
             elif cmd == "/retry":
@@ -4766,10 +4805,81 @@ def _interactive_repl(
                         except Exception as e:
                             print(f"    Store init failed: {e}")
 
+                elif sub == "status":
+                    from axon import security as _security
+
+                    user_dir = Path(brain.config.projects_root)
+                    try:
+                        st = _security.store_status(user_dir)
+                    except Exception as exc:
+                        print(f"    Sealed-store status unavailable: {exc}")
+                    else:
+                        print(f"\n    Initialized:  {st.get('initialized', False)}")
+                        print(f"    Unlocked:     {st.get('unlocked', False)}")
+                        print(f"    Cipher suite: {st.get('cipher_suite', '') or '(none)'}\n")
+
+                elif sub == "bootstrap":
+                    from axon import security as _security
+
+                    if not sub_arg:
+                        print("    Usage: /store bootstrap <passphrase>")
+                    else:
+                        try:
+                            _security.bootstrap_store(
+                                Path(brain.config.projects_root), sub_arg.strip()
+                            )
+                            print("    Sealed-store bootstrapped and unlocked.")
+                        except _security.SecurityError as exc:
+                            print(f"    Bootstrap failed: {exc}")
+
+                elif sub == "unlock":
+                    from axon import security as _security
+
+                    if not sub_arg:
+                        print("    Usage: /store unlock <passphrase>")
+                    else:
+                        try:
+                            _security.unlock_store(
+                                Path(brain.config.projects_root), sub_arg.strip()
+                            )
+                            print("    Sealed-store unlocked.")
+                        except _security.SecurityError as exc:
+                            print(f"    Unlock failed: {exc}")
+
+                elif sub == "lock":
+                    from axon import security as _security
+
+                    try:
+                        _security.lock_store(Path(brain.config.projects_root))
+                        print("    Sealed-store locked.")
+                    except _security.SecurityError as exc:
+                        print(f"    Lock failed: {exc}")
+
+                elif sub == "change-passphrase":
+                    from axon import security as _security
+
+                    parts = sub_arg.split(maxsplit=1) if sub_arg else []
+                    if len(parts) != 2:
+                        print("    Usage: /store change-passphrase <old> <new>")
+                    else:
+                        try:
+                            _security.change_passphrase(
+                                Path(brain.config.projects_root),
+                                parts[0].strip(),
+                                parts[1].strip(),
+                            )
+                            print("    Sealed-store passphrase rotated.")
+                        except _security.SecurityError as exc:
+                            print(f"    Passphrase rotation failed: {exc}")
+
                 else:
                     print(f"    Unknown sub-command '{sub}'.")
 
-                    print("    Usage: /store whoami | /store init <base_path>")
+                    print(
+                        "    Usage: /store whoami | /store init <base_path> | "
+                        "/store status | /store bootstrap <pp> | /store unlock <pp> | "
+                        "/store lock | /store change-passphrase <old> <new>"
+                    )
 
             elif cmd == "/refresh":
                 # ── /refresh — re-ingest changed documents ───────────────────────

--- a/src/axon/security/__init__.py
+++ b/src/axon/security/__init__.py
@@ -49,39 +49,107 @@ class SecurityError(Exception):
 
 
 def store_status(user_dir: Path) -> dict[str, Any]:
-    """Return the current security store status."""
+    """Return the current security store status.
+
+    Phase 2 (PR #57) — wired to the on-disk master record via
+    :mod:`axon.security.master`. When the optional ``[sealed]`` extra
+    is not installed, falls back to the v0 stub response so callers
+    on minimal installs keep working.
+    """
+    try:
+        from . import master as _m
+    except ImportError:
+        return {
+            "initialized": False,
+            "unlocked": False,
+            "sealed_hidden_count": 0,
+            "public_key_fingerprint": "",
+            "cipher_suite": "",
+        }
+
+    initialized = _m.is_bootstrapped(user_dir)
     return {
-        "initialized": False,
-        "unlocked": False,
+        "initialized": initialized,
+        "unlocked": _m.is_unlocked(user_dir) if initialized else False,
         "sealed_hidden_count": 0,
         "public_key_fingerprint": "",
-        "cipher_suite": "",
+        "cipher_suite": "AES-256-GCM-v1" if initialized else "",
     }
 
 
 def bootstrap_store(user_dir: Path, passphrase: str) -> dict[str, Any]:
-    """Bootstrap the security store with a passphrase."""
-    raise SecurityError("Security store not configured")
+    """Bootstrap the security store with a passphrase.
+
+    Phase 2 (PR #57) — wired to :mod:`axon.security.master`.
+    Requires the ``[sealed]`` extra (``pip install axon-rag[sealed]``)
+    so the ``cryptography`` + ``keyring`` dependencies are present.
+    """
+    try:
+        from . import master as _m
+    except ImportError as exc:
+        raise SecurityError(
+            "Sealed-store support is not installed. " "Install with: pip install axon-rag[sealed]"
+        ) from exc
+    return _m.bootstrap_store(user_dir, passphrase)
 
 
 def unlock_store(user_dir: Path, passphrase: str) -> dict[str, Any]:
-    """Unlock the security store."""
-    raise SecurityError("unlock failed: store not initialized")
+    """Unlock the security store.
+
+    Phase 2 (PR #57) — wired to :mod:`axon.security.master`. Raises
+    :class:`axon.security.master.BadPassphraseError` (a SecurityError
+    subclass) on a wrong passphrase.
+    """
+    try:
+        from . import master as _m
+    except ImportError as exc:
+        raise SecurityError(
+            "Sealed-store support is not installed. " "Install with: pip install axon-rag[sealed]"
+        ) from exc
+    return _m.unlock_store(user_dir, passphrase)
 
 
 def lock_store(user_dir: Path) -> dict[str, Any]:
-    """Lock the security store."""
-    return {"initialized": False, "unlocked": False}
+    """Lock the security store.
+
+    Phase 2 (PR #57) — wired to :mod:`axon.security.master`. Always
+    returns successfully even when nothing was unlocked, so callers
+    can use this as a no-throw cleanup hook on shutdown.
+    """
+    try:
+        from . import master as _m
+    except ImportError:
+        return {"initialized": False, "unlocked": False}
+    return _m.lock_store(user_dir)
 
 
 def change_passphrase(user_dir: Path, old_passphrase: str, new_passphrase: str) -> dict[str, Any]:
-    """Change the store passphrase."""
-    raise SecurityError("passphrase change failed: store not initialized")
+    """Change the store passphrase.
+
+    Phase 2 (PR #57) — wired to :mod:`axon.security.master`. Project
+    DEKs are not touched (they're wrapped under the master, not the
+    passphrase), so this is O(1) regardless of how many sealed
+    projects the owner has.
+    """
+    try:
+        from . import master as _m
+    except ImportError as exc:
+        raise SecurityError(
+            "Sealed-store support is not installed. " "Install with: pip install axon-rag[sealed]"
+        ) from exc
+    return _m.change_passphrase(user_dir, old_passphrase, new_passphrase)
 
 
 def is_unlocked(user_dir: Path) -> bool:
-    """Return True if the sealed store is currently unlocked."""
-    return False
+    """Return True if the sealed store is currently unlocked.
+
+    Phase 2 (PR #57) — wired to :mod:`axon.security.master`.
+    """
+    try:
+        from . import master as _m
+    except ImportError:
+        return False
+    return _m.is_unlocked(user_dir)
 
 
 def get_sealed_project_record(project: str, user_dir: Path) -> dict[str, Any] | None:

--- a/src/axon/security/__init__.py
+++ b/src/axon/security/__init__.py
@@ -85,8 +85,14 @@ def is_unlocked(user_dir: Path) -> bool:
 
 
 def get_sealed_project_record(project: str, user_dir: Path) -> dict[str, Any] | None:
-    """Return the sealed project record if this project is sealed, else None."""
-    return None
+    """Return the sealed project record if this project is sealed, else None.
+
+    Phase 2 (PR #57) — wired to the on-disk ``.security/.sealed`` marker
+    via :mod:`axon.security.seal`.
+    """
+    from .seal import get_sealed_project_record as _impl
+
+    return _impl(project, user_dir)
 
 
 def generate_sealed_share(
@@ -128,9 +134,24 @@ def project_seal(
     project_name: str,
     user_dir: Path,
     *,
-    migration_mode: str = "snapshot",
+    migration_mode: str = "in_place",
     config: Any = None,
     embedding: Any = None,
 ) -> dict[str, Any]:
-    """Seal an existing open project, converting it to sealed_v1 mode."""
-    raise SecurityError("project_seal not configured")
+    """Seal an existing open project, converting it to sealed_v1 mode.
+
+    Phase 2 (PR #57) — wired to the in-place per-file AES-256-GCM
+    sealer in :mod:`axon.security.seal`. ``migration_mode`` /
+    ``config`` / ``embedding`` are reserved for future variants and
+    have no effect in v1; the parameters are preserved so existing
+    callers (api_routes/projects.py) keep working.
+    """
+    from .seal import project_seal as _impl
+
+    return _impl(
+        project_name,
+        user_dir,
+        migration_mode=migration_mode,
+        config=config,
+        embedding=embedding,
+    )

--- a/src/axon/security/__init__.py
+++ b/src/axon/security/__init__.py
@@ -156,9 +156,14 @@ def get_sealed_project_record(project: str, user_dir: Path) -> dict[str, Any] | 
     """Return the sealed project record if this project is sealed, else None.
 
     Phase 2 (PR #57) — wired to the on-disk ``.security/.sealed`` marker
-    via :mod:`axon.security.seal`.
+    via :mod:`axon.security.seal`. When the optional ``[sealed]`` extra
+    is not installed, returns ``None`` (no project can be sealed on a
+    minimal install) so callers like ``shares.py`` keep working.
     """
-    from .seal import get_sealed_project_record as _impl
+    try:
+        from .seal import get_sealed_project_record as _impl
+    except ImportError:
+        return None
 
     return _impl(project, user_dir)
 
@@ -214,7 +219,12 @@ def project_seal(
     have no effect in v1; the parameters are preserved so existing
     callers (api_routes/projects.py) keep working.
     """
-    from .seal import project_seal as _impl
+    try:
+        from .seal import project_seal as _impl
+    except ImportError as exc:
+        raise SecurityError(
+            "Sealed-store support is not installed. " "Install with: pip install axon-rag[sealed]"
+        ) from exc
 
     return _impl(
         project_name,

--- a/src/axon/security/cache.py
+++ b/src/axon/security/cache.py
@@ -182,8 +182,11 @@ def _pid_alive(pid: int) -> bool:
       and ``ESRCH`` for "no such process". ``PermissionError`` again
       means a live PID we can't signal.
 
-    Cleanup leans toward wiping orphans rather than leaking plaintext:
-    on any unrecognised error we treat the PID as dead.
+    On unrecognised errors we treat the PID as **alive** (return True)
+    so we don't accidentally wipe a cache that another process might
+    still be reading. The next boot will re-evaluate; preserving a
+    live cache once is much better than wiping it under another
+    process's nose.
     """
     if pid <= 0:
         return False

--- a/src/axon/security/cache.py
+++ b/src/axon/security/cache.py
@@ -1,0 +1,452 @@
+"""Ephemeral plaintext cache for sealed Axon projects (Phase 2 of #SEALED).
+
+When an owner queries a sealed project, the on-disk files are AES-GCM
+ciphertext. Backends like TurboQuantDB / LanceDB / BM25 mmap their data
+files for performance — and mmap can't see through encryption. The
+v1 policy (decision §5.1 in ``docs/SHARE_MOUNT_SEALED.md``, locked
+2026-04-25) is to **decrypt the whole project into an ephemeral
+plaintext cache** in the OS temp dir at mount time, point the backend
+at the cache path, and wipe the cache on close. Backends mmap the
+cache normally, so query performance is identical to plaintext mode.
+
+Cost: a session-bounded plaintext footprint on disk. Mitigations
+implemented here:
+
+- **Cache location**: ``tempfile.mkdtemp(prefix="axon-sealed-")``
+  (Linux/macOS uses ``/tmp``; Windows uses ``%LOCALAPPDATA%\\Temp``).
+  Per-mount; never shared between projects.
+- **Wipe on close**: every cache file is overwritten with zeros
+  (``O_RDWR`` re-open + ``write(b"\\x00" * size)`` + fsync) before
+  unlink. This won't survive low-level disk forensics on SSDs (TRIM
+  / wear-leveling defeat overwrite), but at the filesystem layer the
+  plaintext is gone.
+- **Crash recovery**: every cache dir contains a ``.pid`` sentinel
+  with the creating process's PID. :func:`cleanup_orphans` walks the
+  temp dir on next AxonBrain boot, finds ``axon-sealed-*`` dirs whose
+  PID is no longer alive, wipes them.
+- **Capacity check**: before decrypting, verify free disk ≥ project
+  size × 1.1; raise :class:`CacheCapacityError` with concrete numbers
+  if not.
+
+Phase 2 deliverable; consumed by Phase 2's seal-aware backend
+integration. **Nothing outside ``axon.security`` consumes this yet**
+— the module is testable in isolation.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+try:
+    from .crypto import MAGIC, SealedFile, make_aad
+except ImportError as exc:  # pragma: no cover — import-time guard
+    raise ImportError(
+        "axon.security.cache requires axon.security.crypto, which requires the "
+        "'cryptography' package. Install with: pip install axon-rag[sealed]"
+    ) from exc
+
+logger = logging.getLogger("Axon")
+
+__all__ = [
+    "CACHE_PREFIX",
+    "PID_SENTINEL_FILENAME",
+    "CACHE_HEADROOM_FRACTION",
+    "CacheCapacityError",
+    "SealedCache",
+    "cleanup_orphans",
+    "is_sealed_file",
+]
+
+CACHE_PREFIX: str = "axon-sealed-"
+PID_SENTINEL_FILENAME: str = ".axon-cache-pid"
+
+# Free disk required as a fraction of project size before we'll create
+# a cache. 1.1 = 10% headroom; refuses cache creation when the free
+# space would drop below that.
+CACHE_HEADROOM_FRACTION: float = 1.1
+
+
+class CacheCapacityError(RuntimeError):
+    """Raised when the OS temp dir doesn't have enough free space to
+    decrypt the sealed project.
+
+    Surfaced with concrete numbers (project size, free space, deficit)
+    so the user can either free up disk or move ``TMPDIR`` /
+    ``TEMP`` to a roomier volume.
+    """
+
+
+def is_sealed_file(path: Path) -> bool:
+    """Return True if *path* starts with the AXSL magic header.
+
+    Used by :class:`SealedCache` to decide whether to decrypt or copy
+    each file when materialising the cache. Cheap — reads only the
+    first 4 bytes.
+    """
+    if not path.is_file():
+        return False
+    try:
+        with path.open("rb") as fh:
+            return fh.read(4) == MAGIC
+    except OSError:
+        return False
+
+
+def _project_size_bytes(sealed_dir: Path) -> int:
+    """Total bytes of every regular file under *sealed_dir* (recursive)."""
+    total = 0
+    for p in sealed_dir.rglob("*"):
+        if p.is_file():
+            try:
+                total += p.stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def _secure_delete_file(path: Path) -> None:
+    """Overwrite *path* with zeros, fsync, then unlink.
+
+    Best-effort at the filesystem layer — won't defeat SSD TRIM /
+    wear-leveling, but ensures no readable plaintext bytes remain at
+    the file's logical address before the inode is freed. Errors are
+    silently swallowed (the unlink is the desired post-condition; if
+    we can't even unlink, there's nothing useful to do here).
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+    if size > 0:
+        try:
+            with path.open("r+b") as fh:
+                # Write zeros in 64 KiB chunks so we don't allocate a
+                # huge buffer for huge files.
+                chunk = b"\x00" * min(size, 64 * 1024)
+                remaining = size
+                while remaining > 0:
+                    write_len = min(remaining, len(chunk))
+                    fh.write(chunk[:write_len])
+                    remaining -= write_len
+                fh.flush()
+                try:
+                    os.fsync(fh.fileno())
+                except OSError:
+                    pass
+        except OSError as exc:
+            logger.debug("secure-delete overwrite failed for %s: %s", path, exc)
+    try:
+        path.unlink()
+    except OSError as exc:
+        logger.debug("secure-delete unlink failed for %s: %s", path, exc)
+
+
+def _wipe_dir_contents(cache_dir: Path) -> None:
+    """Securely delete every regular file under *cache_dir*, then remove
+    empty directories bottom-up. Used by :meth:`SealedCache.wipe` and
+    :func:`cleanup_orphans`."""
+    if not cache_dir.exists():
+        return
+    # Walk bottom-up so we can rmdir empty dirs after their files are gone.
+    for root, dirs, files in os.walk(cache_dir, topdown=False):
+        root_path = Path(root)
+        for name in files:
+            _secure_delete_file(root_path / name)
+        for name in dirs:
+            try:
+                (root_path / name).rmdir()
+            except OSError:
+                pass
+    try:
+        cache_dir.rmdir()
+    except OSError:
+        # Race vs cleanup_orphans, or something we couldn't unlink —
+        # leave the dir but it should be effectively empty.
+        pass
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if a process with *pid* is still running.
+
+    Cross-platform best-effort check: ``os.kill(pid, 0)`` on POSIX is
+    the canonical existence test; on Windows we use the same call
+    which Python's ``os.kill`` translates to ``OpenProcess`` semantics.
+    Treat any error other than "process exists" as "not alive" so
+    cleanup leans toward wiping orphans rather than leaking them.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, PermissionError):
+        # PermissionError on Windows means the process exists but we
+        # can't signal it — treat as alive (don't wipe a cache that
+        # might still be in use by another user).
+        # POSIX: PermissionError likewise indicates the PID is in use.
+        # Pure OSError (ESRCH / "no such process") = not alive.
+        import errno
+
+        if isinstance(getattr(_pid_alive, "_last_exc", None), OSError):
+            pass  # placeholder — real branch is below via except
+        # Re-classify by inspecting the original exception; simpler
+        # to just re-call with a different probe:
+        try:
+            os.kill(pid, 0)
+            return True
+        except PermissionError:
+            return True
+        except OSError as exc:
+            return exc.errno != errno.ESRCH
+
+
+# ---------------------------------------------------------------------------
+# SealedCache
+# ---------------------------------------------------------------------------
+
+
+class SealedCache:
+    """An ephemeral plaintext cache backing one mounted sealed project.
+
+    Use as a context manager so the cache is reliably wiped on close::
+
+        with SealedCache.create(project_dir, dek, key_id="sk_xxx") as cache:
+            backend = OpenVectorStore(cfg.with_path(cache.path))
+            ...
+        # cache.path no longer exists here
+    """
+
+    def __init__(self, cache_dir: Path) -> None:
+        self._path = cache_dir
+        self._wiped = False
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def create(
+        cls,
+        sealed_dir: Path | str,
+        dek: bytes,
+        *,
+        key_id: str,
+        cache_root: Path | str | None = None,
+    ) -> SealedCache:
+        """Decrypt every sealed file in *sealed_dir* into a fresh cache.
+
+        Args:
+            sealed_dir: Project root containing AXSL-sealed files.
+            dek: 32-byte AES-256 Data Encryption Key for the project.
+            key_id: Share/project key identifier — bound into the GCM
+                AAD via :func:`make_aad` so files cannot be swapped
+                between projects without an InvalidTag.
+            cache_root: Override the temp directory (default: the OS
+                temp dir from :func:`tempfile.gettempdir`).
+
+        Returns:
+            A :class:`SealedCache` instance bound to the new cache dir.
+
+        Raises:
+            CacheCapacityError: free disk < project size × 1.1.
+            FileNotFoundError: sealed_dir does not exist.
+            cryptography.exceptions.InvalidTag: a sealed file's GCM tag
+                doesn't validate (wrong DEK or tampered ciphertext).
+            SealedFormatError: a file with an AXSL prefix has a bad
+                schema version or unknown cipher_id.
+        """
+        sealed_dir = Path(sealed_dir)
+        if not sealed_dir.is_dir():
+            raise FileNotFoundError(f"sealed_dir does not exist: {sealed_dir}")
+
+        size = _project_size_bytes(sealed_dir)
+        cache_parent = Path(cache_root) if cache_root else Path(tempfile.gettempdir())
+        cache_parent.mkdir(parents=True, exist_ok=True)
+
+        # Capacity check BEFORE we mkdtemp so we don't leave an empty
+        # cache dir behind on failure.
+        try:
+            free = shutil.disk_usage(cache_parent).free
+        except OSError as exc:
+            logger.debug("disk_usage on %s failed: %s", cache_parent, exc)
+            free = -1  # unknown — skip the check rather than fail
+        required = int(size * CACHE_HEADROOM_FRACTION)
+        if free >= 0 and free < required:
+            raise CacheCapacityError(
+                f"Cannot create sealed cache: project is {size:,} bytes, "
+                f"need {required:,} bytes free in {cache_parent} "
+                f"(have {free:,}). Free up disk or set TMPDIR/TEMP to a "
+                "roomier volume."
+            )
+
+        cache_dir = Path(tempfile.mkdtemp(prefix=CACHE_PREFIX, dir=str(cache_parent)))
+        try:
+            # PID sentinel — used by cleanup_orphans on next boot.
+            (cache_dir / PID_SENTINEL_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
+            # Walk sealed_dir, decrypt sealed files, copy non-sealed.
+            for src in sealed_dir.rglob("*"):
+                if not src.is_file():
+                    continue
+                rel = src.relative_to(sealed_dir)
+                dst = cache_dir / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                if is_sealed_file(src):
+                    aad = make_aad(key_id, str(rel).replace("\\", "/"))
+                    plaintext = SealedFile.read(src, dek, aad=aad)
+                    dst.write_bytes(plaintext)
+                else:
+                    # Non-sealed file (e.g. version.json which is
+                    # deliberately plaintext). Copy as-is so the
+                    # cache is a faithful materialisation of the
+                    # project view.
+                    shutil.copy2(src, dst)
+        except Exception:
+            # On any failure during materialisation, wipe the partial
+            # cache so we don't leak plaintext bytes already decrypted.
+            _wipe_dir_contents(cache_dir)
+            raise
+
+        logger.info(
+            "SealedCache.create: %d bytes from %s decrypted into %s (pid=%d)",
+            size,
+            sealed_dir,
+            cache_dir,
+            os.getpid(),
+        )
+        return cls(cache_dir)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def path(self) -> Path:
+        """Cache directory backends should be pointed at."""
+        return self._path
+
+    def wipe(self) -> None:
+        """Securely delete every cache file, then remove the cache dir.
+
+        Idempotent — calling on an already-wiped cache is a no-op.
+        """
+        if self._wiped:
+            return
+        _wipe_dir_contents(self._path)
+        self._wiped = True
+
+    # ------------------------------------------------------------------
+    # Context-manager protocol
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> SealedCache:
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.wipe()
+
+    def __repr__(self) -> str:
+        return f"SealedCache(path={self._path!r}, wiped={self._wiped})"
+
+
+# ---------------------------------------------------------------------------
+# Orphan cleanup
+# ---------------------------------------------------------------------------
+
+
+def list_orphans(cache_root: Path | str | None = None) -> list[Path]:
+    """Return cache dirs whose owner process is no longer alive.
+
+    Looks for ``axon-sealed-*`` directories under *cache_root* (default
+    OS temp dir) and reads each one's ``.axon-cache-pid`` sentinel.
+    A dir is "orphan" iff its sentinel PID is not alive (or the
+    sentinel is unreadable / missing — defensive).
+    """
+    root = Path(cache_root) if cache_root else Path(tempfile.gettempdir())
+    if not root.is_dir():
+        return []
+    orphans: list[Path] = []
+    for entry in root.iterdir():
+        if not entry.is_dir() or not entry.name.startswith(CACHE_PREFIX):
+            continue
+        pid_path = entry / PID_SENTINEL_FILENAME
+        try:
+            pid_text = pid_path.read_text(encoding="utf-8").strip()
+            pid = int(pid_text)
+        except (OSError, ValueError):
+            # Missing/unreadable sentinel → orphan. Defensive: a real
+            # active cache should always have a parseable PID file.
+            orphans.append(entry)
+            continue
+        if not _pid_alive(pid):
+            orphans.append(entry)
+    return orphans
+
+
+def cleanup_orphans(cache_root: Path | str | None = None) -> int:
+    """Wipe every orphan cache dir; return the count wiped.
+
+    Called from ``AxonBrain.__init__`` (Phase 2 follow-up) so a crashed
+    previous session doesn't leak plaintext indefinitely. Always
+    safe to call: reports findings via DEBUG logs and never raises.
+    """
+    count = 0
+    for orphan in list_orphans(cache_root):
+        try:
+            _wipe_dir_contents(orphan)
+            count += 1
+            logger.info("SealedCache: wiped orphan cache %s", orphan)
+        except Exception as exc:
+            logger.debug("SealedCache: orphan wipe failed for %s: %s", orphan, exc)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+
+def _self_check() -> dict[str, Any]:
+    """Round-trip a tiny sealed project through the cache to confirm wiring.
+
+    Used by future ``axon doctor`` output. Never raises — failures are
+    reported in the dict.
+    """
+    out: dict[str, Any] = {"ok": False, "details": ""}
+    try:
+        from .crypto import generate_dek
+
+        with tempfile.TemporaryDirectory() as td:
+            sealed = Path(td) / "sealed_proj"
+            sealed.mkdir()
+            dek = generate_dek()
+            # Seal one file, copy one plaintext-passthrough file.
+            SealedFile.write(
+                sealed / "encrypted.bin",
+                b"sealed-payload",
+                dek,
+                aad=make_aad("sk_selfcheck", "encrypted.bin"),
+            )
+            (sealed / "passthrough.txt").write_text("plaintext-ok", encoding="utf-8")
+            # Materialise + verify.
+            cache = SealedCache.create(sealed, dek, key_id="sk_selfcheck")
+            try:
+                if (cache.path / "encrypted.bin").read_bytes() != b"sealed-payload":
+                    out["details"] = "encrypted file decrypted to wrong bytes"
+                    return out
+                if (cache.path / "passthrough.txt").read_text(encoding="utf-8") != "plaintext-ok":
+                    out["details"] = "plaintext passthrough file copied with wrong contents"
+                    return out
+            finally:
+                cache.wipe()
+            if cache.path.exists():
+                out["details"] = "cache dir survived wipe()"
+                return out
+        out["ok"] = True
+        out["details"] = "SealedCache create/read/wipe round-trip OK"
+    except Exception as exc:  # pragma: no cover — defensive
+        out["details"] = f"self-check raised: {type(exc).__name__}: {exc}"
+    return out

--- a/src/axon/security/cache.py
+++ b/src/axon/security/cache.py
@@ -172,36 +172,40 @@ def _wipe_dir_contents(cache_dir: Path) -> None:
 def _pid_alive(pid: int) -> bool:
     """Return True if a process with *pid* is still running.
 
-    Cross-platform best-effort check: ``os.kill(pid, 0)`` on POSIX is
-    the canonical existence test; on Windows we use the same call
-    which Python's ``os.kill`` translates to ``OpenProcess`` semantics.
-    Treat any error other than "process exists" as "not alive" so
-    cleanup leans toward wiping orphans rather than leaking them.
+    Cross-platform best-effort check:
+
+    - POSIX: ``os.kill(pid, 0)`` succeeds for live PIDs, raises
+      ``ProcessLookupError`` (errno ``ESRCH``) for dead ones, and
+      ``PermissionError`` for live PIDs we don't own.
+    - Windows: ``os.kill(pid, 0)`` raises ``OSError`` with ``errno``
+      ``EINVAL`` for invalid handle (PID never existed / out of range)
+      and ``ESRCH`` for "no such process". ``PermissionError`` again
+      means a live PID we can't signal.
+
+    Cleanup leans toward wiping orphans rather than leaking plaintext:
+    on any unrecognised error we treat the PID as dead.
     """
     if pid <= 0:
         return False
+    import errno
+
     try:
         os.kill(pid, 0)
+    except PermissionError:
+        # Live PID owned by another user — leave its cache alone.
         return True
-    except (OSError, PermissionError):
-        # PermissionError on Windows means the process exists but we
-        # can't signal it — treat as alive (don't wipe a cache that
-        # might still be in use by another user).
-        # POSIX: PermissionError likewise indicates the PID is in use.
-        # Pure OSError (ESRCH / "no such process") = not alive.
-        import errno
-
-        if isinstance(getattr(_pid_alive, "_last_exc", None), OSError):
-            pass  # placeholder — real branch is below via except
-        # Re-classify by inspecting the original exception; simpler
-        # to just re-call with a different probe:
-        try:
-            os.kill(pid, 0)
-            return True
-        except PermissionError:
-            return True
-        except OSError as exc:
-            return exc.errno != errno.ESRCH
+    except ProcessLookupError:
+        return False
+    except OSError as exc:
+        # ESRCH = "no such process". EINVAL on Windows = handle out of
+        # range / invalid PID. Either way: not a live process.
+        if exc.errno in (errno.ESRCH, errno.EINVAL):
+            return False
+        # Unknown failure mode — be conservative and treat as alive
+        # so we don't accidentally wipe a cache that might still be
+        # in use. The next boot will re-check.
+        return True
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/src/axon/security/master.py
+++ b/src/axon/security/master.py
@@ -1,0 +1,496 @@
+"""Owner master key + per-project DEK lifecycle (Phase 2 of #SEALED).
+
+Two key tiers (envelope encryption, the standard KMS pattern):
+
+- **Master key** — random 32 bytes per owner. NEVER stored in
+  plaintext on disk and NEVER in the user's keyring directly. The
+  keyring stores the master *encrypted under a passphrase-derived
+  KEK*: ``salt + wrap(master, scrypt(passphrase, salt))``. Unlock =
+  re-derive the KEK from the user's passphrase and unwrap.
+- **Project DEK** — random 32 bytes per project. Wrapped with the
+  master and persisted at ``<project>/.security/dek.wrapped`` (40
+  bytes). At unlock time, the master is in process memory so the DEK
+  can be re-derived on demand.
+
+Why this layering:
+
+- Passphrase rotation re-derives a new KEK and re-wraps the master,
+  but does NOT touch any project's wrapped DEK — the master is
+  unchanged across passphrase changes.
+- Loss of the master would force re-encrypt of every project. So we
+  never persist the master in plaintext anywhere; recovery is via
+  passphrase, full stop.
+- Recovery: lose the passphrase, lose access to all sealed projects.
+  Documented; no escrow in v1.
+
+Wire-level keyring secret (JSON): ``{"v": 1, "salt": "<b64>", "wrapped":
+"<b64>"}`` stored at ``axon.master.<owner>`` / ``master``. Bumping
+``v`` is the breaking-change signal for future format migrations.
+
+Phase 2 deliverable. Replaces the same-named stubs in
+``axon/security/__init__.py`` (which currently raise
+``SecurityError("not configured")``).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+try:
+    from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+    from cryptography.hazmat.primitives.keywrap import (
+        InvalidUnwrap,
+        aes_key_unwrap,
+        aes_key_wrap,
+    )
+except ImportError as exc:  # pragma: no cover — import-time guard
+    raise ImportError(
+        "axon.security.master requires the 'cryptography' package. "
+        "Install with: pip install axon-rag[sealed]"
+    ) from exc
+
+from . import SecurityError
+from . import keyring as _kr
+from .crypto import DEK_LEN, generate_dek, wrap_key
+
+logger = logging.getLogger("Axon")
+
+__all__ = [
+    "BadPassphraseError",
+    "MASTER_USERNAME",
+    "PROJECT_DEK_FILENAME",
+    "SCHEMA_VERSION",
+    "bootstrap_store",
+    "unlock_store",
+    "lock_store",
+    "is_unlocked",
+    "change_passphrase",
+    "get_master_key",
+    "get_or_create_project_dek",
+    "get_project_dek",
+    "is_bootstrapped",
+]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MASTER_USERNAME: str = "master"
+PROJECT_DEK_FILENAME: str = ".security/dek.wrapped"
+SCHEMA_VERSION: int = 1
+
+# scrypt parameters (RFC 7914). N=2^15 keeps unlock under ~150 ms on
+# modern hardware while making brute-force expensive.
+_SCRYPT_N: int = 2**15
+_SCRYPT_R: int = 8
+_SCRYPT_P: int = 1
+_SCRYPT_LEN: int = 32  # 256-bit KEK
+_SALT_LEN: int = 32  # 256 bits of salt entropy
+
+
+class BadPassphraseError(SecurityError):
+    """Raised when ``unlock_store`` or ``change_passphrase`` is given a
+    passphrase that does not unwrap the stored master key.
+
+    Distinct from generic ``SecurityError`` so callers (REPL, REST,
+    MCP) can show a focused "wrong passphrase" message without
+    swallowing actual configuration / I/O errors.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Process-local unlocked-master cache
+# ---------------------------------------------------------------------------
+
+_unlock_lock = threading.Lock()
+# Per-owner cache so a multi-tenant test or future multi-user process can
+# unlock several stores independently. Keyed by the keyring "service" string.
+_unlocked_masters: dict[str, bytes] = {}
+
+
+def _owner_from_user_dir(user_dir: Path) -> str:
+    """The "owner" identity in the keyring service-name.
+
+    Uses the user_dir basename — matches the AxonStore convention
+    (``~/.axon/AxonStore/<owner>/...``). Tests can pass any user_dir.
+    """
+    name = Path(user_dir).name
+    if not name:
+        raise ValueError(f"user_dir has no basename: {user_dir!r}")
+    return name
+
+
+def _service(user_dir: Path) -> str:
+    return _kr.master_service(_owner_from_user_dir(user_dir))
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _unb64(text: str) -> bytes:
+    return base64.b64decode(text.encode("ascii"))
+
+
+def _derive_kek(passphrase: str, salt: bytes) -> bytes:
+    """scrypt(passphrase, salt) → 32-byte KEK."""
+    if not passphrase:
+        raise ValueError("passphrase must be a non-empty string")
+    if len(salt) != _SALT_LEN:
+        raise ValueError(f"salt must be {_SALT_LEN} bytes, got {len(salt)}")
+    return Scrypt(
+        salt=salt,
+        length=_SCRYPT_LEN,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+    ).derive(passphrase.encode("utf-8"))
+
+
+def _read_keyring_record(user_dir: Path) -> dict[str, Any] | None:
+    """Read the JSON keyring record; return None when not bootstrapped.
+
+    Raises ``SecurityError`` if the record exists but is malformed —
+    a defence-in-depth signal that the user's keyring may have been
+    tampered with.
+    """
+    raw = _kr.get_secret(_service(user_dir), MASTER_USERNAME)
+    if raw is None:
+        return None
+    try:
+        record: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SecurityError(
+            f"keyring record at {_service(user_dir)} is unparseable JSON ({exc}). "
+            "Manual recovery may be needed."
+        ) from exc
+    if not isinstance(record, dict) or record.get("v") != SCHEMA_VERSION:
+        raise SecurityError(
+            f"keyring record schema_version mismatch (expected {SCHEMA_VERSION}, "
+            f"got {record.get('v') if isinstance(record, dict) else type(record).__name__})."
+        )
+    return record
+
+
+def _write_keyring_record(user_dir: Path, *, salt: bytes, wrapped_master: bytes) -> None:
+    payload = json.dumps(
+        {
+            "v": SCHEMA_VERSION,
+            "salt": _b64(salt),
+            "wrapped": _b64(wrapped_master),
+        },
+        separators=(",", ":"),
+    )
+    _kr.store_secret(_service(user_dir), MASTER_USERNAME, payload)
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap / unlock / lock / change_passphrase
+# ---------------------------------------------------------------------------
+
+
+def is_bootstrapped(user_dir: Path) -> bool:
+    """Return True if a master record already exists in the keyring."""
+    try:
+        return _read_keyring_record(user_dir) is not None
+    except SecurityError:
+        # Malformed record → still "bootstrapped" but in a bad state;
+        # caller will get the same SecurityError on unlock.
+        return True
+
+
+def bootstrap_store(user_dir: Path, passphrase: str) -> dict[str, Any]:
+    """Initial setup — generate the master + persist its passphrase-wrapped form.
+
+    Raises:
+        SecurityError: the store is already bootstrapped (use
+            :func:`change_passphrase` to rotate, or wipe the keyring
+            entry first if you really mean to start over).
+        BadPassphraseError: the supplied passphrase is empty.
+
+    Returns a status dict with ``{"initialized": True, "owner": ...}``.
+    """
+    if not passphrase:
+        raise BadPassphraseError("passphrase must be a non-empty string")
+    if is_bootstrapped(user_dir):
+        raise SecurityError(
+            f"Store at {_service(user_dir)} is already bootstrapped. "
+            "Use change_passphrase to rotate, or delete the keyring entry "
+            "manually if you really mean to discard the master key."
+        )
+
+    master = generate_dek()  # 32 random bytes — never persisted in plaintext
+    salt = os.urandom(_SALT_LEN)
+    kek = _derive_kek(passphrase, salt)
+    wrapped = aes_key_wrap(kek, master)
+    _write_keyring_record(user_dir, salt=salt, wrapped_master=wrapped)
+
+    # Cache the master so the bootstrapping process is immediately
+    # unlocked — no need for the caller to re-supply the passphrase.
+    with _unlock_lock:
+        _unlocked_masters[_service(user_dir)] = master
+
+    logger.info(
+        "Sealed-store bootstrapped for owner=%s (keyring service=%s)",
+        _owner_from_user_dir(user_dir),
+        _service(user_dir),
+    )
+    return {
+        "initialized": True,
+        "owner": _owner_from_user_dir(user_dir),
+        "service": _service(user_dir),
+    }
+
+
+def unlock_store(user_dir: Path, passphrase: str) -> dict[str, Any]:
+    """Verify the passphrase, decrypt the master, cache it in this process."""
+    record = _read_keyring_record(user_dir)
+    if record is None:
+        raise SecurityError(
+            f"Store at {_service(user_dir)} is not bootstrapped. "
+            "Run bootstrap_store(user_dir, passphrase) first."
+        )
+    salt = _unb64(record["salt"])
+    wrapped = _unb64(record["wrapped"])
+    kek = _derive_kek(passphrase, salt)
+    try:
+        master = aes_key_unwrap(kek, wrapped)
+    except InvalidUnwrap as exc:
+        raise BadPassphraseError(f"Wrong passphrase for store {_service(user_dir)}.") from exc
+
+    with _unlock_lock:
+        _unlocked_masters[_service(user_dir)] = master
+
+    return {
+        "unlocked": True,
+        "owner": _owner_from_user_dir(user_dir),
+        "service": _service(user_dir),
+    }
+
+
+def lock_store(user_dir: Path) -> dict[str, Any]:
+    """Clear the in-memory cached master for this owner.
+
+    Subsequent DEK lookups will raise ``SecurityError("locked")`` until
+    :func:`unlock_store` is called again.
+    """
+    with _unlock_lock:
+        existed = _unlocked_masters.pop(_service(user_dir), None) is not None
+    return {
+        "locked": True,
+        "was_unlocked": existed,
+        "owner": _owner_from_user_dir(user_dir),
+    }
+
+
+def is_unlocked(user_dir: Path) -> bool:
+    """Return True if the master is cached in this process for *user_dir*."""
+    with _unlock_lock:
+        return _service(user_dir) in _unlocked_masters
+
+
+def change_passphrase(user_dir: Path, old_passphrase: str, new_passphrase: str) -> dict[str, Any]:
+    """Re-wrap the master under a fresh KEK derived from *new_passphrase*.
+
+    Project DEKs are NOT touched — they're wrapped under the master,
+    not the passphrase, so passphrase rotation costs O(1) regardless
+    of how many sealed projects the owner has.
+    """
+    if not new_passphrase:
+        raise BadPassphraseError("new_passphrase must be a non-empty string")
+    record = _read_keyring_record(user_dir)
+    if record is None:
+        raise SecurityError(f"Store at {_service(user_dir)} is not bootstrapped.")
+    salt = _unb64(record["salt"])
+    wrapped = _unb64(record["wrapped"])
+    kek_old = _derive_kek(old_passphrase, salt)
+    try:
+        master = aes_key_unwrap(kek_old, wrapped)
+    except InvalidUnwrap as exc:
+        raise BadPassphraseError(
+            f"Old passphrase did not unlock store {_service(user_dir)}."
+        ) from exc
+
+    new_salt = os.urandom(_SALT_LEN)
+    kek_new = _derive_kek(new_passphrase, new_salt)
+    new_wrapped = aes_key_wrap(kek_new, master)
+    _write_keyring_record(user_dir, salt=new_salt, wrapped_master=new_wrapped)
+
+    # Refresh in-memory cache (master is unchanged but the cache may
+    # have been cleared between unlock and change).
+    with _unlock_lock:
+        _unlocked_masters[_service(user_dir)] = master
+
+    return {
+        "rotated": True,
+        "owner": _owner_from_user_dir(user_dir),
+    }
+
+
+def get_master_key(user_dir: Path) -> bytes:
+    """Return the cached unlocked master key.
+
+    Raises:
+        SecurityError: the store is locked; call :func:`unlock_store`
+            first.
+    """
+    with _unlock_lock:
+        master = _unlocked_masters.get(_service(user_dir))
+    if master is None:
+        raise SecurityError(f"Store {_service(user_dir)} is locked. Call unlock_store first.")
+    return master
+
+
+# ---------------------------------------------------------------------------
+# Project DEK lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _project_dek_path(project_dir: Path) -> Path:
+    return Path(project_dir) / PROJECT_DEK_FILENAME
+
+
+def get_or_create_project_dek(user_dir: Path, project_dir: Path) -> bytes:
+    """Return the per-project DEK; create + persist on first call.
+
+    Reads ``<project_dir>/.security/dek.wrapped`` if present; unwraps
+    with the cached master and returns the 32-byte DEK. If absent,
+    generates a fresh DEK, wraps it under the master, writes the wrap
+    to disk atomically, and returns the new DEK.
+
+    Raises:
+        SecurityError: store is locked, or wrapped DEK exists but won't
+            unwrap (likely keyring/passphrase mismatch — the project
+            was sealed under a different master).
+    """
+    master = get_master_key(user_dir)
+    wrap_path = _project_dek_path(project_dir)
+
+    if wrap_path.is_file():
+        try:
+            dek: bytes = aes_key_unwrap(master, wrap_path.read_bytes())
+        except InvalidUnwrap as exc:
+            raise SecurityError(
+                f"Wrapped DEK at {wrap_path} won't unwrap with the current "
+                "master. The project was likely sealed under a different "
+                "master / owner; recovery requires the original passphrase."
+            ) from exc
+        if len(dek) != DEK_LEN:
+            raise SecurityError(
+                f"Wrapped DEK at {wrap_path} unwrapped to {len(dek)} bytes "
+                f"(expected {DEK_LEN}); manifest may be corrupted."
+            )
+        return dek
+
+    # No DEK yet — mint one, persist, return.
+    dek = generate_dek()
+    wrapped = wrap_key(dek, master)
+    wrap_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = wrap_path.with_suffix(wrap_path.suffix + ".sealing")
+    tmp.write_bytes(wrapped)
+    os.replace(tmp, wrap_path)
+    # Lock down the wrap file — only the owner needs to read it.
+    try:
+        os.chmod(wrap_path, 0o600)
+    except OSError:
+        # Windows: chmod is largely a no-op; ACL inheritance protects.
+        pass
+    logger.info(
+        "Generated new project DEK at %s (wrapped, %d bytes)",
+        wrap_path,
+        len(wrapped),
+    )
+    return dek
+
+
+def get_project_dek(user_dir: Path, project_dir: Path) -> bytes:
+    """Read the existing wrapped DEK; raise if it doesn't exist.
+
+    Use this on the read path (mount / open) where creating a new DEK
+    silently would be a bug — if the project file is gone the caller
+    needs to know.
+    """
+    wrap_path = _project_dek_path(project_dir)
+    if not wrap_path.is_file():
+        raise SecurityError(
+            f"Project DEK file missing at {wrap_path}. The project may not "
+            "be sealed, or the .security directory was deleted."
+        )
+    master = get_master_key(user_dir)
+    try:
+        dek: bytes = aes_key_unwrap(master, wrap_path.read_bytes())
+    except InvalidUnwrap as exc:
+        raise SecurityError(
+            f"Wrapped DEK at {wrap_path} won't unwrap with the current " "master."
+        ) from exc
+    return dek
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+
+def _self_check(user_dir: Path | None = None) -> dict[str, Any]:
+    """Diagnostic round-trip used by future ``axon doctor`` output.
+
+    Uses an isolated temp dir + a synthetic owner so the user's real
+    keyring is not touched. Never raises.
+    """
+    import tempfile
+
+    out: dict[str, Any] = {"ok": False, "details": ""}
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            ud = Path(td) / "selfcheck-owner"
+            ud.mkdir()
+            # Use a unique service to avoid stomping a real user's keyring
+            # entry — same code path but different keyring slot.
+            unique_service = f"axon.master.__selfcheck_{os.getpid()}"
+
+            # Stash the original master_service to restore later.
+            original = _kr.master_service
+            _kr.master_service = lambda owner: unique_service  # type: ignore[assignment]
+            try:
+                bootstrap_store(ud, "selfcheck-passphrase")
+                if not is_unlocked(ud):
+                    out["details"] = "is_unlocked False after bootstrap"
+                    return out
+                lock_store(ud)
+                if is_unlocked(ud):
+                    out["details"] = "is_unlocked True after lock"
+                    return out
+                unlock_store(ud, "selfcheck-passphrase")
+                # Per-project DEK round-trip.
+                proj = ud / "proj"
+                proj.mkdir()
+                dek1 = get_or_create_project_dek(ud, proj)
+                dek2 = get_or_create_project_dek(ud, proj)  # idempotent
+                if dek1 != dek2:
+                    out["details"] = "DEK changed across two get_or_create calls"
+                    return out
+                # Bad-passphrase rejection.
+                lock_store(ud)
+                try:
+                    unlock_store(ud, "wrong-passphrase")
+                    out["details"] = "wrong passphrase did not raise"
+                    return out
+                except BadPassphraseError:
+                    pass
+            finally:
+                _kr.master_service = original  # type: ignore[assignment]
+                # Best-effort cleanup of the test keyring entry.
+                try:
+                    _kr.delete_secret(unique_service, MASTER_USERNAME)
+                except Exception:
+                    pass
+        out["ok"] = True
+        out["details"] = "bootstrap / unlock / lock / DEK round-trip OK"
+    except Exception as exc:  # pragma: no cover — defensive
+        out["details"] = f"self-check raised: {type(exc).__name__}: {exc}"
+    return out

--- a/src/axon/security/master.py
+++ b/src/axon/security/master.py
@@ -455,7 +455,7 @@ def _self_check(user_dir: Path | None = None) -> dict[str, Any]:
 
             # Stash the original master_service to restore later.
             original = _kr.master_service
-            _kr.master_service = lambda owner: unique_service  # type: ignore[assignment]
+            _kr.master_service = lambda owner: unique_service
             try:
                 bootstrap_store(ud, "selfcheck-passphrase")
                 if not is_unlocked(ud):
@@ -483,7 +483,7 @@ def _self_check(user_dir: Path | None = None) -> dict[str, Any]:
                 except BadPassphraseError:
                     pass
             finally:
-                _kr.master_service = original  # type: ignore[assignment]
+                _kr.master_service = original
                 # Best-effort cleanup of the test keyring entry.
                 try:
                     _kr.delete_secret(unique_service, MASTER_USERNAME)

--- a/src/axon/security/mount.py
+++ b/src/axon/security/mount.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from . import SecurityError
 from .cache import SealedCache
-from .master import get_or_create_project_dek
+from .master import get_project_dek
 from .seal import is_project_sealed, read_sealed_marker
 
 logger = logging.getLogger("Axon")
@@ -94,8 +94,11 @@ def materialize_for_read(
             "The project may have been sealed by an older incompatible version."
         )
 
-    # Raises SecurityError("…locked…") if the store is not unlocked.
-    dek = get_or_create_project_dek(user_dir, project_dir)
+    # Read-only DEK lookup. Refuses to mint a fresh DEK if dek.wrapped
+    # is missing — silently creating a new DEK on the read path would
+    # make the existing ciphertext permanently undecryptable. Raises
+    # SecurityError on locked store OR on missing DEK file.
+    dek = get_project_dek(user_dir, project_dir)
 
     try:
         cache = SealedCache.create(

--- a/src/axon/security/mount.py
+++ b/src/axon/security/mount.py
@@ -1,0 +1,132 @@
+"""Sealed-project mount glue (Phase 2 of #SEALED).
+
+Translates "open this sealed project for reading" into a concrete
+plaintext directory the existing TurboQuantDB / LanceDB / BM25
+backends can mmap. The actual mechanics live elsewhere:
+
+- :mod:`axon.security.master` — supplies the per-project DEK, gated
+  on the store being unlocked.
+- :mod:`axon.security.seal` — supplies the on-disk sealed marker
+  (``.security/.sealed``) which carries the ``seal_id`` used as the
+  GCM AAD's key_id position.
+- :mod:`axon.security.cache` — does the actual decrypt-into-tempdir
+  + secure wipe.
+
+Why the indirection: ``AxonBrain.switch_project`` shouldn't need to
+know about scrypt, AES-GCM, or PID sentinels. It just asks
+:func:`materialize_for_read` for a path, points its backends at it,
+and calls :func:`release_cache` on close. Everything else stays
+inside ``axon.security``.
+
+This module is imported lazily by ``main.py`` so installs without
+the ``[sealed]`` extra continue to import cleanly.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from . import SecurityError
+from .cache import SealedCache
+from .master import get_or_create_project_dek
+from .seal import is_project_sealed, read_sealed_marker
+
+logger = logging.getLogger("Axon")
+
+__all__ = [
+    "materialize_for_read",
+    "release_cache",
+]
+
+
+def materialize_for_read(
+    project_dir: Path | str,
+    user_dir: Path | str,
+    *,
+    cache_root: Path | str | None = None,
+) -> SealedCache:
+    """Decrypt a sealed project into an ephemeral cache + return the handle.
+
+    The returned :class:`SealedCache` exposes ``cache.path`` — point
+    every backend constructor at that path instead of *project_dir*.
+    Call :func:`release_cache` (or use the cache as a context manager)
+    when the brain closes the project to wipe the plaintext.
+
+    Args:
+        project_dir: The owner's on-disk project directory (the same
+            path that would be opened directly in the unsealed flow).
+        user_dir: The owner's AxonStore user directory — needed to
+            locate the keyring service and cached master.
+        cache_root: Override the OS temp dir for the cache (mostly for
+            tests; production should leave it as None).
+
+    Returns:
+        A live :class:`SealedCache` whose ``path`` contains plaintext
+        copies of every sealed content file plus the project's
+        passthrough plaintext files (``version.json``, ``store_meta.json``,
+        ``.security/`` contents).
+
+    Raises:
+        SecurityError: project is not sealed, or the store is locked,
+            or the sealed marker is missing/malformed, or any underlying
+            decryption fails (caller sees one error type rather than
+            three different exception classes from three modules).
+    """
+    project_dir = Path(project_dir)
+    user_dir = Path(user_dir)
+
+    if not is_project_sealed(project_dir):
+        raise SecurityError(
+            f"materialize_for_read called on a non-sealed project at "
+            f"{project_dir}. Call this only after is_project_sealed "
+            "returns True."
+        )
+
+    marker = read_sealed_marker(project_dir)
+    if marker is None:
+        # Defensive — is_project_sealed was True so the marker file
+        # exists, but it disappeared in the gap (race with a wipe?).
+        raise SecurityError(f"Sealed marker disappeared between probe and read at {project_dir}.")
+    seal_id = marker.get("seal_id", "")
+    if not isinstance(seal_id, str) or not seal_id:
+        raise SecurityError(
+            f"Sealed marker at {project_dir} has no seal_id; refusing to mount. "
+            "The project may have been sealed by an older incompatible version."
+        )
+
+    # Raises SecurityError("…locked…") if the store is not unlocked.
+    dek = get_or_create_project_dek(user_dir, project_dir)
+
+    try:
+        cache = SealedCache.create(
+            project_dir,
+            dek,
+            key_id=seal_id,
+            cache_root=cache_root,
+        )
+    except Exception as exc:
+        # Unify the exception surface for callers — they already
+        # handle SecurityError; everything else (InvalidTag,
+        # CacheCapacityError, OSError) gets wrapped.
+        raise SecurityError(
+            f"Failed to materialise sealed project {project_dir}: " f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    logger.info(
+        "materialize_for_read: %s mounted at %s (seal_id=%s)",
+        project_dir,
+        cache.path,
+        seal_id,
+    )
+    return cache
+
+
+def release_cache(cache: SealedCache | None) -> None:
+    """Securely wipe *cache* if it exists; safe on ``None``.
+
+    Convenience wrapper so ``AxonBrain.close`` and similar callers can
+    do ``release_cache(self._sealed_cache)`` without a None-guard.
+    """
+    if cache is None:
+        return
+    cache.wipe()

--- a/src/axon/security/seal.py
+++ b/src/axon/security/seal.py
@@ -65,8 +65,15 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 SEALED_MARKER_PATH: str = ".security/.sealed"
+SEALING_INPROGRESS_PATH: str = ".security/.sealing"
 SEAL_SCHEMA_VERSION: int = 1
 CIPHER_SUITE_AES_256_GCM_V1: str = "AES-256-GCM-v1"
+
+# Vector store segment files routinely run 100 MB+ but should not exceed a
+# few hundred MB; refuse anything wildly larger so we don't OOM the seal
+# process. Streaming AES-GCM (CipherContext + chunked I/O) is tracked as
+# follow-up work — until then, keep the safety net.
+_SEAL_MAX_FILE_BYTES: int = 1024 * 1024 * 1024  # 1 GiB
 
 # Content directories whose every file gets sealed. Anything OUTSIDE
 # this set + the explicit single-file allowlist below stays plaintext.
@@ -184,16 +191,67 @@ def _cleanup_sealing_orphans(project_dir: Path) -> int:
     rename hadn't happened) so the orphan is just dead weight; remove
     it before re-sealing.
 
+    Skips the in-progress seal context file (``.security/.sealing``) —
+    that one is intentionally kept across crashes so the resume can
+    re-use the same ``seal_id``.
+
     Returns the number of orphans removed.
     """
     removed = 0
+    inprogress = project_dir / SEALING_INPROGRESS_PATH
     for orphan in project_dir.rglob("*.sealing"):
+        if orphan == inprogress:
+            continue  # the resume context — leave alone
         try:
             orphan.unlink()
             removed += 1
         except OSError as exc:
             logger.debug("could not remove .sealing orphan %s: %s", orphan, exc)
     return removed
+
+
+def _read_inprogress_seal_id(project_dir: Path) -> str | None:
+    """Return the persisted resume ``seal_id`` if a prior seal crashed.
+
+    The file is written via :func:`_write_inprogress_seal_id` BEFORE any
+    file is encrypted, so a crash leaves the seal_id on disk for the
+    next attempt to pick up. Mismatched / malformed files are treated
+    as "no resume context" and the caller mints a fresh seal_id (the
+    pre-existing AXSL files are then unrecoverable, which surfaces as
+    InvalidTag at mount time — better than silent corruption).
+    """
+    path = project_dir / SEALING_INPROGRESS_PATH
+    if not path.is_file():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(record, dict):
+        return None
+    if record.get("v") != SEAL_SCHEMA_VERSION:
+        return None
+    seal_id = record.get("seal_id")
+    return seal_id if isinstance(seal_id, str) and seal_id else None
+
+
+def _write_inprogress_seal_id(project_dir: Path, seal_id: str) -> None:
+    """Persist the seal_id BEFORE encrypting any file (resume safety)."""
+    path = project_dir / SEALING_INPROGRESS_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"v": SEAL_SCHEMA_VERSION, "seal_id": seal_id})
+    tmp = path.with_suffix(path.suffix + ".write")
+    tmp.write_text(payload, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _remove_inprogress_seal_id(project_dir: Path) -> None:
+    """Clean up the resume context after a successful seal."""
+    path = project_dir / SEALING_INPROGRESS_PATH
+    try:
+        path.unlink()
+    except OSError:
+        pass  # absent or in use — best-effort, won't impact correctness
 
 
 # ---------------------------------------------------------------------------
@@ -279,9 +337,21 @@ def project_seal(
 
     # Stable seal_id used as the AAD's key_id position so that files
     # cannot be swapped between two projects sealed with the same
-    # owner master. Persisted in the marker so the read path can
-    # recompute the AAD.
-    seal_id = "seal_" + secrets.token_hex(8)
+    # owner master. Persisted in .security/.sealing BEFORE any file is
+    # encrypted so a crash mid-seal can re-use the same seal_id on
+    # resume — otherwise already-sealed files would have AADs that no
+    # longer match the marker's seal_id and become undecryptable.
+    resumed_seal_id = _read_inprogress_seal_id(project_dir)
+    if resumed_seal_id:
+        seal_id = resumed_seal_id
+        logger.info(
+            "project_seal: resuming prior crashed seal of %s (seal_id=%s)",
+            project_name,
+            seal_id,
+        )
+    else:
+        seal_id = "seal_" + secrets.token_hex(8)
+        _write_inprogress_seal_id(project_dir, seal_id)
 
     files_sealed = 0
     files_skipped = 0
@@ -295,10 +365,27 @@ def project_seal(
             files_skipped += 1
             continue
         if is_sealed_file(src):
-            # Resumed after a crash — file already encrypted.
+            # Resumed after a crash — file already encrypted under the
+            # SAME seal_id (we just persisted/recovered it above), so
+            # the AAD will validate at mount time.
             files_already_sealed += 1
             files_sealed += 1
             continue
+
+        # Refuse oversized files — full read into memory would OOM. The
+        # streaming path is tracked as future work; for now, surface a
+        # clear error rather than crash the process.
+        try:
+            size = src.stat().st_size
+        except OSError:
+            size = 0
+        if size > _SEAL_MAX_FILE_BYTES:
+            raise SecurityError(
+                f"project_seal refusing to seal {src} ({size:,} bytes); "
+                f"current implementation reads the file into memory and the "
+                f"per-file limit is {_SEAL_MAX_FILE_BYTES:,} bytes. Streaming "
+                "encryption is tracked as follow-up work."
+            )
 
         plaintext = src.read_bytes()
         aad = make_aad(seal_id, str(rel).replace("\\", "/"))
@@ -321,6 +408,8 @@ def project_seal(
         files_sealed=files_sealed,
         files_skipped=files_skipped,
     )
+    # Marker persisted — clean up the resume context.
+    _remove_inprogress_seal_id(project_dir)
 
     logger.info(
         "project_seal: %s sealed (%d files; %d skipped; %d already-sealed; "

--- a/src/axon/security/seal.py
+++ b/src/axon/security/seal.py
@@ -1,0 +1,362 @@
+"""``axon project seal <name>`` — encrypt every content file in a project (Phase 2).
+
+Walks an existing plaintext project directory and rewrites each
+content file as AXSL-sealed ciphertext using the project's DEK. The
+operation is **atomic per file**: each file is written to a sibling
+``<name>.sealing`` tempfile, fsynced, then ``os.replace``'d over the
+live name — so a crash mid-seal leaves the original file intact (or
+fully sealed) but never partially overwritten.
+
+What gets sealed (per ``docs/SHARE_MOUNT_SEALED.md`` §4.6):
+  - ``meta.json``
+  - everything under ``bm25_index/``
+  - everything under ``vector_store_data/``
+  - the dynamic-graph snapshot (``.dynamic_graph.snapshot.json``)
+
+What stays plaintext:
+  - ``version.json`` (grantees need to detect changes without the DEK)
+  - ``.security/`` (the wrap files themselves, plus the sealed marker)
+  - ``store_meta.json`` (AxonStore root metadata)
+  - Anything else not in a content directory (config files, logs, etc.)
+
+After a successful seal, ``.security/.sealed`` is written as a
+plaintext JSON marker so :func:`is_project_sealed` can probe the
+state without any key material.
+
+Idempotency:
+  - If ``.security/.sealed`` already exists, ``project_seal`` returns
+    ``{"status": "already_sealed"}`` without touching files.
+  - If individual files are already AXSL-headered (mid-seal crash
+    recovery), they're skipped and counted as ``files_already_sealed``.
+  - Leftover ``.sealing`` orphans from a crashed prior attempt are
+    removed before sealing begins.
+
+Phase 2 part 3. Replaces the ``project_seal`` and
+``get_sealed_project_record`` stubs in ``axon/security/__init__.py``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+from . import SecurityError
+from .cache import is_sealed_file
+from .crypto import SealedFile, make_aad
+from .master import get_or_create_project_dek
+
+logger = logging.getLogger("Axon")
+
+__all__ = [
+    "SEALED_MARKER_PATH",
+    "SEAL_SCHEMA_VERSION",
+    "CIPHER_SUITE_AES_256_GCM_V1",
+    "is_project_sealed",
+    "read_sealed_marker",
+    "project_seal",
+    "get_sealed_project_record",
+]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SEALED_MARKER_PATH: str = ".security/.sealed"
+SEAL_SCHEMA_VERSION: int = 1
+CIPHER_SUITE_AES_256_GCM_V1: str = "AES-256-GCM-v1"
+
+# Content directories whose every file gets sealed. Anything OUTSIDE
+# this set + the explicit single-file allowlist below stays plaintext.
+_SEAL_CONTENT_DIRS: frozenset[str] = frozenset(
+    {
+        "bm25_index",
+        "vector_store_data",
+    }
+)
+
+# Single files at the project root that get sealed.
+_SEAL_ROOT_FILES: frozenset[str] = frozenset(
+    {
+        "meta.json",
+        ".dynamic_graph.snapshot.json",  # may live under bm25_index too — caught by dir rule
+    }
+)
+
+# Explicitly NEVER seal — these need to stay plaintext for the
+# refresh-marker / store-meta probes to work without unlocking.
+_NEVER_SEAL_DIRS: frozenset[str] = frozenset({".security"})
+_NEVER_SEAL_NAMES: frozenset[str] = frozenset(
+    {
+        "version.json",
+        "store_meta.json",
+        ".sealed",
+    }
+)
+
+
+def _should_seal(rel: Path) -> bool:
+    """Decide whether to encrypt a file at *rel* (relative to project_dir)."""
+    if rel.name in _NEVER_SEAL_NAMES:
+        return False
+    if any(part in _NEVER_SEAL_DIRS for part in rel.parts):
+        return False
+    if rel.parts and rel.parts[0] in _SEAL_CONTENT_DIRS:
+        return True
+    if len(rel.parts) == 1 and rel.name in _SEAL_ROOT_FILES:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Sealed marker
+# ---------------------------------------------------------------------------
+
+
+def is_project_sealed(project_dir: Path | str) -> bool:
+    """Return True iff ``<project>/.security/.sealed`` exists.
+
+    Cheap probe — does not require an unlocked store. Used by
+    :func:`get_sealed_project_record` and by api_routes/shares to
+    decide whether the sealed-share code path applies to a project.
+    """
+    return (Path(project_dir) / SEALED_MARKER_PATH).is_file()
+
+
+def read_sealed_marker(project_dir: Path | str) -> dict[str, Any] | None:
+    """Read the sealed marker JSON; return ``None`` when absent.
+
+    Raises ``SecurityError`` if the file exists but is malformed —
+    that's a defence-in-depth signal worth surfacing to the user
+    (someone may have tampered with ``.security/``).
+    """
+    path = Path(project_dir) / SEALED_MARKER_PATH
+    if not path.is_file():
+        return None
+    try:
+        marker: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SecurityError(
+            f"Sealed marker at {path} is unreadable / malformed ({exc}). "
+            "Manual recovery may be needed."
+        ) from exc
+    if not isinstance(marker, dict) or marker.get("v") != SEAL_SCHEMA_VERSION:
+        raise SecurityError(
+            f"Sealed marker schema_version mismatch at {path} "
+            f"(expected {SEAL_SCHEMA_VERSION}, got {marker.get('v') if isinstance(marker, dict) else type(marker).__name__})."
+        )
+    return marker
+
+
+def _write_sealed_marker(
+    project_dir: Path, *, seal_id: str, files_sealed: int, files_skipped: int
+) -> None:
+    """Write the plaintext sealed marker after a successful seal."""
+    from datetime import datetime, timezone
+
+    marker = {
+        "v": SEAL_SCHEMA_VERSION,
+        "cipher_suite": CIPHER_SUITE_AES_256_GCM_V1,
+        "seal_id": seal_id,
+        "sealed_at": datetime.now(tz=timezone.utc).isoformat(),
+        "files_sealed": files_sealed,
+        "files_skipped": files_skipped,
+    }
+    target = project_dir / SEALED_MARKER_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".sealing")
+    tmp.write_text(json.dumps(marker, indent=2), encoding="utf-8")
+    os.replace(tmp, target)
+
+
+# ---------------------------------------------------------------------------
+# Crash-recovery: clean up .sealing tempfiles from a prior failed attempt
+# ---------------------------------------------------------------------------
+
+
+def _cleanup_sealing_orphans(project_dir: Path) -> int:
+    """Delete any ``*.sealing`` orphans under *project_dir*.
+
+    A previous ``project_seal`` may have crashed between the tempfile
+    write and the ``os.replace``. The original file is intact (atomic
+    rename hadn't happened) so the orphan is just dead weight; remove
+    it before re-sealing.
+
+    Returns the number of orphans removed.
+    """
+    removed = 0
+    for orphan in project_dir.rglob("*.sealing"):
+        try:
+            orphan.unlink()
+            removed += 1
+        except OSError as exc:
+            logger.debug("could not remove .sealing orphan %s: %s", orphan, exc)
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# project_seal
+# ---------------------------------------------------------------------------
+
+
+def _resolve_project_dir(project_name: str, user_dir: Path) -> Path:
+    """Mirror the AxonStore subs/ layout for nested projects.
+
+    ``research/papers`` → ``<user_dir>/research/subs/papers``
+    """
+    segments = project_name.split("/")
+    project_dir = Path(user_dir) / segments[0]
+    for seg in segments[1:]:
+        project_dir = project_dir / "subs" / seg
+    return project_dir
+
+
+def project_seal(
+    project_name: str,
+    user_dir: Path,
+    *,
+    migration_mode: str = "in_place",
+    config: Any = None,
+    embedding: Any = None,
+) -> dict[str, Any]:
+    """Encrypt every content file in *project_name* in place.
+
+    Idempotent — if the project is already sealed, returns immediately
+    with ``status="already_sealed"``. On a crashed prior attempt, any
+    individually-sealed files are kept (skipped on re-run) and any
+    ``.sealing`` orphans are removed.
+
+    Args:
+        project_name: Project name as used in the AxonStore (supports
+            the ``parent/child`` nested form).
+        user_dir: AxonStore user directory (``~/.axon/AxonStore/<owner>``).
+        migration_mode: Reserved for future variants — only ``"in_place"``
+            is implemented in v1. Other values are accepted for
+            backward-compat with the existing api_routes signature but
+            currently have no effect.
+        config: Reserved for future variants (e.g. backend-specific
+            re-build during seal).
+        embedding: Reserved for future variants.
+
+    Returns:
+        ``{"status": "sealed" | "already_sealed", "project": ...,
+        "files_sealed": int, "files_skipped": int, "orphans_removed": int}``
+
+    Raises:
+        SecurityError: store is locked (call ``unlock_store`` first), or
+            project does not exist, or any file write failed.
+    """
+    project_dir = _resolve_project_dir(project_name, Path(user_dir))
+    if not project_dir.is_dir():
+        raise SecurityError(
+            f"Project does not exist: {project_dir} "
+            "(check the project name and that AxonStore is initialised)"
+        )
+
+    if is_project_sealed(project_dir):
+        existing = read_sealed_marker(project_dir) or {}
+        return {
+            "status": "already_sealed",
+            "project": project_name,
+            "seal_id": existing.get("seal_id", ""),
+        }
+
+    # Get/create the per-project DEK. Raises SecurityError if the
+    # store is locked — surfaces upward to the caller.
+    dek = get_or_create_project_dek(Path(user_dir), project_dir)
+
+    # Crash-recovery: drop any leftover .sealing tempfiles before we
+    # start writing new ones.
+    orphans_removed = _cleanup_sealing_orphans(project_dir)
+    if orphans_removed:
+        logger.info(
+            "project_seal: removed %d leftover .sealing orphan(s) under %s",
+            orphans_removed,
+            project_dir,
+        )
+
+    # Stable seal_id used as the AAD's key_id position so that files
+    # cannot be swapped between two projects sealed with the same
+    # owner master. Persisted in the marker so the read path can
+    # recompute the AAD.
+    seal_id = "seal_" + secrets.token_hex(8)
+
+    files_sealed = 0
+    files_skipped = 0
+    files_already_sealed = 0
+
+    for src in project_dir.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(project_dir)
+        if not _should_seal(rel):
+            files_skipped += 1
+            continue
+        if is_sealed_file(src):
+            # Resumed after a crash — file already encrypted.
+            files_already_sealed += 1
+            files_sealed += 1
+            continue
+
+        plaintext = src.read_bytes()
+        aad = make_aad(seal_id, str(rel).replace("\\", "/"))
+        tmp = src.with_suffix(src.suffix + ".sealing")
+        try:
+            SealedFile.write(tmp, plaintext, dek, aad=aad)
+            os.replace(tmp, src)
+        except OSError as exc:
+            # Clean up the failed tempfile before propagating.
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise SecurityError(f"project_seal failed to atomically replace {src}: {exc}") from exc
+        files_sealed += 1
+
+    _write_sealed_marker(
+        project_dir,
+        seal_id=seal_id,
+        files_sealed=files_sealed,
+        files_skipped=files_skipped,
+    )
+
+    logger.info(
+        "project_seal: %s sealed (%d files; %d skipped; %d already-sealed; "
+        "%d orphans removed; seal_id=%s)",
+        project_name,
+        files_sealed,
+        files_skipped,
+        files_already_sealed,
+        orphans_removed,
+        seal_id,
+    )
+    return {
+        "status": "sealed",
+        "project": project_name,
+        "seal_id": seal_id,
+        "files_sealed": files_sealed,
+        "files_already_sealed": files_already_sealed,
+        "files_skipped": files_skipped,
+        "orphans_removed": orphans_removed,
+    }
+
+
+def get_sealed_project_record(project: str, user_dir: Path) -> dict[str, Any] | None:
+    """Cheap probe: return the marker dict if sealed, else ``None``.
+
+    Used by api_routes/shares.py to decide whether a share should go
+    through the sealed-share generation path. Does NOT require an
+    unlocked store.
+    """
+    project_dir = _resolve_project_dir(project, Path(user_dir))
+    if not is_project_sealed(project_dir):
+        return None
+    try:
+        return read_sealed_marker(project_dir)
+    except SecurityError:
+        # Marker exists but is malformed — surface as "not sealed" for
+        # the share routing decision; the actual unlock attempt will
+        # surface the underlying SecurityError with full context.
+        return None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -57,6 +57,13 @@ EXPECTED_MCP_TOOL_NAMES = {
     "list_shares",
     "init_store",
     "get_store_status",
+    # Sealed-store (Phase 2 of #SEALED)
+    "security_status",
+    "security_bootstrap",
+    "security_unlock",
+    "security_lock",
+    "security_change_passphrase",
+    "seal_project",
     # Graph
     "graph_status",
     "graph_finalize",

--- a/tests/test_project_seal.py
+++ b/tests/test_project_seal.py
@@ -1,0 +1,327 @@
+"""Phase 2: project_seal end-to-end tests.
+
+Covers ``axon.security.seal`` and the wired ``project_seal`` /
+``get_sealed_project_record`` entry points in ``axon.security``.
+
+Skips when ``cryptography`` / ``keyring`` aren't installed (the
+``sealed`` extra hasn't been pulled in).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("cryptography")
+pytest.importorskip("keyring")
+
+from axon import security as _security  # noqa: E402
+from axon.security.cache import is_sealed_file  # noqa: E402
+from axon.security.master import bootstrap_store, lock_store  # noqa: E402
+from axon.security.seal import (  # noqa: E402
+    SEALED_MARKER_PATH,
+    is_project_sealed,
+    project_seal,
+    read_sealed_marker,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures: in-memory keyring + a populated plaintext project
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryKeyring:
+    priority = 1
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, username, secret):
+        self._store[(service, username)] = secret
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def delete_password(self, service, username):
+        import keyring.errors
+
+        if (service, username) not in self._store:
+            raise keyring.errors.PasswordDeleteError("not found")
+        del self._store[(service, username)]
+
+
+@pytest.fixture
+def kr_backend():
+    backend = _InMemoryKeyring()
+    with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+        from axon.security import master as _master_mod
+
+        _master_mod._unlocked_masters.clear()
+        yield backend
+        _master_mod._unlocked_masters.clear()
+
+
+@pytest.fixture
+def user_dir(tmp_path):
+    ud = tmp_path / "alice"
+    ud.mkdir()
+    return ud
+
+
+def _populate_plaintext_project(user_dir: Path, project: str = "research") -> Path:
+    """Write a representative project layout with both content + non-content files."""
+    proj = user_dir / project
+    (proj / "bm25_index").mkdir(parents=True)
+    (proj / "vector_store_data").mkdir(parents=True)
+    (proj / ".security").mkdir(parents=True)  # mirror real layout
+
+    (proj / "meta.json").write_text('{"project_id": "p1", "name": "research"}', encoding="utf-8")
+    (proj / "version.json").write_text('{"seq": 1}', encoding="utf-8")  # plaintext
+    (proj / "bm25_index" / ".bm25_log.jsonl").write_text('{"id":"d1"}\n', encoding="utf-8")
+    (proj / "vector_store_data" / "manifest.json").write_text('{"d":768}', encoding="utf-8")
+    (proj / "vector_store_data" / "seg-00000001.bin").write_bytes(b"\x01" * 4096)
+    return proj
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + missing project + locked store
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSealEntryPath:
+    def test_missing_project_raises(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        with pytest.raises(_security.SecurityError, match="does not exist"):
+            project_seal("does-not-exist", user_dir)
+
+    def test_locked_store_raises(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        _populate_plaintext_project(user_dir)
+        lock_store(user_dir)
+        with pytest.raises(_security.SecurityError, match="locked"):
+            project_seal("research", user_dir)
+
+    def test_already_sealed_is_no_op(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        first = project_seal("research", user_dir)
+        assert first["status"] == "sealed"
+        assert first["files_sealed"] >= 4
+
+        # Second call must be a no-op.
+        second = project_seal("research", user_dir)
+        assert second["status"] == "already_sealed"
+        # Files still sealed (not double-sealed → not corrupted).
+        assert is_sealed_file(proj / "meta.json")
+
+
+# ---------------------------------------------------------------------------
+# What gets sealed vs left plaintext
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSealCoverage:
+    def test_meta_json_is_sealed(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        assert is_sealed_file(proj / "meta.json")
+
+    def test_bm25_files_sealed(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        assert is_sealed_file(proj / "bm25_index" / ".bm25_log.jsonl")
+
+    def test_vector_store_files_sealed(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        assert is_sealed_file(proj / "vector_store_data" / "manifest.json")
+        assert is_sealed_file(proj / "vector_store_data" / "seg-00000001.bin")
+
+    def test_version_json_stays_plaintext(self, kr_backend, user_dir):
+        """Grantees need to detect changes without the DEK — so version.json
+        is deliberately NOT sealed (per docs/SHARE_MOUNT_SEALED.md §4.6)."""
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        assert not is_sealed_file(proj / "version.json")
+        assert (proj / "version.json").read_text(encoding="utf-8") == '{"seq": 1}'
+
+    def test_security_dir_not_sealed(self, kr_backend, user_dir):
+        """The wrap files in .security/ must stay plaintext — they contain
+        no plaintext secrets themselves (DEK is wrapped) but sealing them
+        would cause a chicken-and-egg unwrap loop."""
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        # The dek.wrapped file is binary AES-KW output (40 bytes), NOT
+        # AXSL-headered. Verify the project_seal didn't accidentally
+        # AXSL-wrap it.
+        assert not is_sealed_file(proj / ".security" / "dek.wrapped")
+
+
+# ---------------------------------------------------------------------------
+# Sealed marker + get_sealed_project_record
+# ---------------------------------------------------------------------------
+
+
+class TestSealedMarker:
+    def test_marker_written_after_seal(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        marker = proj / SEALED_MARKER_PATH
+        assert marker.is_file()
+
+    def test_is_project_sealed_true_after_seal(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        assert is_project_sealed(proj) is False
+        project_seal("research", user_dir)
+        assert is_project_sealed(proj) is True
+
+    def test_read_sealed_marker_has_required_fields(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        result = project_seal("research", user_dir)
+        marker = read_sealed_marker(proj)
+        assert marker is not None
+        assert marker["v"] == 1
+        assert marker["cipher_suite"] == "AES-256-GCM-v1"
+        assert marker["seal_id"] == result["seal_id"]
+        assert "sealed_at" in marker
+        assert marker["files_sealed"] == result["files_sealed"]
+
+    def test_read_sealed_marker_returns_none_when_unsealed(self, tmp_path):
+        assert read_sealed_marker(tmp_path) is None
+
+    def test_read_sealed_marker_raises_on_malformed(self, kr_backend, user_dir):
+        proj = _populate_plaintext_project(user_dir)
+        marker = proj / SEALED_MARKER_PATH
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("{not json", encoding="utf-8")
+        with pytest.raises(_security.SecurityError, match="malformed"):
+            read_sealed_marker(proj)
+
+    def test_get_sealed_project_record_returns_marker(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        record = _security.get_sealed_project_record("research", user_dir)
+        assert record is not None
+        assert record["cipher_suite"] == "AES-256-GCM-v1"
+
+    def test_get_sealed_project_record_returns_none_when_unsealed(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        _populate_plaintext_project(user_dir)
+        assert _security.get_sealed_project_record("research", user_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# Atomicity + crash-recovery
+# ---------------------------------------------------------------------------
+
+
+class TestSealAtomicity:
+    def test_no_sealing_tempfiles_left_after_success(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        leftover = list(proj.rglob("*.sealing"))
+        assert leftover == []
+
+    def test_orphan_sealing_files_removed_on_resume(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        # Simulate a crashed prior attempt: leave a .sealing orphan.
+        orphan = proj / "vector_store_data" / "seg-00000001.bin.sealing"
+        orphan.write_bytes(b"junk-from-crashed-seal")
+
+        result = project_seal("research", user_dir)
+        assert result["orphans_removed"] == 1
+        assert not orphan.exists()
+
+    def test_partial_seal_resumes_skips_already_sealed_files(self, kr_backend, user_dir):
+        """If the prior run sealed some files before crashing, those files
+        already have an AXSL header. A re-run must not double-seal them."""
+        from axon.security.crypto import SealedFile, make_aad
+
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        # Hand-seal one file with a different DEK to simulate the
+        # "partial prior run" condition. Only the magic header check
+        # should matter — content is overwritten on next full seal? No,
+        # the resume path SKIPS already-sealed files and trusts them.
+        # So we must seal it with the SAME DEK that project_seal will
+        # derive — that means we have to pre-bootstrap and grab the DEK
+        # first.
+        from axon.security.master import get_or_create_project_dek
+
+        dek = get_or_create_project_dek(user_dir, proj)
+        rel = "bm25_index/.bm25_log.jsonl"
+        target = proj / rel
+        target.write_bytes(b"")  # blank it so the existing read doesn't matter
+        # Note: we need the seal_id from project_seal's marker write,
+        # but project_seal generates it fresh. So pre-sealing with a
+        # synthetic key_id will FAIL to decrypt later. To test the
+        # "already sealed → skipped" branch correctly, just verify the
+        # files_already_sealed counter increments when ANY file is
+        # AXSL-headered going in.
+        SealedFile.write(target, b"prior-payload", dek, aad=make_aad("synthetic", rel))
+
+        result = project_seal("research", user_dir)
+        # Already-sealed file counted but NOT re-encrypted with the new
+        # AAD. The counter increments per file that started AXSL.
+        assert result["files_already_sealed"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Files actually contain ciphertext (smoke check)
+# ---------------------------------------------------------------------------
+
+
+class TestSealedContentIsCiphertext:
+    def test_meta_json_no_longer_readable_as_plaintext(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        # On-disk bytes of meta.json must NOT contain the original
+        # plaintext substring "project_id".
+        sealed_bytes = (proj / "meta.json").read_bytes()
+        assert b"project_id" not in sealed_bytes
+        # And starts with the AXSL magic.
+        assert sealed_bytes[:4] == b"AXSL"
+
+    def test_vector_store_segment_no_longer_readable(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        project_seal("research", user_dir)
+        sealed_bytes = (proj / "vector_store_data" / "seg-00000001.bin").read_bytes()
+        # Original was 4096 bytes of 0x01 — sealed must not start with 0x01.
+        assert sealed_bytes[:4] == b"AXSL"
+        assert b"\x01" * 16 not in sealed_bytes  # no run of original plaintext
+
+
+# ---------------------------------------------------------------------------
+# Nested project layout (parent/child via subs/)
+# ---------------------------------------------------------------------------
+
+
+class TestNestedProjectSeal:
+    def test_seal_nested_project_via_subs_layout(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        # research/papers → user_dir/research/subs/papers
+        nested = user_dir / "research" / "subs" / "papers"
+        (nested / "bm25_index").mkdir(parents=True)
+        (nested / "vector_store_data").mkdir(parents=True)
+        (nested / "meta.json").write_text(
+            '{"project_id": "papers", "name": "papers"}', encoding="utf-8"
+        )
+
+        result = project_seal("research/papers", user_dir)
+        assert result["status"] == "sealed"
+        assert is_project_sealed(nested) is True
+        assert is_sealed_file(nested / "meta.json") is True

--- a/tests/test_project_seal.py
+++ b/tests/test_project_seal.py
@@ -244,38 +244,58 @@ class TestSealAtomicity:
         assert result["orphans_removed"] == 1
         assert not orphan.exists()
 
-    def test_partial_seal_resumes_skips_already_sealed_files(self, kr_backend, user_dir):
-        """If the prior run sealed some files before crashing, those files
-        already have an AXSL header. A re-run must not double-seal them."""
+    def test_partial_seal_resumes_with_persisted_seal_id(self, kr_backend, user_dir):
+        """A real resume case: prior run persisted ``.security/.sealing``
+        before encrypting one file then crashed. The next run reads the
+        persisted seal_id, re-uses it, and skips the already-sealed file
+        with a matching AAD so a subsequent mount can decrypt it.
+        """
         from axon.security.crypto import SealedFile, make_aad
+        from axon.security.master import get_or_create_project_dek
+        from axon.security.seal import (
+            SEALING_INPROGRESS_PATH,
+            _read_inprogress_seal_id,
+            _write_inprogress_seal_id,
+        )
 
         bootstrap_store(user_dir, "pw")
         proj = _populate_plaintext_project(user_dir)
-        # Hand-seal one file with a different DEK to simulate the
-        # "partial prior run" condition. Only the magic header check
-        # should matter — content is overwritten on next full seal? No,
-        # the resume path SKIPS already-sealed files and trusts them.
-        # So we must seal it with the SAME DEK that project_seal will
-        # derive — that means we have to pre-bootstrap and grab the DEK
-        # first.
-        from axon.security.master import get_or_create_project_dek
-
         dek = get_or_create_project_dek(user_dir, proj)
+
+        # Simulate the prior run: persist a seal_id then encrypt one file
+        # under that seal_id and crash before completing.
+        prior_seal_id = "seal_resume_test_0001"
+        _write_inprogress_seal_id(proj, prior_seal_id)
         rel = "bm25_index/.bm25_log.jsonl"
         target = proj / rel
-        target.write_bytes(b"")  # blank it so the existing read doesn't matter
-        # Note: we need the seal_id from project_seal's marker write,
-        # but project_seal generates it fresh. So pre-sealing with a
-        # synthetic key_id will FAIL to decrypt later. To test the
-        # "already sealed → skipped" branch correctly, just verify the
-        # files_already_sealed counter increments when ANY file is
-        # AXSL-headered going in.
-        SealedFile.write(target, b"prior-payload", dek, aad=make_aad("synthetic", rel))
+        SealedFile.write(target, b"prior-payload", dek, aad=make_aad(prior_seal_id, rel))
 
+        # Resume: project_seal reads the persisted seal_id and re-uses it.
         result = project_seal("research", user_dir)
-        # Already-sealed file counted but NOT re-encrypted with the new
-        # AAD. The counter increments per file that started AXSL.
+        assert result["status"] == "sealed"
         assert result["files_already_sealed"] >= 1
+        # The marker carries the resumed seal_id, NOT a fresh one.
+        marker = read_sealed_marker(proj)
+        assert marker is not None
+        assert marker["seal_id"] == prior_seal_id
+        # Resume context is cleaned up after success.
+        assert not (proj / SEALING_INPROGRESS_PATH).is_file()
+        assert _read_inprogress_seal_id(proj) is None
+
+    def test_fresh_seal_persists_inprogress_marker_then_cleans_it_up(self, kr_backend, user_dir):
+        """The .security/.sealing resume context must exist DURING seal but
+        be removed after the marker is written.
+        """
+        from axon.security.seal import SEALING_INPROGRESS_PATH
+
+        bootstrap_store(user_dir, "pw")
+        proj = _populate_plaintext_project(user_dir)
+        # Pre-condition: no resume context.
+        assert not (proj / SEALING_INPROGRESS_PATH).is_file()
+        result = project_seal("research", user_dir)
+        # Post-condition: resume context cleaned up.
+        assert result["status"] == "sealed"
+        assert not (proj / SEALING_INPROGRESS_PATH).is_file()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sealed_cache.py
+++ b/tests/test_sealed_cache.py
@@ -1,0 +1,368 @@
+"""Phase 2 of the sealed-mount design: ephemeral cache subsystem tests.
+
+Covers ``axon.security.cache``:
+- :class:`SealedCache` create + wipe round-trip
+- Mixed sealed-and-plaintext source dirs
+- Wrong-DEK / tampered-ciphertext rejection (no plaintext leak on failure)
+- Capacity check
+- PID-based orphan cleanup
+- ``is_sealed_file`` magic detection
+- Context-manager wipe
+- Self-check round-trip
+
+Skips the entire module when the optional ``cryptography`` package isn't
+installed (the ``sealed`` extra hasn't been pulled in).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from axon.security.cache import (  # noqa: E402
+    CACHE_PREFIX,
+    PID_SENTINEL_FILENAME,
+    CacheCapacityError,
+    SealedCache,
+    _self_check,
+    cleanup_orphans,
+    is_sealed_file,
+    list_orphans,
+)
+from axon.security.crypto import SealedFile, generate_dek, make_aad  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _seal_project(sealed_dir: Path, dek: bytes, *, key_id: str, files: dict[str, bytes]) -> None:
+    """Write *files* (relpath → plaintext) into *sealed_dir* as AXSL-sealed."""
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    for rel, payload in files.items():
+        target = sealed_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        SealedFile.write(target, payload, dek, aad=make_aad(key_id, rel))
+
+
+# ---------------------------------------------------------------------------
+# is_sealed_file
+# ---------------------------------------------------------------------------
+
+
+class TestIsSealedFile:
+    def test_returns_true_for_sealed_file(self, tmp_path):
+        path = tmp_path / "x.bin"
+        SealedFile.write(path, b"hi", generate_dek())
+        assert is_sealed_file(path) is True
+
+    def test_returns_false_for_plaintext(self, tmp_path):
+        path = tmp_path / "y.txt"
+        path.write_text("plain", encoding="utf-8")
+        assert is_sealed_file(path) is False
+
+    def test_returns_false_for_missing(self, tmp_path):
+        assert is_sealed_file(tmp_path / "nope") is False
+
+    def test_returns_false_for_directory(self, tmp_path):
+        assert is_sealed_file(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# SealedCache.create — round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCacheCreate:
+    def test_round_trip_single_file(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b'{"id":"x"}'})
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        try:
+            assert (cache.path / "meta.json").read_bytes() == b'{"id":"x"}'
+        finally:
+            cache.wipe()
+
+    def test_round_trip_nested_dirs(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        files = {
+            "meta.json": b'{"id":"x"}',
+            "vector_store_data/manifest.json": b'{"d":768}',
+            "vector_store_data/seg-00000001.bin": b"\x01" * 1024,
+            "bm25_index/.bm25_log.jsonl": b'{"seq":1}\n',
+        }
+        _seal_project(sealed, dek, key_id="sk_a", files=files)
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        try:
+            for rel, payload in files.items():
+                assert (cache.path / rel).read_bytes() == payload
+        finally:
+            cache.wipe()
+
+    def test_passthrough_for_non_sealed_files(self, tmp_path):
+        """Files without an AXSL header are copied as-is — meant for
+        ``version.json`` which deliberately stays plaintext."""
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        sealed.mkdir()
+        # Plaintext version marker — no AXSL header.
+        (sealed / "version.json").write_text('{"seq":42}', encoding="utf-8")
+        # And one sealed file alongside it.
+        SealedFile.write(
+            sealed / "meta.json",
+            b'{"id":"x"}',
+            dek,
+            aad=make_aad("sk_a", "meta.json"),
+        )
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        try:
+            # Plaintext file copied verbatim.
+            assert (cache.path / "version.json").read_text(encoding="utf-8") == '{"seq":42}'
+            # Sealed file decrypted.
+            assert (cache.path / "meta.json").read_bytes() == b'{"id":"x"}'
+        finally:
+            cache.wipe()
+
+    def test_pid_sentinel_written(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b"{}"})
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        try:
+            sentinel = cache.path / PID_SENTINEL_FILENAME
+            assert sentinel.exists()
+            assert int(sentinel.read_text(encoding="utf-8")) == os.getpid()
+        finally:
+            cache.wipe()
+
+    def test_cache_dir_uses_expected_prefix(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b"{}"})
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        try:
+            assert cache.path.name.startswith(CACHE_PREFIX)
+            assert cache.path.parent == tmp_path
+        finally:
+            cache.wipe()
+
+    def test_missing_sealed_dir_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            SealedCache.create(tmp_path / "does-not-exist", generate_dek(), key_id="sk_a")
+
+
+# ---------------------------------------------------------------------------
+# SealedCache.create — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestCacheCreateFailures:
+    def test_wrong_dek_raises_invalid_tag_and_wipes_partial(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        sealed = tmp_path / "proj"
+        right_dek = generate_dek()
+        wrong_dek = generate_dek()
+        _seal_project(sealed, right_dek, key_id="sk_a", files={"meta.json": b"{}"})
+
+        # Snapshot existing temp dir contents so we can detect a partial.
+        before = {p.name for p in tmp_path.iterdir()}
+        with pytest.raises(InvalidTag):
+            SealedCache.create(sealed, wrong_dek, key_id="sk_a", cache_root=tmp_path)
+        after = {p.name for p in tmp_path.iterdir()}
+        # No new axon-sealed-* dir survived the failure.
+        new_caches = [n for n in (after - before) if n.startswith(CACHE_PREFIX)]
+        assert new_caches == []
+
+    def test_wrong_aad_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_orig", files={"meta.json": b"{}"})
+
+        # Different key_id → AAD mismatch → InvalidTag.
+        with pytest.raises(InvalidTag):
+            SealedCache.create(sealed, dek, key_id="sk_other", cache_root=tmp_path)
+
+    def test_capacity_error_when_disk_too_small(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b"x" * 1000})
+
+        # Mock free space to a value below the 1.1× headroom threshold.
+        from collections import namedtuple
+
+        Usage = namedtuple("Usage", "total used free")
+
+        with patch(
+            "axon.security.cache.shutil.disk_usage",
+            return_value=Usage(total=1_000_000, used=999_000, free=10),
+        ):
+            with pytest.raises(CacheCapacityError, match="bytes free"):
+                SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# SealedCache.wipe + context manager
+# ---------------------------------------------------------------------------
+
+
+class TestCacheWipe:
+    def test_wipe_removes_cache_dir(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b"{}"})
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        cache_path = cache.path
+        assert cache_path.exists()
+        cache.wipe()
+        assert not cache_path.exists()
+
+    def test_wipe_is_idempotent(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b"{}"})
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        cache.wipe()
+        # Second wipe must NOT raise.
+        cache.wipe()
+
+    def test_wipe_removes_nested_files(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(
+            sealed,
+            dek,
+            key_id="sk_a",
+            files={
+                "meta.json": b"{}",
+                "vector_store_data/manifest.json": b"{}",
+                "vector_store_data/seg-00000001.bin": b"\x00" * 4096,
+                "bm25_index/.bm25_log.jsonl": b"{}\n",
+            },
+        )
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+        cache_path = cache.path
+        assert (cache_path / "vector_store_data" / "seg-00000001.bin").exists()
+        cache.wipe()
+        # Whole tree gone — including the nested subdirs.
+        assert not cache_path.exists()
+
+    def test_context_manager_wipes_on_exit(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b"{}"})
+
+        with SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path) as cache:
+            cache_path = cache.path
+            assert cache_path.exists()
+        assert not cache_path.exists()
+
+    def test_context_manager_wipes_even_on_exception(self, tmp_path):
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_a", files={"meta.json": b"{}"})
+
+        cache_path_holder: list[Path] = []
+        with pytest.raises(RuntimeError):
+            with SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path) as cache:
+                cache_path_holder.append(cache.path)
+                raise RuntimeError("simulated failure mid-use")
+        assert not cache_path_holder[0].exists()
+
+
+# ---------------------------------------------------------------------------
+# Orphan cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanCleanup:
+    def _make_orphan_with_pid(self, root: Path, *, pid: int, with_files: bool = True) -> Path:
+        """Hand-craft a cache-shaped dir with the given PID sentinel."""
+        import tempfile as _tempfile
+
+        d = Path(_tempfile.mkdtemp(prefix=CACHE_PREFIX, dir=str(root)))
+        (d / PID_SENTINEL_FILENAME).write_text(str(pid), encoding="utf-8")
+        if with_files:
+            (d / "junk.bin").write_bytes(b"residue" * 100)
+        return d
+
+    def test_dead_pid_listed_as_orphan(self, tmp_path):
+        # PID 0 is never a valid live process.
+        orphan = self._make_orphan_with_pid(tmp_path, pid=0)
+        orphans = list_orphans(cache_root=tmp_path)
+        assert orphan in orphans
+
+    def test_alive_pid_not_listed(self, tmp_path):
+        # The current process IS alive.
+        not_orphan = self._make_orphan_with_pid(tmp_path, pid=os.getpid())
+        orphans = list_orphans(cache_root=tmp_path)
+        assert not_orphan not in orphans
+
+    def test_missing_pid_file_treated_as_orphan(self, tmp_path):
+        """Defensive: if the sentinel is gone or unreadable, wipe.
+        A real active cache always writes its sentinel."""
+        import tempfile as _tempfile
+
+        d = Path(_tempfile.mkdtemp(prefix=CACHE_PREFIX, dir=str(tmp_path)))
+        (d / "stuff.bin").write_bytes(b"x")
+        # No PID file.
+        orphans = list_orphans(cache_root=tmp_path)
+        assert d in orphans
+
+    def test_unparseable_pid_treated_as_orphan(self, tmp_path):
+        import tempfile as _tempfile
+
+        d = Path(_tempfile.mkdtemp(prefix=CACHE_PREFIX, dir=str(tmp_path)))
+        (d / PID_SENTINEL_FILENAME).write_text("not a number", encoding="utf-8")
+        orphans = list_orphans(cache_root=tmp_path)
+        assert d in orphans
+
+    def test_non_axon_dirs_ignored(self, tmp_path):
+        unrelated = tmp_path / "some-other-temp"
+        unrelated.mkdir()
+        (unrelated / PID_SENTINEL_FILENAME).write_text("0", encoding="utf-8")
+        assert list_orphans(cache_root=tmp_path) == []
+
+    def test_cleanup_orphans_wipes_dead_caches(self, tmp_path):
+        dead = self._make_orphan_with_pid(tmp_path, pid=0)
+        alive = self._make_orphan_with_pid(tmp_path, pid=os.getpid())
+        wiped = cleanup_orphans(cache_root=tmp_path)
+        assert wiped == 1
+        assert not dead.exists()
+        assert alive.exists()  # left alone
+
+    def test_cleanup_orphans_returns_zero_when_none(self, tmp_path):
+        # Empty temp dir.
+        assert cleanup_orphans(cache_root=tmp_path) == 0
+
+    def test_cleanup_orphans_never_raises(self, tmp_path):
+        # Even if the temp dir doesn't exist, return 0 cleanly.
+        assert cleanup_orphans(cache_root=tmp_path / "does-not-exist") == 0
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+
+class TestSelfCheck:
+    def test_self_check_ok_on_healthy_install(self):
+        result = _self_check()
+        assert result["ok"] is True
+        assert "round-trip OK" in result["details"]

--- a/tests/test_sealed_master.py
+++ b/tests/test_sealed_master.py
@@ -1,0 +1,348 @@
+"""Phase 2: master-key + project-DEK lifecycle tests.
+
+Covers ``axon.security.master`` end-to-end via a mocked keyring backend
+(no touching the developer's real OS keyring during the test run).
+
+Skips when the ``cryptography`` or ``keyring`` packages are missing
+(the ``sealed`` extra hasn't been installed).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("cryptography")
+pytest.importorskip("keyring")
+
+from axon.security import SecurityError  # noqa: E402
+from axon.security.master import (  # noqa: E402
+    DEK_LEN,
+    MASTER_USERNAME,
+    BadPassphraseError,
+    bootstrap_store,
+    change_passphrase,
+    get_master_key,
+    get_or_create_project_dek,
+    get_project_dek,
+    is_bootstrapped,
+    is_unlocked,
+    lock_store,
+    unlock_store,
+)
+
+# ---------------------------------------------------------------------------
+# In-memory keyring backend (used by every test — never touches the OS keyring)
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryKeyring:
+    priority = 1
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, username, secret):
+        self._store[(service, username)] = secret
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def delete_password(self, service, username):
+        import keyring.errors
+
+        if (service, username) not in self._store:
+            raise keyring.errors.PasswordDeleteError("not found")
+        del self._store[(service, username)]
+
+
+@pytest.fixture
+def kr_backend():
+    """Each test gets a fresh in-memory keyring + a clean unlock cache."""
+    backend = _InMemoryKeyring()
+    with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+        # Also clear any cached unlocked masters from prior tests.
+        from axon.security import master as _master_mod
+
+        _master_mod._unlocked_masters.clear()
+        yield backend
+        _master_mod._unlocked_masters.clear()
+
+
+@pytest.fixture
+def user_dir(tmp_path):
+    """A tmp_path-rooted "AxonStore user dir" with a stable basename."""
+    ud = tmp_path / "alice"
+    ud.mkdir()
+    return ud
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_store
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapStore:
+    def test_first_bootstrap_marks_initialized(self, kr_backend, user_dir):
+        result = bootstrap_store(user_dir, "correct-horse-battery-staple")
+        assert result["initialized"] is True
+        assert result["owner"] == "alice"
+        assert is_bootstrapped(user_dir)
+
+    def test_bootstrap_caches_master_so_user_is_unlocked_immediately(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        assert is_unlocked(user_dir)
+
+    def test_bootstrap_again_raises_security_error(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        with pytest.raises(SecurityError, match="already bootstrapped"):
+            bootstrap_store(user_dir, "pw2")
+
+    def test_empty_passphrase_rejected(self, kr_backend, user_dir):
+        with pytest.raises(BadPassphraseError, match="non-empty"):
+            bootstrap_store(user_dir, "")
+
+    def test_bootstrap_writes_keyring_record_with_schema_version(self, kr_backend, user_dir):
+        import json
+
+        bootstrap_store(user_dir, "pw")
+        record = json.loads(kr_backend.get_password("axon.master.alice", MASTER_USERNAME))
+        assert record["v"] == 1
+        assert "salt" in record and "wrapped" in record
+
+
+# ---------------------------------------------------------------------------
+# unlock_store / lock_store / is_unlocked
+# ---------------------------------------------------------------------------
+
+
+class TestUnlockLock:
+    def test_unlock_after_bootstrap_with_correct_passphrase(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        lock_store(user_dir)
+        assert not is_unlocked(user_dir)
+
+        result = unlock_store(user_dir, "pw")
+        assert result["unlocked"] is True
+        assert is_unlocked(user_dir)
+
+    def test_unlock_with_wrong_passphrase_raises(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "right")
+        lock_store(user_dir)
+        with pytest.raises(BadPassphraseError, match="Wrong passphrase"):
+            unlock_store(user_dir, "wrong")
+        assert not is_unlocked(user_dir)
+
+    def test_unlock_before_bootstrap_raises(self, kr_backend, user_dir):
+        with pytest.raises(SecurityError, match="not bootstrapped"):
+            unlock_store(user_dir, "pw")
+
+    def test_lock_clears_master_cache(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        assert is_unlocked(user_dir)
+        result = lock_store(user_dir)
+        assert result["locked"] is True
+        assert result["was_unlocked"] is True
+        assert not is_unlocked(user_dir)
+
+    def test_lock_idempotent_when_not_unlocked(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        lock_store(user_dir)
+        result = lock_store(user_dir)  # again
+        assert result["locked"] is True
+        assert result["was_unlocked"] is False
+
+
+# ---------------------------------------------------------------------------
+# change_passphrase
+# ---------------------------------------------------------------------------
+
+
+class TestChangePassphrase:
+    def test_rotate_with_correct_old_passphrase(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "old")
+        master_before = get_master_key(user_dir)
+        result = change_passphrase(user_dir, "old", "new")
+        assert result["rotated"] is True
+        # Master is UNCHANGED across passphrase rotation.
+        assert get_master_key(user_dir) == master_before
+
+    def test_rotate_with_wrong_old_raises(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "old")
+        with pytest.raises(BadPassphraseError, match="Old passphrase"):
+            change_passphrase(user_dir, "wrong-old", "new")
+
+    def test_after_rotate_old_passphrase_no_longer_works(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "old")
+        change_passphrase(user_dir, "old", "new")
+        lock_store(user_dir)
+        with pytest.raises(BadPassphraseError):
+            unlock_store(user_dir, "old")
+        # New one works.
+        unlock_store(user_dir, "new")
+        assert is_unlocked(user_dir)
+
+    def test_empty_new_passphrase_rejected(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "old")
+        with pytest.raises(BadPassphraseError):
+            change_passphrase(user_dir, "old", "")
+
+
+# ---------------------------------------------------------------------------
+# get_master_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetMasterKey:
+    def test_returns_32_bytes_when_unlocked(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        master = get_master_key(user_dir)
+        assert isinstance(master, bytes)
+        assert len(master) == 32
+
+    def test_raises_when_locked(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        lock_store(user_dir)
+        with pytest.raises(SecurityError, match="locked"):
+            get_master_key(user_dir)
+
+    def test_master_stable_across_lock_unlock(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        m1 = get_master_key(user_dir)
+        lock_store(user_dir)
+        unlock_store(user_dir, "pw")
+        m2 = get_master_key(user_dir)
+        assert m1 == m2
+
+
+# ---------------------------------------------------------------------------
+# get_or_create_project_dek
+# ---------------------------------------------------------------------------
+
+
+class TestProjectDek:
+    def test_first_call_creates_and_persists_wrapped_dek(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = user_dir / "research"
+        proj.mkdir()
+        dek = get_or_create_project_dek(user_dir, proj)
+        assert isinstance(dek, bytes)
+        assert len(dek) == DEK_LEN
+        # On disk: 40 bytes (AES-KW wraps 32 → 40).
+        wrap_path = proj / ".security" / "dek.wrapped"
+        assert wrap_path.is_file()
+        assert wrap_path.stat().st_size == 40
+
+    def test_idempotent_returns_same_dek(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = user_dir / "research"
+        proj.mkdir()
+        d1 = get_or_create_project_dek(user_dir, proj)
+        d2 = get_or_create_project_dek(user_dir, proj)
+        assert d1 == d2
+
+    def test_distinct_projects_get_distinct_deks(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        p1 = user_dir / "p1"
+        p2 = user_dir / "p2"
+        p1.mkdir()
+        p2.mkdir()
+        d1 = get_or_create_project_dek(user_dir, p1)
+        d2 = get_or_create_project_dek(user_dir, p2)
+        assert d1 != d2
+
+    def test_locked_store_blocks_dek_access(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        lock_store(user_dir)
+        proj = user_dir / "research"
+        proj.mkdir()
+        with pytest.raises(SecurityError, match="locked"):
+            get_or_create_project_dek(user_dir, proj)
+
+    def test_dek_survives_passphrase_rotation(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "old")
+        proj = user_dir / "research"
+        proj.mkdir()
+        dek_before = get_or_create_project_dek(user_dir, proj)
+        change_passphrase(user_dir, "old", "new")
+        # DEK should be retrievable AND identical — passphrase rotation
+        # doesn't touch project DEKs.
+        dek_after = get_or_create_project_dek(user_dir, proj)
+        assert dek_before == dek_after
+
+    def test_dek_survives_lock_unlock_cycle(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = user_dir / "research"
+        proj.mkdir()
+        dek1 = get_or_create_project_dek(user_dir, proj)
+        lock_store(user_dir)
+        unlock_store(user_dir, "pw")
+        dek2 = get_or_create_project_dek(user_dir, proj)
+        assert dek1 == dek2
+
+    def test_no_partial_wrap_left_after_failed_write(self, kr_backend, user_dir):
+        """Atomic per-file write — the .sealing tempfile must not survive."""
+        bootstrap_store(user_dir, "pw")
+        proj = user_dir / "research"
+        proj.mkdir()
+        get_or_create_project_dek(user_dir, proj)
+        sec_dir = proj / ".security"
+        leftover = list(sec_dir.glob("*.sealing"))
+        assert leftover == []
+
+    def test_corrupt_wrapped_dek_raises_security_error(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = user_dir / "research"
+        proj.mkdir()
+        get_or_create_project_dek(user_dir, proj)
+        # Tamper.
+        wrap_path = proj / ".security" / "dek.wrapped"
+        wrap_path.write_bytes(b"\xff" * 40)
+        with pytest.raises(SecurityError, match="won't unwrap"):
+            get_or_create_project_dek(user_dir, proj)
+
+
+# ---------------------------------------------------------------------------
+# get_project_dek (read-only variant)
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectDekReadOnly:
+    def test_raises_when_no_dek_file(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = user_dir / "research"
+        proj.mkdir()
+        # No DEK created yet.
+        with pytest.raises(SecurityError, match="missing"):
+            get_project_dek(user_dir, proj)
+
+    def test_returns_existing_dek_unchanged(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "pw")
+        proj = user_dir / "research"
+        proj.mkdir()
+        original = get_or_create_project_dek(user_dir, proj)
+        recovered = get_project_dek(user_dir, proj)
+        assert original == recovered
+
+
+# ---------------------------------------------------------------------------
+# Keyring record validation
+# ---------------------------------------------------------------------------
+
+
+class TestKeyringRecordValidation:
+    def test_malformed_json_raises_security_error(self, kr_backend, user_dir):
+        kr_backend.set_password("axon.master.alice", MASTER_USERNAME, "{not json")
+        with pytest.raises(SecurityError, match="unparseable JSON"):
+            unlock_store(user_dir, "pw")
+
+    def test_wrong_schema_version_raises_security_error(self, kr_backend, user_dir):
+        import json
+
+        kr_backend.set_password(
+            "axon.master.alice",
+            MASTER_USERNAME,
+            json.dumps({"v": 99, "salt": "x", "wrapped": "x"}),
+        )
+        with pytest.raises(SecurityError, match="schema_version mismatch"):
+            unlock_store(user_dir, "pw")

--- a/tests/test_sealed_mount.py
+++ b/tests/test_sealed_mount.py
@@ -1,0 +1,282 @@
+"""Phase 2 part 4: sealed-project mount tests.
+
+Covers ``axon.security.mount`` (the materialise/release glue) and the
+``AxonBrain.switch_project`` / ``close()`` / ``__init__`` lifecycle
+hooks that route sealed projects through an ephemeral plaintext cache.
+
+Skips when the optional ``[sealed]`` extra is not installed.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("cryptography")
+pytest.importorskip("keyring")
+
+from axon.security import SecurityError  # noqa: E402
+from axon.security.cache import (  # noqa: E402
+    CACHE_PREFIX,
+    PID_SENTINEL_FILENAME,
+    cleanup_orphans,
+    is_sealed_file,
+)
+from axon.security.master import bootstrap_store, lock_store  # noqa: E402
+from axon.security.mount import materialize_for_read, release_cache  # noqa: E402
+from axon.security.seal import project_seal  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# In-memory keyring fixture (mirrors the other sealed-* test files)
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryKeyring:
+    priority = 1
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, username, secret):
+        self._store[(service, username)] = secret
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def delete_password(self, service, username):
+        import keyring.errors
+
+        if (service, username) not in self._store:
+            raise keyring.errors.PasswordDeleteError("not found")
+        del self._store[(service, username)]
+
+
+@pytest.fixture
+def kr_backend():
+    backend = _InMemoryKeyring()
+    with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+        from axon.security import master as _master_mod
+
+        _master_mod._unlocked_masters.clear()
+        yield backend
+        _master_mod._unlocked_masters.clear()
+
+
+@pytest.fixture
+def user_dir(tmp_path):
+    ud = tmp_path / "alice"
+    ud.mkdir()
+    return ud
+
+
+def _populate_and_seal(user_dir: Path, project: str = "research") -> Path:
+    """Build a representative project, seal it, return its directory."""
+    proj = user_dir / project
+    (proj / "bm25_index").mkdir(parents=True)
+    (proj / "vector_store_data").mkdir(parents=True)
+    (proj / ".security").mkdir(parents=True)
+    (proj / "meta.json").write_text('{"project_id":"p1","name":"research"}', encoding="utf-8")
+    (proj / "version.json").write_text('{"seq":1}', encoding="utf-8")  # passthrough
+    (proj / "bm25_index" / ".bm25_log.jsonl").write_text('{"id":"d1"}\n', encoding="utf-8")
+    (proj / "vector_store_data" / "manifest.json").write_text('{"d":768}', encoding="utf-8")
+    (proj / "vector_store_data" / "seg-00000001.bin").write_bytes(b"\xab" * 4096)
+
+    bootstrap_store(user_dir, "pw")
+    project_seal(project, user_dir)
+    return proj
+
+
+# ---------------------------------------------------------------------------
+# materialize_for_read — happy path + decryption fidelity
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeForReadHappyPath:
+    def test_decrypts_into_temp_cache(self, kr_backend, user_dir, tmp_path):
+        proj = _populate_and_seal(user_dir)
+        cache_root = tmp_path / "cache_root"
+        cache_root.mkdir()
+
+        cache = materialize_for_read(proj, user_dir, cache_root=cache_root)
+        try:
+            # Cache dir lives under our cache_root override and uses
+            # the documented prefix.
+            assert cache.path.parent == cache_root
+            assert cache.path.name.startswith(CACHE_PREFIX)
+            # PID sentinel exists.
+            assert (cache.path / PID_SENTINEL_FILENAME).read_text(encoding="utf-8") == str(
+                os.getpid()
+            )
+            # Plaintext content matches what we put in pre-seal.
+            assert (
+                cache.path / "vector_store_data" / "seg-00000001.bin"
+            ).read_bytes() == b"\xab" * 4096
+            assert (cache.path / "vector_store_data" / "manifest.json").read_text(
+                encoding="utf-8"
+            ) == '{"d":768}'
+            assert (cache.path / "bm25_index" / ".bm25_log.jsonl").read_text(
+                encoding="utf-8"
+            ) == '{"id":"d1"}\n'
+            assert (cache.path / "meta.json").read_text(
+                encoding="utf-8"
+            ) == '{"project_id":"p1","name":"research"}'
+            # Passthrough plaintext file copied as-is.
+            assert (cache.path / "version.json").read_text(encoding="utf-8") == '{"seq":1}'
+        finally:
+            release_cache(cache)
+        # release_cache wipes the directory.
+        assert not cache.path.exists()
+
+    def test_release_cache_safe_on_none(self):
+        # No-op for the convenience wrapper.
+        release_cache(None)
+
+
+# ---------------------------------------------------------------------------
+# materialize_for_read — error / refusal paths
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeForReadErrors:
+    def test_refuses_unsealed_project(self, kr_backend, user_dir, tmp_path):
+        proj = user_dir / "open_proj"
+        proj.mkdir()
+        (proj / "meta.json").write_text("{}", encoding="utf-8")
+        with pytest.raises(SecurityError, match="non-sealed"):
+            materialize_for_read(proj, user_dir, cache_root=tmp_path / "cr")
+
+    def test_refuses_when_locked(self, kr_backend, user_dir, tmp_path):
+        proj = _populate_and_seal(user_dir)
+        # Lock the store after seal; materialize should refuse.
+        lock_store(user_dir)
+        with pytest.raises(SecurityError, match="locked"):
+            materialize_for_read(proj, user_dir, cache_root=tmp_path / "cr")
+
+    def test_refuses_when_marker_missing_seal_id(self, kr_backend, user_dir, tmp_path, monkeypatch):
+        proj = _populate_and_seal(user_dir)
+
+        # Patch read_sealed_marker to return a marker without seal_id.
+        from axon.security import mount as _mount
+
+        monkeypatch.setattr(_mount, "read_sealed_marker", lambda _p: {"v": 1, "seal_id": ""})
+        with pytest.raises(SecurityError, match="no seal_id"):
+            materialize_for_read(proj, user_dir, cache_root=tmp_path / "cr")
+
+    def test_wraps_underlying_failure_as_security_error(
+        self, kr_backend, user_dir, tmp_path, monkeypatch
+    ):
+        proj = _populate_and_seal(user_dir)
+
+        # Force SealedCache.create to raise an arbitrary OSError —
+        # mount.py should wrap it into SecurityError.
+        from axon.security import mount as _mount
+
+        def _boom(*_a, **_kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(_mount.SealedCache, "create", classmethod(_boom))
+        with pytest.raises(SecurityError, match="disk full"):
+            materialize_for_read(proj, user_dir, cache_root=tmp_path / "cr")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — seal, mount, read, wipe, verify ciphertext on disk unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestSealMountRoundTrip:
+    def test_disk_stays_ciphertext_after_mount(self, kr_backend, user_dir, tmp_path):
+        proj = _populate_and_seal(user_dir)
+
+        # Confirm pre-mount: content files on disk are AXSL ciphertext.
+        assert is_sealed_file(proj / "meta.json")
+        assert is_sealed_file(proj / "vector_store_data" / "seg-00000001.bin")
+
+        cache = materialize_for_read(proj, user_dir, cache_root=tmp_path / "cr")
+        try:
+            # While mounted: cache has plaintext, original is still sealed.
+            assert not is_sealed_file(cache.path / "meta.json")
+            assert is_sealed_file(proj / "meta.json")  # untouched
+        finally:
+            release_cache(cache)
+
+        # Post-wipe: original is still sealed.
+        assert is_sealed_file(proj / "meta.json")
+
+
+# ---------------------------------------------------------------------------
+# AxonBrain integration — switch_project / close / __init__
+# Use targeted attribute checks rather than instantiating a real brain
+# (heavy: pulls in embedders + LLM).
+# ---------------------------------------------------------------------------
+
+
+class TestBrainHooksContract:
+    """Lightweight contract checks for the brain-side wiring.
+
+    Avoids constructing a full ``AxonBrain`` (loads embeddings, executor,
+    config). Instead exercises the private helpers directly on a
+    minimal duck-typed object so we can verify the path-routing logic
+    without paying the AxonBrain init cost.
+    """
+
+    def test_project_is_sealed_returns_false_for_open(self, kr_backend, user_dir):
+        from axon.main import AxonBrain
+
+        proj = user_dir / "open_proj"
+        proj.mkdir()
+        (proj / "meta.json").write_text("{}", encoding="utf-8")
+        # Use any object as `self` — the method only consults its arg.
+        stub: object = object()
+        result = AxonBrain._project_is_sealed(stub, proj)  # type: ignore[arg-type]
+        assert result is False
+
+    def test_project_is_sealed_returns_true_after_seal(self, kr_backend, user_dir):
+        from axon.main import AxonBrain
+
+        proj = _populate_and_seal(user_dir)
+        stub: object = object()
+        result = AxonBrain._project_is_sealed(stub, proj)  # type: ignore[arg-type]
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Orphan cleanup — survives across "process restarts"
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanCleanupAcrossRestart:
+    def test_orphan_with_dead_pid_is_wiped(self, tmp_path, kr_backend, user_dir):
+        proj = _populate_and_seal(user_dir)
+        cache_root = tmp_path / "cr"
+        cache_root.mkdir()
+
+        # Create a "stale" cache then forge a non-existent PID into the
+        # sentinel — simulates a crashed previous session.
+        cache = materialize_for_read(proj, user_dir, cache_root=cache_root)
+        cache_dir = cache.path
+        # Forge: pick a PID that is extremely unlikely to be alive.
+        # PID 999999999 isn't valid on Linux/Windows.
+        (cache_dir / PID_SENTINEL_FILENAME).write_text("999999999", encoding="utf-8")
+
+        # Don't release — let cleanup_orphans find it as if a previous
+        # process died holding it.
+        wiped = cleanup_orphans(cache_root=cache_root)
+        assert wiped >= 1
+        assert not cache_dir.exists()
+
+    def test_active_pid_is_left_alone(self, tmp_path, kr_backend, user_dir):
+        proj = _populate_and_seal(user_dir)
+        cache_root = tmp_path / "cr"
+        cache_root.mkdir()
+
+        cache = materialize_for_read(proj, user_dir, cache_root=cache_root)
+        try:
+            # Sentinel has THIS process's PID — must not be wiped.
+            wiped = cleanup_orphans(cache_root=cache_root)
+            assert wiped == 0
+            assert cache.path.exists()
+        finally:
+            release_cache(cache)


### PR DESCRIPTION
## Summary

Closes the encryption-at-rest layer for sealed Axon projects. Owner can `axon --project-seal <name>` to convert a plaintext project to AES-256-GCM ciphertext on disk; subsequent `--project switch` decrypts the project into an ephemeral plaintext cache that the existing TurboQuantDB / LanceDB / BM25 backends can mmap. The cache is wiped on close, switch, or process exit (PID-sentinel orphan cleanup catches crashes).

This is the foundation that makes OneDrive-style sharing safe — bytes on the synced drive are opaque ciphertext without the key, even though the data owner is offline. (Phase 3 will add the share generate/redeem flow on top of this layer.)

Five focused commits:

- **part 1** (`3ef2fda`) — ephemeral plaintext cache subsystem (`SealedCache.create/wipe`, capacity check, secure overwrite, PID-sentinel orphan cleanup)
- **part 2** (`7e6be17`) — master key + project DEK lifecycle (`bootstrap_store`, `unlock_store`, `lock_store`, `change_passphrase`, `get_or_create_project_dek` — envelope encryption pattern, scrypt-derived KEK, AES-KW wrap)
- **part 3** (`85b716d`) — `project_seal()` in-place encryption with atomic `.sealing` tempfile + `os.replace` + crash-resume
- **part 4** (`26793b0`) — `AxonBrain.switch_project` / `close()` / `__init__` lifecycle hooks; sealed projects route through the cache transparently to backends
- **part 5** (`d3e1c2b`) — cross-interface surfaces: REST `/security/*` + `/project/seal` (existing routes now route through real implementations); MCP gains 6 new tools; REPL gains `/store {status, bootstrap, unlock, lock, change-passphrase}` + `/project seal`; CLI gains 6 new flags

## Test plan
- [x] All 133 sealed-* unit/integration tests pass
- [x] All 320 project/switch/mount tests pass
- [x] All 31 MCP server tests pass (6 new sealed tool names added to expected set)
- [x] All 17 surface-parity tests pass
- [x] Pre-commit hooks (black, ruff, py_compile, full pytest, evaluation-smoke) green on every commit
- [ ] CI matrix (4 OS × 4 Python) — to be confirmed after push
- [ ] Real OneDrive end-to-end smoke — deferred to **Phase 7** with a dedicated test harness (research summary in PR thread)

## Notes for reviewer
- The crypto layer is unchanged from PR #56; only `__init__.py` re-wiring is new in this PR
- `_pid_alive()` in `cache.py` was fixed to handle Windows EINVAL (invalid handle for an out-of-range PID) so cleanup_orphans actually wipes stale caches on Windows
- `switch_project` defers cache materialization until **after** `close()` (because `close()` wipes the previous cache); the `_pending_seal_mount` two-phase handoff lives on the instance for that reason
- All sealed code is gated by `try: from . import master` so installs without the `[sealed]` extra (`cryptography` + `keyring`) keep the v0 stub behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)