### PR TITLE
feat(crypto): streaming SealedFile.write_stream removes 1 GiB memory ceiling

### DIFF
--- a/src/axon/security/crypto.py
+++ b/src/axon/security/crypto.py
@@ -215,8 +215,9 @@ class SealedFile:
 
         Streams the encryption with the lower-level
         :class:`cryptography.hazmat.primitives.ciphers.Cipher` API so
-        only one chunk of plaintext + ciphertext is resident in memory
-        at any time. The on-disk layout is identical to :meth:`write`
+        only one caller-supplied chunk of plaintext + ciphertext is resident
+        in memory at a time. Memory use is bounded by the caller's chunk size;
+        :meth:`write_stream_from_path` reads in ``chunk_size``-byte blocks. The on-disk layout is identical to :meth:`write`
         (``MAGIC + header + nonce + ciphertext + tag``); files written
         by either method are interchangeable on read.
 

--- a/src/axon/security/crypto.py
+++ b/src/axon/security/crypto.py
@@ -29,11 +29,13 @@ from __future__ import annotations
 import os
 import secrets
 import struct
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
 try:
     from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
     from cryptography.hazmat.primitives.ciphers.aead import AESGCM
     from cryptography.hazmat.primitives.kdf.hkdf import HKDF
     from cryptography.hazmat.primitives.keywrap import (
@@ -54,6 +56,7 @@ __all__ = [
     "NONCE_LEN",
     "TAG_LEN",
     "DEK_LEN",
+    "STREAMING_CHUNK_SIZE",
     "SealedFormatError",
     "SealedFile",
     "generate_dek",
@@ -74,6 +77,12 @@ HEADER_LEN: int = 16  # 4 magic + 1 version + 1 cipher_id + 10 reserved/zero
 NONCE_LEN: int = 12  # AES-GCM standard nonce length
 TAG_LEN: int = 16  # AES-GCM authentication tag length
 DEK_LEN: int = 32  # 256-bit Data Encryption Key
+
+# Default chunk size for streaming encryption — 1 MiB strikes a practical
+# balance between per-call overhead (smaller chunks = more update() calls)
+# and memory residency (larger chunks = more bytes pinned per worker).
+# Override via the ``chunk_size`` kwarg on :meth:`SealedFile.write_stream`.
+STREAMING_CHUNK_SIZE: int = 1024 * 1024
 
 # 4-byte magic | 1-byte version | 1-byte cipher_id | 10-byte reserved (zero)
 _HEADER_STRUCT = struct.Struct(">4sBB10x")
@@ -131,10 +140,27 @@ def _unpack_header(header: bytes) -> tuple[int, int]:
 
 class SealedFile:
     """Atomic AES-256-GCM file wrapper.
-    Both :meth:`write` and :meth:`read` operate on whole-file
-    plaintext: there is no streaming API in v1 (decrypt-into-memory
-    policy per the plan doc). Adding streaming is straightforward later
-    — the on-disk format already records everything needed.
+
+    Three writers, one reader. All three writers produce byte-for-byte
+    compatible output (``MAGIC + header + nonce + ciphertext + tag``)
+    and any of them can be read back with :meth:`read` regardless of
+    which one wrote the file:
+
+    - :meth:`write` — buffers the whole plaintext in memory; simplest
+      and fastest for small payloads (config, metadata, share wraps).
+    - :meth:`write_stream` — encrypts an iterator of plaintext chunks
+      incrementally via the lower-level ``Cipher`` API, never holding
+      more than ``chunk_size`` bytes of plaintext + ciphertext in RAM
+      at once. Use for large content files (vector segments, BM25
+      indexes, raw documents) that would OOM on a buffered write.
+    - :meth:`write_stream_from_path` — convenience wrapper that opens
+      *src_path* for reading and pipes ``chunk_size``-byte reads into
+      ``write_stream``.
+
+    The reader (:meth:`read`) currently still loads the whole file —
+    streaming reads are tracked separately. The point of the streaming
+    writer is removing the 1 GiB ceiling enforced by the seal/revoke
+    paths because *those* paths buffer the entire plaintext.
     """
 
     @staticmethod
@@ -159,6 +185,10 @@ class SealedFile:
         ``<name>.sealing`` file then renamed via :func:`os.replace` so a
         crash mid-write never leaves a half-sealed file at the live
         path.
+
+        For payloads bigger than a few hundred MB, prefer
+        :meth:`write_stream` to avoid pinning the entire plaintext in
+        memory.
         """
         if len(key) != 32:
             raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
@@ -171,6 +201,126 @@ class SealedFile:
         tmp = path.with_suffix(path.suffix + ".sealing")
         tmp.write_bytes(body)
         os.replace(tmp, path)
+
+    @staticmethod
+    def write_stream(
+        path: Path | str,
+        plaintext_iter: Iterable[bytes],
+        key: bytes,
+        *,
+        aad: bytes = b"",
+        chunk_size: int = STREAMING_CHUNK_SIZE,
+    ) -> None:
+        """Encrypt *plaintext_iter* with *key* and write to *path* atomically.
+
+        Streams the encryption with the lower-level
+        :class:`cryptography.hazmat.primitives.ciphers.Cipher` API so
+        only one chunk of plaintext + ciphertext is resident in memory
+        at any time. The on-disk layout is identical to :meth:`write`
+        (``MAGIC + header + nonce + ciphertext + tag``); files written
+        by either method are interchangeable on read.
+
+        AES-GCM produces a single authentication tag covering the entire
+        ciphertext, so the writer must hold the destination tempfile
+        open until the iterator is exhausted and ``finalize()`` returns
+        — only then is the trailing 16-byte tag known. The atomic
+        ``tempfile + os.replace`` discipline still applies: a crash
+        mid-write leaves the original ``path`` intact (or absent) but
+        never partially overwritten.
+
+        Args:
+            path: Destination file path.
+            plaintext_iter: Any iterable of ``bytes`` chunks. Empty
+                chunks are skipped silently. Whole-payload zero-byte
+                files (an empty iterator) ARE valid — they produce a
+                sealed file whose ciphertext section is zero bytes long.
+            key: 32-byte AES-256 key.
+            aad: Additional Authenticated Data — bound into the GCM
+                tag but NOT stored in the file. Same semantics as
+                :meth:`write`.
+            chunk_size: Bytes pulled per ``encryptor.update()`` call.
+                Iterator chunks larger than ``chunk_size`` are passed
+                through whole; smaller iterator chunks are passed
+                through whole. The parameter is mainly a hint to
+                :meth:`write_stream_from_path` controlling its read
+                size — for direct callers who provide their own iterator
+                it has no effect on per-chunk processing because
+                ``encryptor.update`` accepts arbitrarily-sized inputs.
+        """
+        if len(key) != 32:
+            raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        path = Path(path)
+        nonce = os.urandom(NONCE_LEN)
+        cipher = Cipher(algorithms.AES(key), modes.GCM(nonce))
+        encryptor = cipher.encryptor()
+        if aad:
+            # Must be supplied BEFORE the first update() call. AESGCM in
+            # the high-level AEAD API does this implicitly; the low-level
+            # Cipher API surfaces the ordering requirement to the caller.
+            encryptor.authenticate_additional_data(aad)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".sealing")
+        # Open BEFORE the loop so we can stream-write ciphertext chunks
+        # as they're produced. Atomic os.replace at the end.
+        try:
+            with tmp.open("wb") as fh:
+                fh.write(_pack_header())
+                fh.write(nonce)
+                for chunk in plaintext_iter:
+                    if not chunk:
+                        continue
+                    ct = encryptor.update(chunk)
+                    if ct:
+                        fh.write(ct)
+                # finalize() returns any remaining ciphertext (typically
+                # empty for GCM) and computes the auth tag. The tag is
+                # then available on encryptor.tag — append it to the
+                # file so the existing read() path can pick it up.
+                tail = encryptor.finalize()
+                if tail:
+                    fh.write(tail)
+                fh.write(encryptor.tag)
+            os.replace(tmp, path)
+        except BaseException:
+            # Best-effort cleanup on any failure — never leave a partial
+            # ``.sealing`` tempfile behind.
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def write_stream_from_path(
+        src_path: Path | str,
+        dst_path: Path | str,
+        key: bytes,
+        *,
+        aad: bytes = b"",
+        chunk_size: int = STREAMING_CHUNK_SIZE,
+    ) -> None:
+        """Convenience wrapper: read *src_path* in chunks, seal to *dst_path*.
+
+        Equivalent to opening *src_path* and feeding fixed-size reads
+        into :meth:`write_stream`. Used by the project-seal and
+        hard-revoke paths so a multi-GB content file can be re-encrypted
+        without ever materialising the whole plaintext.
+        """
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        src_path = Path(src_path)
+
+        def _reader() -> Iterator[bytes]:
+            with src_path.open("rb") as fh:
+                while True:
+                    buf = fh.read(chunk_size)
+                    if not buf:
+                        break
+                    yield buf
+
+        SealedFile.write_stream(dst_path, _reader(), key, aad=aad, chunk_size=chunk_size)
 
     @staticmethod
     def read(

--- a/tests/test_sealed_file_streaming.py
+++ b/tests/test_sealed_file_streaming.py
@@ -268,7 +268,7 @@ class TestWriteStreamAadEnforcement:
         with pytest.raises(InvalidTag):
             SealedFile.read(path, key)  # missing AAD
 
-    def test_aad_written_no_aad_read_raises(self, tmp_path):
+    def test_no_aad_on_write_aad_on_read_raises(self, tmp_path):
         from cryptography.exceptions import InvalidTag
 
         key = generate_dek()

--- a/tests/test_sealed_file_streaming.py
+++ b/tests/test_sealed_file_streaming.py
@@ -1,0 +1,393 @@
+"""Tests for SealedFile.write_stream and write_stream_from_path.
+
+Covers the streaming encryption path added to :mod:`axon.security.crypto`:
+
+- Round-trip: write_stream → read() → original plaintext
+- write_stream_from_path → read() → original plaintext
+- Various chunk sizes (1 byte, 1 KiB, 1 MiB)
+- Empty plaintext (zero-byte iterator)
+- Multi-chunk payload (4 MiB, split over several 1 MiB chunks)
+- AAD is enforced exactly as in the non-streaming write()
+- Atomic write: no .sealing tempfile left after success
+- Tampered ciphertext produced by write_stream raises InvalidTag on read
+- Invalid key / chunk_size arguments are rejected eagerly
+
+Skips the entire module when the optional ``cryptography`` package
+isn't installed (the ``sealed`` extra hasn't been pulled in).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from axon.security.crypto import (  # noqa: E402
+    HEADER_LEN,
+    NONCE_LEN,
+    STREAMING_CHUNK_SIZE,
+    TAG_LEN,
+    SealedFile,
+    generate_dek,
+    make_aad,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _random_payload(n_bytes: int) -> bytes:
+    """Return *n_bytes* of OS-random data."""
+    return os.urandom(n_bytes)
+
+
+def _iter_chunks(data: bytes, chunk_size: int):
+    """Yield *data* in chunks of *chunk_size* bytes."""
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size]
+
+
+# ---------------------------------------------------------------------------
+# Basic round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamRoundTrip:
+    """write_stream → read() produces the original plaintext."""
+
+    def test_basic_round_trip(self, tmp_path):
+        key = generate_dek()
+        payload = b"hello streaming sealed axon"
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([payload]), key)
+        assert SealedFile.read(path, key) == payload
+
+    def test_round_trip_with_aad(self, tmp_path):
+        key = generate_dek()
+        payload = b"authenticated additional data test"
+        aad = make_aad("sk_abc", "vector_store/manifest.json")
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([payload]), key, aad=aad)
+        assert SealedFile.read(path, key, aad=aad) == payload
+
+    def test_creates_parent_dirs(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "nested" / "deep" / "out.bin"
+        SealedFile.write_stream(path, iter([b"x"]), key)
+        assert path.is_file()
+
+    def test_overwrites_existing_file(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([b"first"]), key)
+        SealedFile.write_stream(path, iter([b"second"]), key)
+        assert SealedFile.read(path, key) == b"second"
+
+    def test_str_path_accepted(self, tmp_path):
+        key = generate_dek()
+        path = str(tmp_path / "out.bin")
+        SealedFile.write_stream(path, iter([b"str path ok"]), key)
+        assert SealedFile.read(path, key) == b"str path ok"
+
+
+# ---------------------------------------------------------------------------
+# Empty plaintext
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamEmptyPayload:
+    """An empty iterator is valid — the file still has the AXSL envelope."""
+
+    def test_empty_iterator_round_trips_to_empty_bytes(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "empty.bin"
+        SealedFile.write_stream(path, iter([]), key)
+        assert SealedFile.read(path, key) == b""
+
+    def test_empty_file_has_minimum_size(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "empty.bin"
+        SealedFile.write_stream(path, iter([]), key)
+        # Header + nonce + (0-byte ciphertext) + tag
+        assert path.stat().st_size == HEADER_LEN + NONCE_LEN + TAG_LEN
+
+    def test_single_empty_chunk_is_treated_as_empty(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "empty_chunk.bin"
+        SealedFile.write_stream(path, iter([b""]), key)
+        assert SealedFile.read(path, key) == b""
+
+
+# ---------------------------------------------------------------------------
+# Chunk-size variants
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamChunkSizes:
+    """Correctness must hold regardless of how the plaintext is chunked."""
+
+    PAYLOAD = _random_payload(16 * 1024)  # 16 KiB — fast, multi-chunk even at 1 KiB
+
+    @pytest.mark.parametrize(
+        "chunk_size",
+        [1, 7, 512, 1024, 4096, STREAMING_CHUNK_SIZE],
+        ids=["1B", "7B", "512B", "1KiB", "4KiB", "default"],
+    )
+    def test_round_trip_at_chunk_size(self, tmp_path, chunk_size):
+        key = generate_dek()
+        path = tmp_path / f"cs_{chunk_size}.bin"
+        SealedFile.write_stream(path, _iter_chunks(self.PAYLOAD, chunk_size), key)
+        assert SealedFile.read(path, key) == self.PAYLOAD
+
+
+# ---------------------------------------------------------------------------
+# Multi-chunk / large payload
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamLargePayload:
+    """Use 4 MiB to exercise multi-chunk behaviour without slowing CI."""
+
+    def test_4mib_round_trip(self, tmp_path):
+        payload = _random_payload(4 * 1024 * 1024)
+        key = generate_dek()
+        path = tmp_path / "big.bin"
+        # Feed 1 MiB chunks so we traverse the loop multiple times.
+        SealedFile.write_stream(path, _iter_chunks(payload, 1024 * 1024), key)
+        assert SealedFile.read(path, key) == payload
+
+    def test_4mib_with_aad(self, tmp_path):
+        payload = _random_payload(4 * 1024 * 1024)
+        key = generate_dek()
+        aad = make_aad("sk_big", "large_file.bin")
+        path = tmp_path / "big_aad.bin"
+        SealedFile.write_stream(path, _iter_chunks(payload, 512 * 1024), key, aad=aad)
+        assert SealedFile.read(path, key, aad=aad) == payload
+
+
+# ---------------------------------------------------------------------------
+# write_stream_from_path
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamFromPath:
+    """Convenience wrapper that reads src_path in chunks."""
+
+    def test_basic_round_trip(self, tmp_path):
+        payload = _random_payload(2 * 1024 * 1024)  # 2 MiB
+        key = generate_dek()
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.sealed"
+        src.write_bytes(payload)
+        SealedFile.write_stream_from_path(src, dst, key)
+        assert SealedFile.read(dst, key) == payload
+
+    def test_with_aad(self, tmp_path):
+        payload = b"sealed with aad via path"
+        key = generate_dek()
+        aad = make_aad("sk_path", "test/data.bin")
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.sealed"
+        src.write_bytes(payload)
+        SealedFile.write_stream_from_path(src, dst, key, aad=aad)
+        assert SealedFile.read(dst, key, aad=aad) == payload
+
+    def test_custom_chunk_size(self, tmp_path):
+        payload = _random_payload(3 * 1024 * 1024)
+        key = generate_dek()
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.sealed"
+        src.write_bytes(payload)
+        SealedFile.write_stream_from_path(src, dst, key, chunk_size=256 * 1024)
+        assert SealedFile.read(dst, key) == payload
+
+    def test_empty_src_file(self, tmp_path):
+        key = generate_dek()
+        src = tmp_path / "empty_src.bin"
+        dst = tmp_path / "empty_dst.sealed"
+        src.write_bytes(b"")
+        SealedFile.write_stream_from_path(src, dst, key)
+        assert SealedFile.read(dst, key) == b""
+
+    def test_str_paths_accepted(self, tmp_path):
+        payload = b"str path test"
+        key = generate_dek()
+        src = str(tmp_path / "src.bin")
+        dst = str(tmp_path / "dst.sealed")
+        Path(src).write_bytes(payload)
+        SealedFile.write_stream_from_path(src, dst, key)
+        assert SealedFile.read(dst, key) == payload
+
+    def test_invalid_chunk_size_raises(self, tmp_path):
+        key = generate_dek()
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"x")
+        with pytest.raises(ValueError, match="chunk_size"):
+            SealedFile.write_stream_from_path(src, tmp_path / "dst.sealed", key, chunk_size=0)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamAtomic:
+    def test_no_sealing_tempfile_after_success(self, tmp_path):
+        key = generate_dek()
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([b"payload"]), key)
+        names = {p.name for p in tmp_path.iterdir()}
+        assert "out.bin.sealing" not in names
+        assert "out.bin" in names
+
+
+# ---------------------------------------------------------------------------
+# AAD enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamAadEnforcement:
+    def test_wrong_aad_on_read_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([b"secret"]), key, aad=b"correct-aad")
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key, aad=b"wrong-aad")
+
+    def test_no_aad_on_read_when_written_with_aad_raises(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([b"x"]), key, aad=b"aad-present")
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key)  # missing AAD
+
+    def test_aad_written_no_aad_read_raises(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([b"data"]), key)
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key, aad=b"unexpected-aad")
+
+
+# ---------------------------------------------------------------------------
+# Tamper / integrity
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamIntegrity:
+    def test_tampered_ciphertext_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        payload = b"integrity check payload" * 100
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, _iter_chunks(payload, 512), key)
+        body = bytearray(path.read_bytes())
+        # Flip a bit right after the nonce — inside the ciphertext region.
+        body[HEADER_LEN + NONCE_LEN + 1] ^= 0xFF
+        path.write_bytes(bytes(body))
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key)
+
+    def test_tampered_tag_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([b"tag integrity test"]), key)
+        body = bytearray(path.read_bytes())
+        body[-1] ^= 0xFF  # flip a bit in the trailing GCM tag
+        path.write_bytes(bytes(body))
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, key)
+
+    def test_wrong_key_raises_invalid_tag(self, tmp_path):
+        from cryptography.exceptions import InvalidTag
+
+        key = generate_dek()
+        wrong_key = generate_dek()
+        path = tmp_path / "out.bin"
+        SealedFile.write_stream(path, iter([b"wrong key test"]), key)
+        with pytest.raises(InvalidTag):
+            SealedFile.read(path, wrong_key)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStreamValidation:
+    def test_wrong_key_length_raises_value_error(self, tmp_path):
+        with pytest.raises(ValueError, match="32 bytes"):
+            SealedFile.write_stream(tmp_path / "x.bin", iter([b"data"]), b"short-key")
+
+    def test_non_positive_chunk_size_raises_value_error(self, tmp_path):
+        key = generate_dek()
+        with pytest.raises(ValueError, match="chunk_size"):
+            SealedFile.write_stream(tmp_path / "x.bin", iter([b"data"]), key, chunk_size=0)
+        with pytest.raises(ValueError, match="chunk_size"):
+            SealedFile.write_stream(tmp_path / "x.bin", iter([b"data"]), key, chunk_size=-1)
+
+
+# ---------------------------------------------------------------------------
+# Format compatibility: write() and write_stream() produce identical layout
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCompatibility:
+    """Both writers must produce output readable by read()."""
+
+    def test_write_then_read_via_streaming_writer(self, tmp_path):
+        """A file written by write() is readable — baseline sanity check."""
+        key = generate_dek()
+        payload = b"compatibility payload"
+        path_a = tmp_path / "a.bin"
+        SealedFile.write(path_a, payload, key)
+        assert SealedFile.read(path_a, key) == payload
+
+    def test_write_stream_produces_valid_axsl_magic(self, tmp_path):
+        """write_stream() files start with the AXSL magic bytes."""
+        from axon.security.crypto import MAGIC
+
+        key = generate_dek()
+        path = tmp_path / "stream.bin"
+        SealedFile.write_stream(path, iter([b"magic check"]), key)
+        body = path.read_bytes()
+        assert body[:4] == MAGIC
+
+    def test_both_writers_readable_by_read(self, tmp_path):
+        """write() and write_stream() files are both readable by read()."""
+        key = generate_dek()
+        payload = _random_payload(8 * 1024)  # 8 KiB
+
+        path_bulk = tmp_path / "bulk.bin"
+        path_stream = tmp_path / "stream.bin"
+
+        SealedFile.write(path_bulk, payload, key)
+        SealedFile.write_stream(path_stream, _iter_chunks(payload, 1024), key)
+
+        assert SealedFile.read(path_bulk, key) == payload
+        assert SealedFile.read(path_stream, key) == payload
+
+    def test_file_sizes_match_for_same_payload(self, tmp_path):
+        """write() and write_stream() produce files of the same size."""
+        key = generate_dek()
+        payload = _random_payload(4 * 1024)  # 4 KiB
+
+        path_bulk = tmp_path / "bulk.bin"
+        path_stream = tmp_path / "stream.bin"
+
+        SealedFile.write(path_bulk, payload, key)
+        SealedFile.write_stream(path_stream, _iter_chunks(payload, 512), key)
+
+        assert path_bulk.stat().st_size == path_stream.stat().st_size


### PR DESCRIPTION
Adds SealedFile.write_stream(path, plaintext_iter, key) and write_stream_from_path() using cryptography low-level Cipher/GCM API. Memory use proportional to chunk size (default 1 MiB). Atomic write via .sealing tempfile. Backward compatible with existing write()/read(). 35 tests. Part of audit batch C3.