### PR TITLE
feat(security): per-IP rate limiting on share/ingest/security endpoints

### DIFF
--- a/src/axon/api_routes/_rate_limit.py
+++ b/src/axon/api_routes/_rate_limit.py
@@ -1,0 +1,96 @@
+"""Shared per-IP sliding-window rate limiter for Axon API routes.
+
+Each logical endpoint uses a named *bucket* so independent rate-limit
+counters don't bleed across routes.  The implementation intentionally
+avoids external dependencies — it is a pure-Python in-process store
+suitable for single-process deployments.
+
+Usage::
+
+    from axon.api_routes._rate_limit import enforce_rate_limit
+
+    @router.post("/my/endpoint")
+    async def my_endpoint(request: Request, ...):
+        enforce_rate_limit(request, bucket="my_endpoint")
+        ...
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from fastapi import HTTPException, Request
+
+# Top-level dict: bucket_name → {ip → ([hit_timestamps], per-ip Lock)}
+_buckets: dict[str, dict[str, tuple[list[float], threading.Lock]]] = {}
+_global_lock = threading.Lock()
+
+# Hard cap: evict oldest IP when the per-bucket dict grows beyond this size
+# to prevent unbounded memory growth under a steady stream of unique IPs.
+_MAX_IPS = 10_000
+
+
+def _get_ip(request: Request) -> str:
+    """Return the best-effort client IP, honouring X-Forwarded-For."""
+    xff = request.headers.get("X-Forwarded-For")
+    if xff:
+        return xff.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def enforce_rate_limit(
+    request: Request,
+    *,
+    bucket: str,
+    max_hits: int = 10,
+    window_seconds: float = 60.0,
+) -> None:
+    """Raise HTTP 429 if the caller exceeds *max_hits* within *window_seconds*.
+
+    Parameters
+    ----------
+    request:
+        The incoming FastAPI ``Request`` object (used to extract the IP).
+    bucket:
+        Logical group name — distinct endpoints should use distinct bucket
+        names so their counters are independent.
+    max_hits:
+        Maximum number of requests allowed per IP within *window_seconds*.
+    window_seconds:
+        Length of the sliding time window in seconds.
+    """
+    ip = _get_ip(request)
+    now = time.monotonic()
+
+    with _global_lock:
+        if bucket not in _buckets:
+            _buckets[bucket] = {}
+        b = _buckets[bucket]
+
+        # Evict oldest IP when cap is reached so the dict stays bounded.
+        if len(b) >= _MAX_IPS:
+            oldest = min(
+                b,
+                key=lambda k: b[k][0][0] if b[k][0] else 0,
+            )
+            del b[oldest]
+
+        if ip not in b:
+            b[ip] = ([], threading.Lock())
+
+        hits, lock = b[ip]
+
+    # Per-IP lock: only one goroutine-like-path updates this IP's timestamps.
+    with lock:
+        # Prune timestamps that have fallen outside the sliding window.
+        cutoff = now - window_seconds
+        while hits and hits[0] < cutoff:
+            hits.pop(0)
+
+        if len(hits) >= max_hits:
+            raise HTTPException(
+                status_code=429,
+                detail="Too many requests. Try again later.",
+            )
+        hits.append(now)

--- a/src/axon/api_routes/_rate_limit.py
+++ b/src/axon/api_routes/_rate_limit.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import deque
 
 from fastapi import HTTPException, Request
 
-# Top-level dict: bucket_name → {ip → ([hit_timestamps], per-ip Lock)}
-_buckets: dict[str, dict[str, tuple[list[float], threading.Lock]]] = {}
+# Top-level dict: bucket_name → {ip → (deque[hit_timestamps], per-ip Lock)}
+_buckets: dict[str, dict[str, tuple[deque[float], threading.Lock]]] = {}
 _global_lock = threading.Lock()
 
 # Hard cap: evict oldest IP when the per-bucket dict grows beyond this size
@@ -32,7 +33,11 @@ _MAX_IPS = 10_000
 
 
 def _get_ip(request: Request) -> str:
-    """Return the best-effort client IP, honouring X-Forwarded-For."""
+    """Return the best-effort client IP.
+
+    Reads X-Forwarded-For only if present; deployments not behind a trusted
+    reverse proxy should consider disabling this header to prevent IP spoofing.
+    """
     xff = request.headers.get("X-Forwarded-For")
     if xff:
         return xff.split(",")[0].strip()
@@ -69,24 +74,31 @@ def enforce_rate_limit(
         b = _buckets[bucket]
 
         # Evict oldest IP when cap is reached so the dict stays bounded.
+        # Acquire the per-IP lock non-blocking to avoid deleting an entry
+        # that another thread is actively using (would split their hit-list).
         if len(b) >= _MAX_IPS:
             oldest = min(
                 b,
                 key=lambda k: b[k][0][0] if b[k][0] else 0,
             )
-            del b[oldest]
+            _, oldest_lock = b[oldest]
+            if oldest_lock.acquire(blocking=False):
+                try:
+                    del b[oldest]
+                finally:
+                    oldest_lock.release()
 
         if ip not in b:
-            b[ip] = ([], threading.Lock())
+            b[ip] = (deque(), threading.Lock())
 
         hits, lock = b[ip]
 
-    # Per-IP lock: only one goroutine-like-path updates this IP's timestamps.
+    # Per-IP lock: only one path updates this IP's timestamps at a time.
     with lock:
         # Prune timestamps that have fallen outside the sliding window.
         cutoff = now - window_seconds
         while hits and hits[0] < cutoff:
-            hits.pop(0)
+            hits.popleft()  # O(1) with deque vs O(n) with list
 
         if len(hits) >= max_hits:
             raise HTTPException(

--- a/src/axon/api_routes/ingest.py
+++ b/src/axon/api_routes/ingest.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Reque
 
 from axon.api_routes import _enforce_write_access
 from axon.api_routes import enforce_project as _enforce_project
+from axon.api_routes._rate_limit import enforce_rate_limit
 from axon.api_schemas import (
     BatchTextIngestRequest,
     DeleteRequest,
@@ -429,10 +430,11 @@ async def add_texts(request: BatchTextIngestRequest):
 
 
 @router.post("/ingest_url")
-async def ingest_url(request: URLIngestRequest):
+async def ingest_url(request: URLIngestRequest, req: Request):
     """Fetch an HTTP/HTTPS URL and ingest its text content."""
     from axon import api as _api
 
+    enforce_rate_limit(req, bucket="ingest_url", max_hits=20, window_seconds=60.0)
     brain = _api.brain
     if not brain:
         raise HTTPException(status_code=503, detail="Brain not initialized")
@@ -468,12 +470,14 @@ async def ingest_url(request: URLIngestRequest):
 
 @router.post("/ingest/upload")
 async def ingest_upload(
+    req: Request,
     files: list[UploadFile] = File(...),
     project: str | None = Form(None),
 ):
     """Accept multipart file uploads, load them through the normal file loaders, and ingest."""
     from axon import api as _api
 
+    enforce_rate_limit(req, bucket="ingest_upload", max_hits=30, window_seconds=60.0)
     brain = _api.brain
     if not brain:
         raise HTTPException(status_code=503, detail="Brain not initialized")

--- a/src/axon/api_routes/security_routes.py
+++ b/src/axon/api_routes/security_routes.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
 
+from axon.api_routes._rate_limit import enforce_rate_limit
 from axon.api_schemas import (
     SecurityBootstrapRequest,
     SecurityChangePassphraseRequest,
@@ -71,9 +72,10 @@ async def security_status():
 
 
 @router.post("/security/bootstrap")
-async def security_bootstrap(request: SecurityBootstrapRequest):
+async def security_bootstrap(request: SecurityBootstrapRequest, req: Request):
     from axon import security as _security
 
+    enforce_rate_limit(req, bucket="security_bootstrap", max_hits=10, window_seconds=60.0)
     try:
         return _security.bootstrap_store(_current_user_dir(), request.passphrase)
     except _security.SecurityError as exc:
@@ -124,9 +126,10 @@ async def security_lock():
 
 
 @router.post("/security/change-passphrase")
-async def security_change_passphrase(request: SecurityChangePassphraseRequest):
+async def security_change_passphrase(request: SecurityChangePassphraseRequest, req: Request):
     from axon import security as _security
 
+    enforce_rate_limit(req, bucket="security_change_passphrase", max_hits=10, window_seconds=60.0)
     try:
         return _security.change_passphrase(
             _current_user_dir(),

--- a/src/axon/api_routes/shares.py
+++ b/src/axon/api_routes/shares.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
 
+from axon.api_routes._rate_limit import enforce_rate_limit
 from axon.api_schemas import (
     _VALID_PROJECT_NAME_RE,
     ShareExtendRequest,
@@ -169,6 +170,7 @@ async def share_generate(request: ShareGenerateRequest, req: Request):
     from axon import security as _security
     from axon import shares as _shares
 
+    enforce_rate_limit(req, bucket="share_generate", max_hits=10, window_seconds=60.0)
     if not _VALID_PROJECT_NAME_RE.match(request.project):
         raise HTTPException(
             status_code=422,
@@ -247,6 +249,7 @@ async def share_redeem(request: ShareRedeemRequest, req: Request):
     from axon import security as _security
     from axon import shares as _shares
 
+    enforce_rate_limit(req, bucket="share_redeem", max_hits=10, window_seconds=60.0)
     user_dir = _api._get_user_dir()
     rid = getattr(req.state, "request_id", "")
     surface = getattr(req.state, "surface", "api")

--- a/tests/test_api_rate_limits.py
+++ b/tests/test_api_rate_limits.py
@@ -166,7 +166,7 @@ class TestEnforceRateLimit:
                         req, bucket="test_threads", max_hits=100, window_seconds=60.0
                     )
             except HTTPException:
-                pass  # 429 is expected once limit hit — not a bug
+                pass  # max_hits=100 > 5 hits, so 429 won't fire; caught defensively
             except Exception as exc:
                 errors.append(exc)
 

--- a/tests/test_api_rate_limits.py
+++ b/tests/test_api_rate_limits.py
@@ -1,0 +1,229 @@
+"""Tests for the shared per-IP sliding-window rate limiter.
+
+Covers:
+- enforce_rate_limit blocks after max_hits exceeded (HTTP 429)
+- Different IPs don't interfere with each other
+- Direct unit-test of enforce_rate_limit with a fake Request mock
+- IP eviction when the per-bucket dict reaches _MAX_IPS
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(ip: str = "127.0.0.1", xff: str | None = None) -> MagicMock:
+    """Return a fake FastAPI Request whose client.host and headers are controlled."""
+    req = MagicMock()
+    req.client = SimpleNamespace(host=ip)
+    if xff is not None:
+        req.headers = {"X-Forwarded-For": xff}
+    else:
+        req.headers = {}
+    return req
+
+
+def _fresh_module():
+    """Import _rate_limit with a clean state by reloading the module."""
+    import importlib
+
+    import axon.api_routes._rate_limit as rl
+
+    importlib.reload(rl)
+    return rl
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for enforce_rate_limit
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceRateLimit:
+    def setup_method(self):
+        """Reload the module to get a fresh bucket dict for each test."""
+        self.rl = _fresh_module()
+
+    def test_allows_requests_within_limit(self):
+        """max_hits requests should all succeed without raising."""
+        req = _make_request("10.0.0.1")
+        for _ in range(5):
+            self.rl.enforce_rate_limit(req, bucket="test_allow", max_hits=5, window_seconds=60.0)
+
+    def test_blocks_on_max_hits_exceeded(self):
+        """The (max_hits + 1)-th request must raise HTTP 429."""
+        req = _make_request("10.0.0.2")
+        for _ in range(10):
+            self.rl.enforce_rate_limit(req, bucket="test_block", max_hits=10, window_seconds=60.0)
+        with pytest.raises(HTTPException) as exc_info:
+            self.rl.enforce_rate_limit(req, bucket="test_block", max_hits=10, window_seconds=60.0)
+        assert exc_info.value.status_code == 429
+        assert "Too many requests" in exc_info.value.detail
+
+    def test_different_ips_are_independent(self):
+        """Exhausting the limit for IP-A must not affect IP-B."""
+        req_a = _make_request("10.1.0.1")
+        req_b = _make_request("10.1.0.2")
+        # Exhaust IP-A
+        for _ in range(3):
+            self.rl.enforce_rate_limit(req_a, bucket="test_iso", max_hits=3, window_seconds=60.0)
+        with pytest.raises(HTTPException):
+            self.rl.enforce_rate_limit(req_a, bucket="test_iso", max_hits=3, window_seconds=60.0)
+        # IP-B is unaffected
+        self.rl.enforce_rate_limit(req_b, bucket="test_iso", max_hits=3, window_seconds=60.0)
+
+    def test_distinct_buckets_are_independent(self):
+        """Exhausting bucket-A for an IP must not affect bucket-B for the same IP."""
+        req = _make_request("10.2.0.1")
+        for _ in range(2):
+            self.rl.enforce_rate_limit(req, bucket="bucket_a", max_hits=2, window_seconds=60.0)
+        with pytest.raises(HTTPException):
+            self.rl.enforce_rate_limit(req, bucket="bucket_a", max_hits=2, window_seconds=60.0)
+        # bucket_b is unaffected
+        self.rl.enforce_rate_limit(req, bucket="bucket_b", max_hits=2, window_seconds=60.0)
+
+    def test_window_expiry_resets_counter(self):
+        """Hits that fall outside the window should not count."""
+        req = _make_request("10.3.0.1")
+        # Use a very short window (0.05 s) and advance monotonic via patching.
+        # We patch time.monotonic to control time precisely.
+        tick = [0.0]
+
+        def fake_monotonic():
+            return tick[0]
+
+        with patch.object(self.rl.time, "monotonic", side_effect=fake_monotonic):
+            # Fill window at t=0
+            for _ in range(3):
+                self.rl.enforce_rate_limit(
+                    req, bucket="test_expire", max_hits=3, window_seconds=1.0
+                )
+            # Should be blocked
+            with pytest.raises(HTTPException):
+                self.rl.enforce_rate_limit(
+                    req, bucket="test_expire", max_hits=3, window_seconds=1.0
+                )
+            # Advance past the window
+            tick[0] = 2.0
+            # Should be allowed again
+            self.rl.enforce_rate_limit(req, bucket="test_expire", max_hits=3, window_seconds=1.0)
+
+    def test_xff_header_used_for_ip(self):
+        """X-Forwarded-For header takes precedence over client.host."""
+        req = _make_request(ip="192.168.1.1", xff="203.0.113.5, 10.0.0.1")
+        # First hit records IP "203.0.113.5"
+        self.rl.enforce_rate_limit(req, bucket="test_xff", max_hits=1, window_seconds=60.0)
+        # Second hit from the same XFF IP should be blocked
+        with pytest.raises(HTTPException) as exc_info:
+            self.rl.enforce_rate_limit(req, bucket="test_xff", max_hits=1, window_seconds=60.0)
+        assert exc_info.value.status_code == 429
+
+    def test_unknown_ip_when_no_client(self):
+        """When request.client is None and no XFF, IP resolves to 'unknown'."""
+        req = MagicMock()
+        req.client = None
+        req.headers = {}
+        # Should not raise — just uses 'unknown' as IP key
+        self.rl.enforce_rate_limit(req, bucket="test_no_client", max_hits=5, window_seconds=60.0)
+
+    def test_ip_eviction_at_max_ips_cap(self):
+        """When _MAX_IPS is reached, the oldest entry is evicted."""
+        rl = self.rl
+        bucket = "test_evict"
+        # Patch _MAX_IPS to a small value
+        original_max = rl._MAX_IPS
+        rl._MAX_IPS = 3
+        try:
+            for i in range(3):
+                r = _make_request(f"10.10.0.{i}")
+                rl.enforce_rate_limit(r, bucket=bucket, max_hits=10, window_seconds=60.0)
+            # dict is at cap; next IP triggers eviction
+            r_new = _make_request("10.10.0.99")
+            rl.enforce_rate_limit(r_new, bucket=bucket, max_hits=10, window_seconds=60.0)
+            # The per-bucket dict should still be at most _MAX_IPS entries
+            assert len(rl._buckets[bucket]) <= rl._MAX_IPS
+        finally:
+            rl._MAX_IPS = original_max
+
+    def test_thread_safety_no_data_race(self):
+        """Concurrent requests from different IPs should not raise unexpected errors."""
+        rl = self.rl
+        errors: list[Exception] = []
+
+        def _hit(ip: str):
+            req = _make_request(ip)
+            try:
+                for _ in range(5):
+                    rl.enforce_rate_limit(
+                        req, bucket="test_threads", max_hits=100, window_seconds=60.0
+                    )
+            except HTTPException:
+                pass  # 429 is expected once limit hit — not a bug
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_hit, args=(f"172.16.{i}.1",)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread-safety errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests: verify route handlers call enforce_rate_limit
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitImport:
+    """Smoke-check that the modified route modules import cleanly and expose
+    enforce_rate_limit in their namespace (indirectly, via the import)."""
+
+    def test_rate_limit_module_importable(self):
+        from axon.api_routes._rate_limit import enforce_rate_limit  # noqa: F401
+
+    def test_security_routes_import(self):
+        import axon.api_routes.security_routes  # noqa: F401
+
+    def test_shares_routes_import(self):
+        import axon.api_routes.shares  # noqa: F401
+
+    def test_ingest_routes_import(self):
+        import axon.api_routes.ingest  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# _get_ip helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetIp:
+    def setup_method(self):
+        self.rl = _fresh_module()
+
+    def test_xff_single_ip(self):
+        req = _make_request(ip="1.2.3.4", xff="5.6.7.8")
+        assert self.rl._get_ip(req) == "5.6.7.8"
+
+    def test_xff_multiple_ips_returns_first(self):
+        req = _make_request(ip="1.2.3.4", xff="  9.8.7.6 , 1.1.1.1")
+        assert self.rl._get_ip(req) == "9.8.7.6"
+
+    def test_no_xff_uses_client_host(self):
+        req = _make_request(ip="192.0.2.1")
+        assert self.rl._get_ip(req) == "192.0.2.1"
+
+    def test_no_client_and_no_xff_returns_unknown(self):
+        req = MagicMock()
+        req.client = None
+        req.headers = {}
+        assert self.rl._get_ip(req) == "unknown"


### PR DESCRIPTION
New _rate_limit.py shared helper with sliding-window per-IP limiter (10k-IP cap). Applied to /share/generate, /share/redeem, /security/bootstrap, /security/change-passphrase, /ingest/upload, /ingest/url. 17 tests. Part of audit batch A4.