### PR TITLE
docs: ADMIN_REFERENCE.md rewrite + doc cleanup sweep (F1+F2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Most RAG tools make you choose between **cloud power** and **data privacy**. Axo
 ### 🛡️ Governance & Agents
 - **Governance Console** — full audit trail of every query
 - Graceful maintenance states: `normal → draining → readonly → offline`
-- **REST API** — 54 endpoints with Swagger docs at `/docs`
-- **MCP server** — 31 tools for Claude Code, Codex, Gemini, Cursor, Copilot
+- **REST API** — 66 endpoints with Swagger docs at `/docs`
+- **MCP server** — 39 tools for Claude Code, Codex, Gemini, Cursor, Copilot
 - **`@axon`** VS Code chat participant with Graph and Governance panels
 
 </td>
@@ -154,9 +154,9 @@ Extensions panel  →  "..."  →  Install from VSIX...
 →  run `axon-ext`  (or install from VSIX manually)
 ```
 
-Or connect via MCP for Copilot agent mode — point `.vscode/mcp.json` at `axon-mcp` and all 31 tools appear in the agent hammer menu automatically.
+Or connect via MCP for Copilot agent mode — point `.vscode/mcp.json` at `axon-mcp` and all 39 tools appear in the agent hammer menu automatically.
 
-> The VS Code extension surfaces **35 LM tools** to Copilot Chat (a superset of the 31 MCP tools, adding VS Code–specific helpers like `show_graph`).
+> The VS Code extension surfaces **35 LM tools** to Copilot Chat (a superset of the 39 MCP tools, adding VS Code–specific helpers like `show_graph`).
 
 **[Full setup guide →](https://github.com/jyunming/Axon/blob/main/docs/SETUP.md)**
 
@@ -179,7 +179,7 @@ Or connect via MCP for Copilot agent mode — point `.vscode/mcp.json` at `axon-
 | 🔑 | **[Admin Reference](https://github.com/jyunming/Axon/blob/main/docs/ADMIN_REFERENCE.md)** | Every endpoint, REPL command, CLI flag, and config option |
 | ⚡ | **[Quick Reference](https://github.com/jyunming/Axon/blob/main/docs/QUICKREF.md)** | Commands and flags at a glance |
 | 📡 | **[API Reference](https://github.com/jyunming/Axon/blob/main/docs/API_REFERENCE.md)** | Full REST endpoint reference with request/response schemas |
-| 🔌 | **[MCP Tools](https://github.com/jyunming/Axon/blob/main/docs/MCP_TOOLS.md)** | All 31 MCP tool signatures with parameter defaults |
+| 🔌 | **[MCP Tools](https://github.com/jyunming/Axon/blob/main/docs/MCP_TOOLS.md)** | All 39 MCP tool signatures with parameter defaults |
 
 **Deep dives**
 
@@ -194,6 +194,7 @@ Or connect via MCP for Copilot agent mode — point `.vscode/mcp.json` at `axon-
 | 📦 | **[Share Mount Guide](https://github.com/jyunming/Axon/blob/main/docs/SHARE_MOUNT.md)** | Which filesystems work for cross-machine sharing (and which corrupt) |
 | 🧪 | **[Share Mount Smoke](https://github.com/jyunming/Axon/blob/main/docs/SHARE_MOUNT_SMOKE.md)** | Manual two-machine OneDrive verification recipe (run before each share-mount release) |
 | 🔐 | **[Share Mount Sealed (plan)](https://github.com/jyunming/Axon/blob/main/docs/SHARE_MOUNT_SEALED.md)** | Encrypted-at-rest share mounts — the next big design change for OneDrive-safe sharing |
+| 🔬 | **[Share Mount Sealed Smoke](https://github.com/jyunming/Axon/blob/main/docs/SHARE_MOUNT_SEALED_SMOKE.md)** | Manual verification recipe for sealed-store two-machine runs |
 | 📊 | **[Governance Console](https://github.com/jyunming/Axon/blob/main/docs/GOVERNANCE_CONSOLE.md)** | Audit trail, maintenance runbook, session management |
 | 📈 | **[Evaluation Guide](https://github.com/jyunming/Axon/blob/main/docs/EVALUATION.md)** | RAGAS metrics, running evals, building testsets |
 | 🛠️ | **[Development Guide](https://github.com/jyunming/Axon/blob/main/docs/DEVELOPMENT.md)** | Tests, contributing, pre-commit hooks, packaging & release |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Extensions panel  →  "..."  →  Install from VSIX...
 
 Or connect via MCP for Copilot agent mode — point `.vscode/mcp.json` at `axon-mcp` and all 39 tools appear in the agent hammer menu automatically.
 
-> The VS Code extension surfaces **35 LM tools** to Copilot Chat (a superset of the 39 MCP tools, adding VS Code–specific helpers like `show_graph`).
+> The VS Code extension surfaces **35 LM tools** to Copilot Chat, covering core RAG operations, sealed-store security, sharing, and governance.
 
 **[Full setup guide →](https://github.com/jyunming/Axon/blob/main/docs/SETUP.md)**
 

--- a/docs/ADMIN_REFERENCE.md
+++ b/docs/ADMIN_REFERENCE.md
@@ -730,7 +730,7 @@ YAML section: `rag:` (graph_rag_* keys)
 | `rag.graph_rag_ner_backend` | str | `llm` | NER backend: `llm` (default) or `gliner` (no LLM for entity extraction) |
 | `rag.graph_rag_relation_backend` | str | `llm` | Relation extraction backend: `llm` or `rebel` |
 | `rag.graph_rag_entity_resolve` | bool | `false` | Merge near-duplicate entity names via cosine similarity |
-| `rag.graph_backend` | str | `graphrag` | Graph backend: `graphrag` (default) or `dynamic` (SQLite-WAL temporal graph) |
+| `rag.graph_backend` | str | `graphrag` | Graph backend: `graphrag` (default) or `dynamic` (SQLite with DELETE journal mode temporal graph) |
 | `rag.code_graph` | bool | `false` | Build File/Symbol nodes with CONTAINS/IMPORTS edges from code chunk metadata |
 | `rag.code_graph_bridge` | bool | `false` | Add MENTIONED_IN edges linking prose chunks to code symbols |
 

--- a/docs/ADMIN_REFERENCE.md
+++ b/docs/ADMIN_REFERENCE.md
@@ -1,10 +1,9 @@
-# Axon Operator & Admin Reference
+# Axon Admin Reference
 
-Complete function reference for operators and administrators of an Axon deployment.
-This document covers every exposed entry point across all four surfaces: REST API, REPL, CLI, and MCP Server.
+Complete operator reference for Axon deployments.
+Covers all four surfaces: CLI, REPL, REST API, and MCP server.
 
-For installation and initial setup, see [SETUP.md](SETUP.md).
-
+For installation and first-run setup, see [SETUP.md](SETUP.md).
 For interactive API docs, start `axon-api` and open `http://localhost:8000/docs`.
 
 ---
@@ -17,10 +16,11 @@ For interactive API docs, start `axon-api` and open `http://localhost:8000/docs`
 | `axon-api` | FastAPI REST server + WebGUI | `8000` | Agents, scripts, CI pipelines, browser UI |
 | `axon-mcp` | MCP stdio server | — | GitHub Copilot agent mode, Claude Code |
 | `axon-ui` | Streamlit web UI | `8501` | Alternative browser-based exploration |
+| `axon-ext` | Install VS Code extension | — | Registers the bundled VSIX in VS Code |
 
-When `axon-api` is running, the built-in WebGUI is available at `http://localhost:8000/gui/` — no separate command needed. It provides chat, document management, and graph exploration in a single-page app.
+When `axon-api` is running, the built-in WebGUI is at `http://localhost:8000/gui/`.
 
-Start flags:
+Start flags for the API server:
 
 ```bash
 axon-api --host 0.0.0.0 --port 8000   # bind to all interfaces
@@ -30,29 +30,304 @@ axon-api --config /path/to/config.yaml  # explicit config file
 
 ---
 
-## 2. REST API — Full Endpoint Reference
+## 2. CLI Reference
 
-**55 endpoints** across 8 route files. Base URL: `http://localhost:8000` (default).
+```bash
+axon [options] ["query string"]
+```
 
-Interactive docs: `/docs` (Swagger), `/redoc`.
+If no query string is given, the interactive REPL starts. If a query string is given, a single query runs and exits.
 
-> For compact endpoint tables without request/response schemas, see [API_REFERENCE.md](API_REFERENCE.md).
+### 2.1 Global Options
 
-### 2.1 Health
+| Flag | Description |
+|------|-------------|
+| `--version` | Print version and exit |
+| `--config PATH` | Path to config YAML (default: `~/.config/axon/config.yaml`) |
+| `--quiet` / `-q` | Suppress spinners and progress (auto-enabled when stdin is not a TTY) |
+| `--non-interactive` | Run in headless mode — do not start the interactive REPL (useful for scripts/CI) |
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `GET` | `/health` | None | Liveness probe — returns `{"status": "ok", "project": "<active-project>"}` |
+### 2.2 Query & Output
 
-### 2.2 Query & Search
+| Flag | Description |
+|------|-------------|
+| `"query string"` | Run a single query (non-interactive) |
+| `--stream` | Stream response token-by-token |
+| `--cite` / `--no-cite` | Enable/disable inline `[Document N]` citations in the response |
+| `--dry-run` | Skip LLM; run retrieval only and print diagnostics and ranked chunks (requires a query argument) |
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `POST` | `/query` | Optional | Full RAG synthesis with optional citations, streaming, and per-request flag overrides |
-| `POST` | `/query/stream` | Optional | SSE streaming version of `/query` — returns `text/event-stream` |
-| `POST` | `/search` | Optional | Semantic/hybrid search — raw document chunks with scores; no LLM synthesis |
-| `POST` | `/search/raw` | Optional | Raw retrieval with optional diagnostics trace; no synthesis |
-| `POST` | `/clear` | Required | Wipe all vectors and BM25 index for the active project |
+### 2.3 RAG Flags (single-query overrides)
+
+| Flag | Description |
+|------|-------------|
+| `--hyde` / `--no-hyde` | Enable/disable HyDE (hypothetical document embedding) |
+| `--multi-query` / `--no-multi-query` | Enable/disable multi-query retrieval (3 paraphrases) |
+| `--step-back` / `--no-step-back` | Enable/disable step-back query abstraction |
+| `--decompose` / `--no-decompose` | Enable/disable query decomposition into sub-questions |
+| `--compress` / `--no-compress` | Enable/disable LLM context compression |
+| `--rerank` / `--no-rerank` | Enable/disable cross-encoder reranking |
+| `--reranker-model MODEL` | Reranker model (e.g. `BAAI/bge-reranker-v2-m3`; default: `cross-encoder/ms-marco-MiniLM-L-6-v2`) |
+| `--hybrid` / `--no-hybrid` | Enable/disable BM25+vector hybrid search |
+| `--graph-rag` / `--no-graph-rag` | Enable/disable GraphRAG entity-graph retrieval |
+| `--graph-rag-mode MODE` | GraphRAG traversal mode: `local`, `global`, or `hybrid` |
+| `--graph-rag-max-hops N` | Max relation-hop depth from matched entity (`0` = direct only) |
+| `--graph-rag-hop-decay F` | Score multiplier per hop (default `0.7`) |
+| `--no-graph-rag-weighted` | Use plain BFS hop count instead of Dijkstra weighted traversal |
+| `--raptor` / `--no-raptor` | Enable/disable RAPTOR hierarchical summary retrieval |
+| `--raptor-group-size N` | Chunks grouped per RAPTOR summary (default: `5`) |
+| `--sentence-window` / `--no-sentence-window` | Enable/disable sentence-window retrieval |
+| `--sentence-window-size N` | Surrounding sentences to include per matched chunk (1–10) |
+| `--crag-lite` / `--no-crag-lite` | Enable/disable CRAG-Lite corrective retrieval |
+| `--discuss` / `--no-discuss` | Enable/disable general-knowledge fallback when no docs match |
+| `--search` / `--no-search` | Enable/disable Brave web search fallback (requires `BRAVE_API_KEY`) |
+| `--cache` / `--no-cache` | Enable/disable in-memory query result caching |
+| `--top-k N` | Number of chunks to retrieve (default: from config, usually `10`) |
+| `--threshold F` | Similarity threshold for retrieval, `0.0`–`1.0` (default: `0.3`) |
+| `--temperature F` | LLM temperature for generation, `0.0`–`2.0` (default: from config) |
+| `--code-graph` / `--no-code-graph` | Enable/disable structural code-symbol graph construction during ingest |
+| `--code-graph-bridge` / `--no-code-graph-bridge` | Enable/disable Phase-3 code-graph bridge (prose-to-code symbol links; requires `--code-graph`) |
+
+### 2.4 Model & Provider
+
+| Flag | Description |
+|------|-------------|
+| `--provider PROVIDER` | LLM provider: `ollama`, `openai`, `gemini`, `grok`, `vllm`, `github_copilot`, `ollama_cloud` |
+| `--model NAME` | LLM model name (e.g. `gemma:2b`, `gemini-1.5-flash`, `gpt-4o`). Also accepts `provider/model` format |
+| `--embed MODEL` | Embedding model (e.g. `all-MiniLM-L6-v2` or `ollama/nomic-embed-text`). Accepts `provider/model` format |
+| `--list-models` | List supported providers and locally installed Ollama models, then exit |
+| `--pull MODEL` | Pull an Ollama model by name, then exit (e.g. `--pull gemma:2b`) |
+
+### 2.5 Ingestion
+
+| Flag | Description |
+|------|-------------|
+| `--ingest PATH` | Ingest a file or directory into the knowledge base, then exit |
+| `--no-dedup` | Disable ingest deduplication (allow re-ingesting identical content) |
+| `--chunk-strategy STRATEGY` | Chunking strategy: `recursive` or `semantic` |
+| `--parent-chunk-size N` | Enable small-to-big retrieval: index child chunks but return parent passages of N tokens as LLM context. `0` = disabled |
+| `--refresh` | Re-ingest any tracked files whose content has changed since last ingest, then exit |
+| `--list-stale` | List documents not re-ingested within `--stale-days` days, then exit |
+| `--stale-days N` | Age threshold in days for `--list-stale` (default: `7`) |
+| `--delete-doc SOURCE` | Delete all chunks for a source (matched by source path/name), then exit |
+| `--delete-doc-id ID...` | Delete specific chunk IDs directly (space-separated), then exit |
+
+### 2.6 Collection & Listing
+
+| Flag | Description |
+|------|-------------|
+| `--list` | List all ingested sources with chunk counts, then exit |
+| `--session-list` | List saved conversation sessions for the current project, then exit |
+
+### 2.7 Project Management
+
+| Flag | Description |
+|------|-------------|
+| `--project NAME` | Use an existing named project (`"default"` = global knowledge base) |
+| `--project-new NAME` | Create a new project (if it does not exist) and use it. Combine with `--ingest` to populate in one step |
+| `--project-list` | List all projects and exit |
+| `--project-delete NAME` | Delete a project and all its data, then exit |
+
+### 2.8 Graph Operations
+
+| Flag | Description |
+|------|-------------|
+| `--graph-status` | Print knowledge graph status (entity count, code nodes, community state), then exit |
+| `--graph-finalize` | Rebuild community summaries and finalize the knowledge graph, then exit |
+| `--graph-export [PATH]` | Export the entity graph as an HTML file to PATH (default: active project dir/graph.html), then exit |
+
+### 2.9 Vector Index Management
+
+| Flag | Description |
+|------|-------------|
+| `--optimize-index` | Build or rebuild the ANN vector index (LanceDB IVF_PQ) for the active project, then exit |
+| `--migrate-vectors [CHROMA_PATH]` | Migrate vectors from ChromaDB at CHROMA_PATH (or `auto` to auto-detect) to LanceDB, then exit |
+
+### 2.10 Config Management
+
+| Flag | Description |
+|------|-------------|
+| `--config-validate` | Validate `config.yaml` and print issues; exits with code `1` if any errors found |
+| `--config-reset` | Reset `config.yaml` to built-in defaults and exit |
+| `--setup` | Run the interactive config setup wizard and exit |
+
+### 2.11 AxonStore (Sealed Store)
+
+| Flag | Description |
+|------|-------------|
+| `--store-init PATH` | Initialise AxonStore multi-user mode at PATH (e.g. `~/axon_data`), then exit |
+| `--store-status` | Show sealed-store init/unlock state, then exit |
+| `--store-bootstrap PASSPHRASE` | One-time sealed-store init with PASSPHRASE. Generates the master key and persists to OS keyring. Losing this passphrase means losing every sealed project — no recovery |
+| `--store-unlock PASSPHRASE` | Unlock the sealed-store for sealed-project queries. Required after every process restart before `--project-seal` works |
+| `--store-lock` | Clear the in-process master key cache, then exit |
+| `--store-change-passphrase OLD NEW` | Rotate the sealed-store passphrase (O(1) — project DEKs are not re-encrypted) |
+| `--project-seal NAME` | Encrypt every content file in project NAME at rest, then exit. Requires store to be unlocked first |
+
+### 2.12 Share Lifecycle
+
+| Flag | Description |
+|------|-------------|
+| `--share-list` | List shares issued by and received by this user, then exit |
+| `--share-generate PROJECT GRANTEE` | Generate a read-only share key for PROJECT and GRANTEE, then exit |
+| `--share-redeem SHARE_STRING` | Redeem a share string and mount the shared project, then exit |
+| `--share-revoke KEY_ID` | Revoke a previously issued share by KEY_ID. For sealed shares (`KEY_ID` starts with `ssk_`), pair with `--share-project` |
+| `--share-rotate` | Hard-revoke a sealed share: rotate the project DEK and re-encrypt every content file (invalidates all share wraps). Pair with `--share-revoke` and `--share-project` |
+| `--share-project NAME` | Project name companion to `--share-revoke` when revoking a sealed share. Required for `ssk_` key IDs |
+
+---
+
+## 3. REPL Commands
+
+Start the REPL with `axon`. All commands begin with `/`. Use `!<cmd>` for shell passthrough (controlled by `repl.shell_passthrough` in config).
+
+### 3.1 Navigation & General
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/help [cmd]` | Show all commands, or detailed help for a specific command | `/help rag` |
+| `/quit` or `/exit` | Exit the REPL | `/quit` |
+| `/clear` | Clear conversation history (does not delete the saved session) | `/clear` |
+| `/debug` | Toggle verbose debug logging on/off | `/debug` |
+| `/theme [NAME]` | Switch syntax-highlighting theme for code blocks (e.g. `monokai`, `dracula`, `solarized-dark`) | `/theme dracula` |
+| `/keys [set PROVIDER]` | Show API key status for all providers; `/keys set <provider>` saves interactively | `/keys set openai` |
+
+### 3.2 Ingestion & Collection
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/ingest PATH` | Ingest a file, directory, or glob pattern | `/ingest ./docs/` |
+| `/ingest URL` | Fetch and ingest a public URL | `/ingest https://example.com/page` |
+| `/refresh` | Re-ingest all tracked files whose content has changed (SHA-256 dedup) | `/refresh` |
+| `/stale [N]` | List documents not refreshed in N days (default: 7) | `/stale 14` |
+| `/list` | List all ingested sources with chunk counts | `/list` |
+| `/compact` | Compact storage (rebuild BM25 index and defrag vector store) | `/compact` |
+
+### 3.3 Query & Search
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `<any text>` | Send a query to the RAG pipeline and get a synthesised answer | `What is RAPTOR?` |
+| `/search QUERY` | Vector search without LLM synthesis — shows raw ranked chunks | `/search entity graph` |
+| `/retry` | Re-send the last query (useful after changing model or RAG flags) | `/retry` |
+| `/discuss` | Toggle `discussion_fallback` — allow general-knowledge answers when no docs match | `/discuss` |
+| `/search` | Toggle Brave web search fallback (`truth_grounding`) | `/search` |
+| `/agent` | Toggle agent mode (LLM calls Axon tools) | `/agent` |
+
+### 3.4 RAG Configuration
+
+All RAG flags can be toggled at runtime without restarting.
+
+| Command | Flag | Description |
+|---------|------|-------------|
+| `/rag` | — | Show all current RAG settings |
+| `/rag hybrid` | `hybrid_search` | Toggle BM25+vector hybrid search |
+| `/rag hyde` | `hyde` | Toggle HyDE (hypothetical document embedding) |
+| `/rag multi` | `multi_query` | Toggle multi-query (3 query paraphrases) |
+| `/rag step-back` | `step_back` | Toggle step-back abstraction |
+| `/rag decompose` | `query_decompose` | Toggle query decomposition into sub-questions |
+| `/rag compress` | `compress_context` | Toggle context compression |
+| `/rag rerank` | `rerank` | Toggle cross-encoder reranking |
+| `/rag rerank-model MODEL` | `reranker_model` | Set reranker model |
+| `/rag sentence-window` | `sentence_window` | Toggle sentence-window retrieval |
+| `/rag crag-lite` | `crag_lite` | Toggle CRAG-Lite corrective retrieval |
+| `/rag cite` | `cite` | Toggle inline citations |
+| `/rag raptor` | `raptor` | Toggle RAPTOR hierarchical summaries |
+| `/rag graph-rag` | `graph_rag` | Toggle GraphRAG entity-graph retrieval |
+| `/rag topk N` | `top_k` | Set number of retrieved chunks (e.g. `/rag topk 20`) |
+| `/rag threshold F` | `similarity_threshold` | Set minimum similarity score (e.g. `/rag threshold 0.4`) |
+
+### 3.5 Model Configuration
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/model [provider/model]` | Switch LLM provider and model. Auto-detects provider from model name (`gemini-*` → gemini, `gpt-*` → openai, else → ollama). Auto-pulls Ollama models if not present | `/model gemini/gemini-2.0-flash` |
+| `/llm [temp=N]` | Show or set LLM temperature | `/llm temp=0.3` |
+| `/embed [provider/model]` | Switch embedding provider and model | `/embed ollama/nomic-embed-text` |
+| `/pull NAME` | Pull an Ollama model with a progress indicator | `/pull gemma3:12b` |
+| `/vllm-url [URL]` | Show or set the vLLM server base URL | `/vllm-url http://gpu-box:8000/v1` |
+
+### 3.6 Configuration
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/config` | Show current effective configuration (all fields and values) | `/config` |
+| `/config KEY VALUE` | Set a single configuration field for the session | `/config top_k 20` |
+| `/context` | Show token usage bar, model info, RAG settings, and last retrieved sources | `/context` |
+
+### 3.7 Projects
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/project list` | List all projects with metadata and tree structure | `/project list` |
+| `/project NAME` | Switch to a named project (creates it if it does not exist) | `/project my-docs` |
+| `/project new NAME` | Create a new project explicitly | `/project new research/2026` |
+| `/project delete NAME` | Delete a project and all its data | `/project delete old-proj` |
+| `/project folder` | Show the filesystem path of the active project | `/project folder` |
+
+### 3.8 Sessions
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/sessions` | List saved conversation sessions (up to 20 most recent) | `/sessions` |
+| `/resume ID` | Load a previous session by its timestamp ID | `/resume 20260426-143022` |
+| `/compact` | Summarise entire chat history via LLM to free context window space | `/compact` |
+
+### 3.9 Sharing & AxonStore
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/store init PATH` | Change the store base path (e.g. to a shared drive) | `/store init /mnt/teamdrive` |
+| `/store whoami` | Show AxonStore identity and current store path | `/store whoami` |
+| `/store status` | Show sealed-store init/unlock state | `/store status` |
+| `/share list` | List outgoing and incoming shares | `/share list` |
+| `/share generate PROJECT GRANTEE` | Generate a read-only HMAC share key | `/share generate my-proj alice` |
+| `/share redeem KEY` | Mount a shared project (read-only) | `/share redeem axon-share-...` |
+| `/share revoke KEY_ID` | Revoke an outgoing share | `/share revoke sk_abc123` |
+
+### 3.10 Graph
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/graph status` | Show GraphRAG entity/community build status | `/graph status` |
+| `/graph build` | Trigger entity extraction and community detection | `/graph build` |
+| `/graph finalize` | Trigger explicit community rebuild | `/graph finalize` |
+| `/graph viz` | Open the interactive 3D graph in VS Code webview (or default browser outside VS Code) | `/graph viz` |
+| `/graph-viz [PATH]` | Export entity–relation graph as standalone HTML file; omit path to open in browser immediately | `/graph-viz /tmp/graph.html` |
+
+### 3.11 Inline Context Attachment
+
+Attach file or folder contents inline to any query using `@`:
+
+```
+axon> Explain this code @./src/axon/main.py
+axon> What changed in @./src/axon/
+axon> Compare @report.pdf with @notes.docx
+```
+
+`@file` and `@folder` can appear anywhere in the prompt; the contents are injected at that position.
+
+---
+
+## 4. REST API Reference
+
+**67 endpoints** across 9 route files. Base URL: `http://localhost:8000` (default).
+
+Interactive docs: `/docs` (Swagger UI), `/redoc`.
+
+### 4.1 Health
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Liveness probe — returns `{"status": "ok", "project": "<active-project>"}` |
+
+### 4.2 Query & Search
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/query` | Full RAG synthesis with optional citations, streaming, and per-request flag overrides |
+| `POST` | `/query/stream` | SSE streaming version of `/query` — returns `text/event-stream` |
+| `POST` | `/search` | Semantic/hybrid search — raw document chunks with scores; no LLM synthesis |
+| `POST` | `/search/raw` | Raw retrieval with optional diagnostics trace; no synthesis |
+| `POST` | `/clear` | Wipe all vectors and BM25 index for the active project |
 
 **`POST /query` parameters:**
 
@@ -62,100 +337,85 @@ Interactive docs: `/docs` (Swagger), `/redoc`.
 |-------|------|---------|-------------|
 | `query` | string | — | *(required)* Query text |
 | `project` | string | `null` | Must match active project if set; `null` = no check |
-| `stream` | bool | `false` | SSE streaming response (`text/event-stream`) |
+| `stream` | bool | `false` | SSE streaming response |
 | `top_k` | int | `10` | Chunks to retrieve |
-| `threshold` | float | `0.3` | Minimum cosine similarity for a chunk to qualify |
+| `threshold` | float | `0.3` | Minimum cosine similarity |
 | `hyde` | bool | `false` | HyDE hypothetical document expansion |
 | `rerank` | bool | `false` | Cross-encoder reranking |
 | `multi_query` | bool | `false` | Multi-query paraphrase expansion |
 | `step_back` | bool | `false` | Step-back query abstraction |
 | `decompose` | bool | `false` | Decompose compound query into sub-questions |
 | `compress` | bool | `false` | LLM context compression post-retrieval |
-| `cite` | bool | `true` | Inline `[source: file]` citations |
-| `discuss` | bool | `true` | Allow general-knowledge fallback when KB has no hits |
+| `cite` | bool | `true` | Inline citations |
+| `discuss` | bool | `true` | Allow general-knowledge fallback |
 | `graph_rag` | bool | `false` | GraphRAG entity-graph retrieval |
 | `raptor` | bool | `false` | RAPTOR hierarchical summary retrieval |
-| `crag_lite` | bool | `false` | CRAG-Lite corrective retrieval on low-confidence results |
+| `crag_lite` | bool | `false` | CRAG-Lite corrective retrieval |
 | `temperature` | float | `0.7` | LLM temperature |
 | `timeout` | int | `60` | LLM request timeout in seconds |
-| `include_diagnostics` | bool | `false` | Add `diagnostics` object (confidence, fallback_triggered) to response |
+| `include_diagnostics` | bool | `false` | Add `diagnostics` object to response |
 | `dry_run` | bool | `false` | Skip LLM synthesis; return retrieved chunks only |
 | `chat_history` | list | `[]` | Prior turns for multi-turn context |
 
-**`POST /query` response:**
-
-```json
-{
-  "query": "...",
-  "response": "...",
-  "settings": { "provider": "ollama", "model": "llama3.1:8b", ... },
-  "provenance": {
-    "answer_source": "local_kb | discussion_fallback | web_snippet",
-    "retrieved_count": 5,
-    "web_snippet_fallback": false
-  }
-}
-```
-
-When `include_diagnostics: true`, adds `"diagnostics": { "confidence": 0.82, "fallback_triggered": false }`.
-
-### 2.3 Ingestion
+### 4.3 Ingestion
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/ingest` | Async ingest of file/directory path — returns `{"job_id": "..."}` |
 | `POST` | `/ingest/refresh` | Re-ingest all tracked files whose SHA-256 hash has changed |
-| `GET` | `/ingest/status/{job_id}` | Poll async ingest job: `pending \| running \| completed \| failed` |
+| `GET` | `/ingest/status/{job_id}` | Poll async ingest job: `pending | running | completed | failed` |
+| `POST` | `/ingest/upload` | Upload a file directly for ingest (multipart form; no path required) |
 | `POST` | `/ingest_url` | Fetch and ingest content from a public URL |
 | `POST` | `/add_text` | Ingest a single text string with optional metadata |
 | `POST` | `/add_texts` | Batch ingest an array of `{text, metadata}` objects |
 | `GET` | `/collection` | Source count and total chunk count for the active project |
 | `GET` | `/collection/stale` | List documents not refreshed in N days (query param: `days=7`) |
-| `GET` | `/tracked-docs` | Full manifest: all ingested sources with hashes and last-seen timestamps |
+| `GET` | `/tracked-docs` | Full manifest: all ingested sources with hashes and timestamps |
 | `POST` | `/delete` | Delete specific document chunks by `doc_ids` list |
 
-**`POST /ingest` parameters:**
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `path` | string | — | *(required)* Absolute path to file or directory |
-| `project` | string | `null` | Expected active project — error on mismatch; `null` = no check |
-| `raptor` | bool | `false` | Enable RAPTOR hierarchical indexing for this ingest |
-| `graph_rag` | bool | `false` | Enable GraphRAG entity extraction for this ingest |
-
-### 2.4 Projects & Configuration
+### 4.4 Projects & Config
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/config` | Read current effective configuration |
-| `POST` | `/config/update` | Apply runtime overrides (scoped to this request; not persisted) |
+| `POST` | `/config/update` | Apply runtime overrides (not persisted to disk) |
+| `GET` | `/config/validate` | Validate the config file and return a list of issues |
+| `POST` | `/config/reset` | Reset config to built-in defaults |
+| `POST` | `/config/set` | Set a single config field by key and value |
 | `GET` | `/projects` | List all projects with tree structure and metadata |
 | `POST` | `/project/new` | Create a new named project |
 | `POST` | `/project/switch` | Switch the active project |
 | `POST` | `/project/delete/{name}` | Delete a project and all its stored data |
+| `POST` | `/project/rotate-keys` | Rotate sealed-project DEK and re-encrypt all content files |
+| `POST` | `/project/seal` | Encrypt all content files in a project at rest |
+| `POST` | `/mount/refresh` | Force-refresh a mounted shared project's handles |
 | `GET` | `/sessions` | List saved conversation sessions (most recent first) |
 | `GET` | `/session/{session_id}` | Retrieve a full session transcript |
 
-### 2.5 Sharing & AxonStore
+### 4.5 Sharing & AxonStore
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/store/init` | Change the store base path (e.g. to a shared drive) |
+| `GET` | `/store/status` | Show sealed-store init/unlock state and cipher suite |
 | `GET` | `/store/whoami` | Return current AxonStore identity and store path |
 | `POST` | `/share/generate` | Generate an HMAC-SHA256 read-only share key |
 | `POST` | `/share/redeem` | Mount a shared project (read-only) |
 | `POST` | `/share/revoke` | Revoke an outgoing share key |
+| `POST` | `/share/extend` | Extend the expiry of an existing share key |
 | `GET` | `/share/list` | List outgoing and incoming shares with revocation status |
 
-**`POST /share/generate` parameters:**
+### 4.6 Security (Sealed Store)
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `project` | string | required | Name of the project to share |
-| `grantee` | string | required | OS username of the recipient |
-| `expires_at` | string | `null` | ISO 8601 expiry timestamp — `null` means no expiry |
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/security/status` | Sealed-store init state and cipher suite |
+| `POST` | `/security/bootstrap` | One-time sealed-store init with a passphrase |
+| `POST` | `/security/unlock` | Unlock the sealed-store for sealed-project operations |
+| `POST` | `/security/lock` | Lock the sealed-store (clear in-process key cache) |
+| `POST` | `/security/change-passphrase` | Rotate the sealed-store passphrase |
 
-### 2.6 Graph
+### 4.7 Graph
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -163,23 +423,25 @@ When `include_diagnostics: true`, adds `"diagnostics": { "confidence": 0.82, "fa
 | `POST` | `/graph/finalize` | Trigger explicit community detection rebuild |
 | `GET` | `/graph/data` | Full entity/relation graph as JSON (`nodes` + `links`) |
 | `GET` | `/code-graph/data` | Structural code graph as JSON (file/class/function nodes) |
-| `GET` | `/graph/visualize` | Interactive 3D graph as HTML — opens in browser. Click a node to see its description and source evidence. (VS Code extension uses the embedded webview which also supports opening files in the editor.) |
-| `GET` | `/graph/backend/status` | Active graph backend type and health metrics — distinguishes graphrag vs dynamic backend |
-| `POST` | `/query/visualize` | Run a query and return a self-contained HTML page with LLM answer, citations, and highlighted graph — nodes matched by the query are golden; first-degree neighbours are orange. |
-| `POST` | `/search/visualize` | Same as `/query/visualize` but skips LLM generation — shows raw retrieved chunks instead of an answer. Useful for inspecting retrieval quality without spending LLM tokens. |
+| `GET` | `/graph/visualize` | Interactive 3D graph as self-contained HTML |
+| `GET` | `/graph/backend/status` | Active graph backend type and health metrics |
+| `POST` | `/query/visualize` | Run a query and return HTML with LLM answer, citations, and highlighted graph |
+| `POST` | `/search/visualize` | Same as `/query/visualize` but skips LLM generation |
 
-### 2.7 Governance & Operations
+### 4.8 Governance & Operations
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/governance/overview` | Active project count, session count, active lease count |
-| `GET` | `/governance/audit` | Per-query event log — project, surface, query, latency. Params: `limit`, `project`, `surface` |
-| `GET` | `/governance/copilot/sessions` | Active Copilot agent sessions (opened_at, last_query, surface) |
+| `GET` | `/governance/audit` | Per-query event log. Params: `limit`, `project`, `surface` |
+| `GET` | `/governance/copilot/sessions` | Active Copilot agent sessions |
 | `GET` | `/governance/projects` | Per-project audit statistics |
 | `POST` | `/governance/graph/rebuild` | Rebuild entity graph for a specific project (admin use) |
-| `POST` | `/governance/project/maintenance` | Set project maintenance state: `normal \| draining \| readonly \| offline` |
+| `POST` | `/governance/project/maintenance` | Set project maintenance state: `normal | draining | readonly | offline` |
 | `POST` | `/governance/copilot/session/{session_id}/expire` | Force-expire a Copilot session |
-| `GET` | `/registry/leases` | Active write-lease counts per project — check before maintenance |
+| `POST` | `/project/maintenance` | Set maintenance state for the active project |
+| `GET` | `/project/maintenance` | Get current maintenance state of the active project |
+| `GET` | `/registry/leases` | Active write-lease counts per project |
 
 **Maintenance state lifecycle:**
 
@@ -192,7 +454,7 @@ offline → normal    (restore: resumes accepting traffic)
 
 Always check `/registry/leases` before transitioning to `readonly`. Wait for `active_leases == 0`.
 
-### 2.8 Internal / Copilot Bridge
+### 4.9 Copilot Bridge (Internal)
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -204,520 +466,405 @@ These endpoints are used internally by the VS Code extension. External callers s
 
 ---
 
-## 3. REPL Commands — Full Reference
+## 5. MCP Tools Reference
 
-Start the REPL with `axon`. All commands begin with `/`. Use `!<cmd>` for shell passthrough.
+44 tools are registered when running `axon-mcp`.
 
-### 3.1 Ingestion & Collection
+### 5.1 Ingestion (6)
 
-| Command | Description |
-|---------|-------------|
-| `/ingest <path\|glob>` | Ingest a file, directory, or glob pattern |
-| `/ingest <url>` | Fetch and ingest a public URL |
-| `/refresh` | Re-ingest all tracked files whose content has changed (SHA-256 dedup) |
-| `/stale [N]` | List documents not refreshed in N days (default: 7) |
-| `/list` | List all ingested sources with chunk counts |
-| `/clear` | Wipe the active project's knowledge base (irreversible) |
-| `/compact` | Compact storage (rebuild BM25 index and defrag vector store) |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `ingest_text` | `text` (str, required), `metadata` (dict, optional), `project` (str, optional) | Ingest a text string |
+| `ingest_texts` | `docs` (list of `{text, metadata}`, required), `project` (str, optional) | Batch ingest multiple documents |
+| `ingest_url` | `url` (str, required), `metadata` (dict, optional), `project` (str, optional) | Fetch and ingest a public URL |
+| `ingest_path` | `path` (str, required) | Ingest a file or directory by absolute path |
+| `refresh_ingest` | `project` (str, optional) | Re-ingest all tracked files whose SHA-256 hash has changed |
+| `get_job_status` | `job_id` (str, required) | Poll async ingest job status |
 
-### 3.2 Query & Search
+Returns: `ingest_path` / `ingest_url` → `{"job_id": "..."}`. `get_job_status` → `{"status": "pending|running|completed|failed", "phase": "...", "chunks_embedded": N}`.
 
-| Command | Description |
-|---------|-------------|
-| `<any text>` | Send a query to the RAG pipeline and get a synthesised answer |
-| `/search <query>` | Vector search without LLM synthesis — shows raw ranked chunks |
-| `/retry` | Re-send the last query (useful after changing model or RAG flags) |
-| `/discuss` | Toggle `discussion_fallback` — allow general-knowledge answers when no documents match |
-| `/search` | Toggle Brave web search fallback (`truth_grounding`) |
+### 5.2 Search & Query (2)
 
-### 3.3 RAG Configuration
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `search_knowledge` | `query` (str), `top_k` (int, default `5`), `threshold` (float, optional), `hybrid` (bool, optional), `project` (str, optional) | Semantic/hybrid search — returns raw chunks with scores, no synthesis |
+| `query_knowledge` | `query` (str), `top_k` (int, optional), `hyde` (bool, optional), `rerank` (bool, optional), `project` (str, optional), `chat_history` (list, default `[]`) | Full RAG query with LLM synthesis |
 
-All RAG flags can be toggled at runtime without restarting. Changes persist for the session.
+### 5.3 Knowledge Base Management (5)
 
-| Command | Flag | Description |
-|---------|------|-------------|
-| `/rag hyde` | `hyde` | Toggle HyDE (hypothetical document embedding) |
-| `/rag multi` | `multi_query` | Toggle multi-query (3 query paraphrases) |
-| `/rag step-back` | `step_back` | Toggle step-back abstraction |
-| `/rag decompose` | `decompose` | Toggle query decomposition into sub-questions |
-| `/rag compress` | `compress` | Toggle context compression |
-| `/rag rerank` | `rerank` | Toggle cross-encoder reranking |
-| `/rag rerank-model <model>` | `rerank_model` | Set reranker model |
-| `/rag sentence-window` | `sentence_window` | Toggle sentence-window retrieval |
-| `/rag crag-lite` | `crag_lite` | Toggle CRAG-Lite corrective retrieval |
-| `/rag cite` | `cite` | Toggle inline citations |
-| `/rag raptor` | `raptor` | Toggle RAPTOR hierarchical summaries |
-| `/rag graph-rag` | `graph_rag` | Toggle GraphRAG entity-graph retrieval |
-| `/rag topk <n>` | `top_k` | Set number of retrieved chunks (e.g. `/rag topk 20`) |
-| `/rag threshold <0-1>` | `similarity_threshold` | Set minimum similarity score |
-| `/rag hybrid` | `hybrid_search` | Toggle BM25+vector hybrid search |
-| `/rag` | — | Show all current RAG settings |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `list_knowledge` | — | List all ingested sources with chunk counts |
+| `delete_documents` | `doc_ids` (list of str, required) | Delete specific chunk IDs |
+| `clear_knowledge` | — | Wipe entire knowledge base for active project (irreversible) |
+| `get_stale_docs` | `days` (int, default `7`) | List documents not refreshed in N days |
+| `get_active_leases` | — | List active write-lease counts per project |
 
-### 3.4 Model Configuration
+### 5.4 Project Management (4)
 
-| Command | Description |
-|---------|-------------|
-| `/model [provider/model]` | Switch LLM provider and model. Auto-detects provider from model name (`gemini-*` → gemini, `gpt-*` → openai, else → ollama). Auto-pulls Ollama models if not present. |
-| `/llm [temp=N]` | Show or set LLM temperature |
-| `/embed [provider/model]` | Switch embedding provider and model |
-| `/pull <name>` | Pull an Ollama model with a progress indicator |
-| `/vllm-url [url]` | Show or set the vLLM server base URL |
-| `/keys [set <provider>]` | Show API key status for all providers; `/keys set <provider>` saves interactively |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `list_projects` | — | List all projects with metadata |
+| `switch_project` | `project_name` (str, required) | Switch to a named project |
+| `create_project` | `name` (str, required), `description` (str, default `""`) | Create a new project |
+| `delete_project` | `name` (str, required) | Delete a project and all its data |
 
-### 3.5 Projects
+### 5.5 Settings (2)
 
-| Command | Description |
-|---------|-------------|
-| `/project list` | List all projects |
-| `/project <name>` | Switch to a named project (creates it if it does not exist) |
-| `/project new <name>` | Create a new project explicitly |
-| `/project delete <name>` | Delete a project and all its data |
-| `/project folder` | Show the filesystem path of the active project |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `get_current_settings` | — | Return all current config values |
+| `update_settings` | `hyde`, `rerank`, `graph_rag`, `cite`, `top_k`, `threshold`, `sentence_window_size`, `llm_provider`, `llm_model` (all optional) | Update config fields for the session |
 
-### 3.6 Sessions
+### 5.6 Sessions (2)
 
-| Command | Description |
-|---------|-------------|
-| `/sessions` | List saved conversation sessions (up to 20 most recent) |
-| `/resume <id>` | Load a previous session by its timestamp ID |
-| `/compact` | Summarise entire chat history via LLM to free context window space |
-| `/context` | Show token usage bar, model info, RAG settings, chat history, last retrieved sources |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `list_sessions` | — | List up to 20 most recent sessions |
+| `get_session` | `session_id` (str, required) | Retrieve a full session transcript |
 
-### 3.7 Sharing & AxonStore
+### 5.7 AxonStore & Sharing (8)
 
-| Command | Description |
-|---------|-------------|
-| `/store init <path>` | Change the store base path (e.g. to a shared drive) |
-| `/store whoami` | Show AxonStore identity and current store path |
-| `/share list` | List outgoing and incoming shares |
-| `/share generate <project> <grantee>` | Generate a read-only HMAC share key |
-| `/share redeem <key>` | Mount a shared project (read-only) |
-| `/share revoke <key_id>` | Revoke an outgoing share |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `get_store_status` | — | Check AxonStore init state, path, version |
+| `init_store` | `base_path` (str, required), `persist` (bool, default `false`) | Initialise or move the store to a shared filesystem |
+| `share_project` | `project` (str), `grantee` (str), `expires_at` (str, optional) | Generate a read-only share key |
+| `redeem_share` | `share_string` (str, required) | Mount a shared project (read-only) |
+| `revoke_share` | `key_id` (str, required) | Revoke an outgoing share |
+| `extend_share` | `key_id` (str, required), `ttl_days` (int, optional) | Extend share expiry |
+| `list_shares` | — | List outgoing and incoming shares |
+| `refresh_mount` | — | Force-refresh a mounted shared project's handles |
 
-### 3.8 Graph
+### 5.8 Security (Sealed Store) (6)
 
-| Command | Description |
-|---------|-------------|
-| `/graph status` | Show GraphRAG entity/community build status |
-| `/graph finalize` | Trigger explicit community rebuild |
-| `/graph viz` | Open the interactive 3D graph in VS Code webview (or default browser outside VS Code) |
-| `/graph-viz [path]` | Export entity–relation graph as standalone HTML file; omit path to open in browser immediately |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `security_status` | — | Show sealed-store init/unlock state |
+| `security_bootstrap` | `passphrase` (str, required) | One-time sealed-store init |
+| `security_unlock` | `passphrase` (str, required) | Unlock for sealed-project operations |
+| `security_lock` | — | Lock the sealed-store (clear in-process key cache) |
+| `security_change_passphrase` | `old_passphrase` (str), `new_passphrase` (str) | Rotate the sealed-store passphrase |
+| `seal_project` | `project_name` (str), `migration_mode` (str, default `"in_place"`) | Encrypt all content files in a project at rest |
 
-### 3.9 Utility
+### 5.9 Graph (4)
 
-| Command | Description |
-|---------|-------------|
-| `/help [cmd]` | Show all commands or detailed help for a specific command |
-| `/clear` | Clear chat history (does not delete the saved session) |
-| `/quit` / `/exit` | Exit the REPL |
-| `! <command>` | Execute a shell command directly (controlled by `repl.shell_passthrough` in config) |
-
-**`@file` / `@folder` inline context:** Attach file or folder contents inline to any query:
-
-```
-axon> Explain this code @./src/axon/main.py
-axon> What changed in @./src/axon/
-axon> Compare @report.pdf with @notes.docx
-```
-
----
-
-## 4. CLI Flags — Full Reference
-
-```bash
-axon [options] ["query string"]
-```
-
-If no query string is given, the interactive REPL starts. If a query string is given, a single query runs and the process exits.
-
-### 4.1 Query & Output
-
-| Flag | Description |
-|------|-------------|
-| `"query"` | Run a single query (non-interactive) |
-| `--stream` | Stream response token-by-token |
-| `--cite` / `--no-cite` | Enable/disable inline citations |
-| `--no-answer` | Skip LLM synthesis; show only retrieved chunks |
-
-### 4.2 RAG Flags (single-query overrides)
-
-| Flag | Description |
-|------|-------------|
-| `--hyde` | Enable HyDE for this query |
-| `--multi-query` | Enable multi-query expansion |
-| `--step-back` | Enable step-back abstraction |
-| `--decompose` | Enable query decomposition |
-| `--compress` | Enable context compression |
-| `--rerank` | Enable cross-encoder reranking |
-| `--graph-rag` | Enable GraphRAG entity-graph retrieval |
-| `--raptor` | Enable RAPTOR hierarchical summaries |
-
-### 4.3 Ingestion
-
-| Flag | Description |
-|------|-------------|
-| `--ingest <path>` | Ingest a file or directory and exit |
-| `--raptor --ingest` | Ingest with RAPTOR hierarchical indexing |
-| `--graph-rag --ingest` | Ingest with GraphRAG entity extraction |
-| `--code-graph --ingest <path>` | Build structural code graph from source directory |
-
-### 4.4 Model & Provider
-
-| Flag | Description |
-|------|-------------|
-| `--model <name>` | Set LLM model for this run |
-| `--provider <name>` | Set LLM provider: `ollama \| openai \| gemini \| grok \| vllm \| copilot \| github_copilot \| ollama_cloud` |
-| `--pull <name>` | Pull an Ollama model and exit |
-| `--list-models` | List available providers and locally installed Ollama models |
-
-### 4.5 Project Management
-
-| Flag | Description |
-|------|-------------|
-| `--project <name>` | Use a named project |
-| `--project-new <name>` | Create a new project |
-| `--project-list` | List all projects |
-| `--project-delete <name>` | Delete a project |
-
-### 4.6 Collection Management
-
-| Flag | Description |
-|------|-------------|
-| `--list` | List all ingested documents |
-
----
-
-## 5. MCP Tools — Full Reference
-
-31 tools are registered when running `axon-mcp`.
-
-### Ingestion (6)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `ingest_text` | `text` | string | required | Text to ingest |
-| | `metadata` | dict | `{}` | Key/value metadata attached to all chunks |
-| | `project` | string | `null` | Expected active project (error on mismatch) |
-| `ingest_texts` | `docs` | `[{text, metadata}]` | required | List of `BatchDocItem` objects |
-| | `project` | string | `null` | Expected active project |
-| `ingest_url` | `url` | string | required | Public URL to fetch and ingest |
-| | `metadata` | dict | `{}` | Metadata for ingested chunks |
-| | `project` | string | `null` | Expected active project |
-| `ingest_path` | `path` | string | required | Absolute path to file or directory |
-| `refresh_ingest` | `project` | string | `null` | Re-ingest all tracked files whose SHA-256 hash has changed |
-| `get_job_status` | `job_id` | string | required | Job ID from `ingest_path` or `ingest_url` |
-
-**Returns:** `ingest_path` / `ingest_url` → `{"job_id": "..."}`. `get_job_status` → `{"status": "pending|running|completed|failed", "phase": "...", "chunks_embedded": N}`.
-
-### Search & Query (2)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `search_knowledge` | `query` | string | required | Search query |
-| | `top_k` | int | `5` | Number of chunks to return |
-| | `threshold` | float | `null` | Minimum similarity score (null = config default 0.3) |
-| | `hybrid` | bool | `null` | BM25+vector hybrid mode (null = config default) |
-| | `project` | string | `null` | Expected active project |
-| `query_knowledge` | `query` | string | required | RAG query |
-| | `top_k` | int | `null` | Chunks to retrieve (null = config default 10) |
-| | `hyde` | bool | `null` | HyDE expansion (null = config default) |
-| | `rerank` | bool | `null` | Cross-encoder reranking (null = config default) |
-| | `project` | string | `null` | Expected active project |
-| | `chat_history` | list | `[]` | Prior turns for multi-turn context |
-
-**Returns:** `search_knowledge` → `[{text, score, metadata}]`. `query_knowledge` → `{response, provenance, settings}`.
-
-### Knowledge Base Management (5)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `list_knowledge` | — | — | — | No parameters |
-| `delete_documents` | `doc_ids` | `[string]` | required | Internal chunk ID list |
-| `clear_knowledge` | — | — | — | No parameters — irreversible |
-| `get_stale_docs` | `days` | int | `7` | Documents not refreshed in this many days |
-| `get_active_leases` | — | — | — | No parameters |
-
-### Project Management (4)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `list_projects` | — | — | — | No parameters |
-| `switch_project` | `project_name` | string | required | Name of project to activate |
-| `create_project` | `name` | string | required | New project name |
-| | `description` | string | `""` | Optional human-readable description |
-| `delete_project` | `name` | string | required | Project to delete (all data removed) |
-
-### Settings (2)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `get_current_settings` | — | — | — | No parameters |
-| `update_settings` | `hyde` | bool | `null` | HyDE toggle (null = no change) |
-| | `rerank` | bool | `null` | Rerank toggle |
-| | `graph_rag` | bool | `null` | GraphRAG toggle |
-| | `cite` | bool | `null` | Citations toggle |
-| | `top_k` | int | `null` | Retrieved chunk count |
-| | `threshold` | float | `null` | Minimum similarity score |
-| | `sentence_window_size` | int | `2` | Window size for sentence-window retrieval |
-| | `llm_provider` | string | `null` | LLM provider name |
-| | `llm_model` | string | `null` | LLM model name |
-
-### Sessions (2)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `list_sessions` | — | — | — | No parameters — returns up to 20 most recent |
-| `get_session` | `session_id` | string | required | Timestamp-based session ID |
-
-### AxonStore & Sharing (6)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `get_store_status` | — | — | — | Check whether AxonStore is initialised; returns path, version, `created_at`. Safe to call before brain is ready. |
-| `init_store` | `base_path` | string | required | Absolute path to shared filesystem location |
-| | `persist` | bool | `false` | Write store path to config.yaml |
-| `share_project` | `project` | string | required | Project to share |
-| | `grantee` | string | required | Recipient identifier |
-| | `expires_at` | string | `null` | ISO 8601 expiry timestamp (null = no expiry) |
-| `redeem_share` | `share_string` | string | required | Full share string from `share_project` |
-| `revoke_share` | `key_id` | string | required | Key ID from `list_shares` |
-| `list_shares` | — | — | — | No parameters |
-
-### Graph (3)
-
-| Tool | Parameter | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `graph_status` | — | — | — | No parameters |
-| `graph_finalize` | — | — | — | No parameters — triggers community rebuild |
-| `graph_data` | — | — | — | No parameters — returns full nodes+links JSON |
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `graph_status` | — | Entity count, edge count, community count, rebuild status |
+| `graph_finalize` | — | Trigger community detection rebuild |
+| `graph_data` | — | Return full nodes+links JSON |
+| `graph_backend_status` | — | Active graph backend type and health metrics |
 
 ---
 
 ## 6. Configuration Reference
 
-### 6.1 LLM Providers
+Config file location: `~/.config/axon/config.yaml`. Override with `--config PATH` or `AXON_CONFIG_PATH` env var.
 
-Set `llm.provider` in `config.yaml`:
+Run `axon --config-validate` to check for errors, or `axon --setup` to run the interactive wizard.
 
-| Provider value | Transport | Required credentials |
-|---------------|-----------|---------------------|
+### 6.1 LLM Settings
+
+YAML section: `llm:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `llm.provider` | str | `ollama` | LLM provider: `ollama`, `openai`, `gemini`, `grok`, `vllm`, `github_copilot`, `ollama_cloud` |
+| `llm.model` | str | `llama3.1:8b` | Model name |
+| `llm.temperature` | float | `0.7` | Generation temperature (`0.0` = deterministic, `2.0` = max creative) |
+| `llm.max_tokens` | int | `2048` | Max tokens in the generated answer |
+| `llm.timeout` | int | `60` | LLM request timeout in seconds |
+| `llm.base_url` | str | `http://localhost:11434` | Ollama server URL (also: `OLLAMA_HOST` env var) |
+| `llm.models_dir` | str | `""` | Ollama model root directory (also: `OLLAMA_MODELS` env var) |
+| `llm.openai_api_key` | str | `""` | OpenAI API key (also: `OPENAI_API_KEY` env var) |
+| `llm.gemini_api_key` | str | `""` | Gemini API key (also: `GEMINI_API_KEY` env var) |
+| `llm.grok_api_key` | str | `""` | xAI Grok API key (also: `XAI_API_KEY` env var) |
+| `llm.vllm_base_url` | str | `http://localhost:8000/v1` | vLLM server base URL (also: `VLLM_BASE_URL` env var) |
+| `llm.ollama_cloud_url` | str | `https://ollama.com/api` | Remote Ollama endpoint URL (also: `OLLAMA_CLOUD_URL` env var) |
+| `llm.ollama_cloud_key` | str | `""` | Remote Ollama API key (also: `OLLAMA_CLOUD_KEY` env var) |
+
+LLM provider transport table:
+
+| Provider | Transport | Required credentials |
+|----------|-----------|---------------------|
 | `ollama` | HTTP to `OLLAMA_HOST` (default `localhost:11434`) | None |
 | `openai` | HTTPS to `api.openai.com` | `OPENAI_API_KEY` or `llm.openai_api_key` |
 | `grok` | HTTPS to `api.x.ai/v1` | `XAI_API_KEY` / `GROK_API_KEY` or `llm.grok_api_key` |
 | `gemini` | HTTPS to Google AI | `GEMINI_API_KEY` or `llm.gemini_api_key` |
 | `vllm` | HTTP to your vLLM server | `llm.vllm_base_url` |
-| `copilot` | VS Code extension bridge | Active VS Code Copilot subscription |
 | `github_copilot` | HTTPS to Copilot API | `GITHUB_COPILOT_PAT` (OAuth token) |
 | `ollama_cloud` | HTTPS to remote Ollama | `OLLAMA_CLOUD_URL` + `OLLAMA_CLOUD_KEY` |
 
 See [MODEL_GUIDE.md](MODEL_GUIDE.md) for per-provider `config.yaml` examples.
 
-### 6.2 Embedding Providers
+### 6.2 Embedding Settings
 
-Set `embedding.provider` in `config.yaml`:
+YAML section: `embedding:`
 
-| Provider value | Description | Install |
-|---------------|-------------|---------|
-| `sentence_transformers` | Local CPU inference (default) | `pip install sentence-transformers` |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `embedding.provider` | str | `sentence_transformers` | Embedding provider: `sentence_transformers`, `ollama`, `fastembed`, `openai` |
+| `embedding.model` | str | `all-MiniLM-L6-v2` | Embedding model name |
+| `embedding.model_path` | str | `""` | Local path override for the embedding model (takes precedence over `model` when set) |
+| `embedding.dim` | int | `0` | Override embedding vector dimension (`0` = auto-detect from model) |
+
+Embedding provider install requirements:
+
+| Provider | Description | Install |
+|----------|-------------|---------|
+| `sentence_transformers` | Local CPU inference (default) | Bundled |
 | `ollama` | Via local Ollama endpoint | Ollama running + model pulled |
 | `fastembed` | Quantised ONNX models (BGE, BAAI) | `pip install 'axon[fastembed]'` |
 | `openai` | OpenAI embedding API | `OPENAI_API_KEY` |
 
-### 6.3 Vector Store Backends
+### 6.3 Vector Store Settings
 
-Set `vector_store.provider` in `config.yaml`:
-
-| Provider value | Description | Install |
-|---------------|-------------|---------|
-| `turboquantdb` | Quantized embedded store — fastest ingest, smallest disk *(default)* | Bundled (`tqdb` on PyPI) |
-| `lancedb` | Embedded columnar store | Bundled |
-| `chroma` | Local persistent store | Bundled |
-| `qdrant` | Local or remote Qdrant | `pip install 'axon[qdrant]'` |
-
-**TurboQuantDB config fields** (only used when `provider: turboquantdb`):
+YAML section: `vector_store:`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `tqdb_bits` | int | `4` | Quantization bits per coordinate (`2`, `4`, or `8`) |
-| `tqdb_fast_mode` | bool | `false` | Trade index build CPU for faster queries; slightly lowers recall |
-| `tqdb_rerank` | bool | `true` | Enable internal ANN rerank pass; improves recall at small CPU cost |
-| `tqdb_rerank_precision` | str\|null | `null` | Rerank precision: `null` = dequant, `"f16"` or `"f32"` = exact (uses more disk) |
-| `tqdb_ef_construction` | int | `200` | HNSW build quality — higher = better recall, slower build |
-| `tqdb_max_degree` | int | `32` | HNSW graph degree — higher = better recall, larger index |
-| `tqdb_search_list_size` | int | `128` | ANN candidate list size (ef_construction alias for build; ef_search at query time) |
-| `tqdb_alpha` | float\|null | `null` | HNSW pruning aggressiveness (`null` = TQDB default 1.2) |
-| `tqdb_n_refinements` | int\|null | `null` | HNSW refinement passes during build (`null` = TQDB default 5) |
+| `vector_store.provider` | str | `turboquantdb` | Backend: `turboquantdb`, `lancedb`, `chroma`, `qdrant` |
+| `vector_store.tqdb_bits` | int | `4` | TurboQuantDB quantization bits per coordinate (`2`, `4`, or `8`) |
+| `vector_store.tqdb_fast_mode` | bool | `false` | Trade index build CPU for faster queries; slightly lowers recall |
+| `vector_store.tqdb_rerank` | bool | `true` | Enable internal ANN rerank pass; improves recall at small CPU cost |
+| `vector_store.tqdb_rerank_precision` | str\|null | `null` | Rerank precision: `null` = dequant, `"f16"` or `"f32"` = exact |
+| `vector_store.tqdb_ef_construction` | int | `200` | HNSW build quality — higher = better recall, slower build |
+| `vector_store.tqdb_max_degree` | int | `32` | HNSW graph degree — higher = better recall, larger index |
+| `vector_store.tqdb_search_list_size` | int | `128` | ANN candidate list size at query time |
+| `vector_store.tqdb_alpha` | float\|null | `null` | HNSW pruning aggressiveness (`null` = TQDB default 1.2) |
+| `vector_store.tqdb_n_refinements` | int\|null | `null` | HNSW refinement passes during build (`null` = TQDB default 5) |
+| `vector_store.qdrant_url` | str | `""` | Qdrant server URL for remote mode (empty = local file mode) |
+| `vector_store.qdrant_api_key` | str | `""` | Qdrant API key for remote mode |
+| `vector_store.qdrant_collection` | str | `""` | Qdrant collection name override |
 
-### 6.4 RAG Flags — Complete List
+### 6.4 Retrieval Settings
 
-All flags are `false` in the shipped `config.yaml`. All can be set in config, as CLI flags, via `/rag` in the REPL, or as per-request fields in `POST /query`.
+YAML section: `rag:`
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `hybrid_search` | bool | false | Combine BM25 + vector scores |
-| `hyde` | bool | false | Hypothetical document embedding |
-| `multi_query` | bool | false | Generate 3 query paraphrases |
-| `step_back` | bool | false | Abstract query to higher-level concept |
-| `decompose` | bool | false | Split compound query into sub-questions |
-| `compress` | bool | false | LLM context compression post-retrieval |
-| `rerank` | bool | false | Cross-encoder (BGE) reranking |
-| `sentence_window` | bool | false | Sentence-granularity indexing + window expansion |
-| `crag_lite` | bool | false | Corrective retrieval on low-confidence results |
-| `cite` | bool | true | Inline `[source: file]` citations in answers |
-| `raptor` | bool | false | Hierarchical clustering summaries (ingest-time) |
-| `graph_rag` | bool | false | Entity/relation graph retrieval |
-| `discuss` | bool | true | Allow general-knowledge fallback when KB has no hits |
-| `top_k` | int | 10 | Retrieved chunk count |
-| `similarity_threshold` | float | 0.3 | Minimum cosine similarity for a chunk to qualify |
-| `rerank_model` | str | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Cross-encoder model |
-| `sentence_window_size` | int | 3 | ±N sentences around each hit |
-| `crag_lite_confidence_threshold` | float | 0.4 | Below this score, CRAG-Lite triggers fallback |
-| `query_router` | str | `heuristic` | `heuristic \| llm \| off` |
-| `code_graph` | bool | false | Build File+Symbol nodes with CONTAINS/IMPORTS edges during code ingest |
-| `code_graph_bridge` | bool | false | Add MENTIONED\_IN edges linking prose docs to code symbols |
-| `graph_rag_mode` | str | `local` | `local \| global \| hybrid` |
-| `graph_rag_depth` | str | `standard` | `light (no LLM) \| standard \| deep (+claims)` |
-| `graph_rag_budget` | int | 3 | Max graph-expanded chunks injected into context |
-| `graph_rag_relations` | bool | true | Extract relation triples (LLM-heavy) |
-| `graph_rag_community` | bool | true | Build Louvain/Leiden community summaries |
-| `graph_rag_community_backend` | str | `louvain` | `louvain` (safe default) or `leidenalg` |
-| `graph_rag_relation_budget` | int | 30 | Max chunks per batch for relation extraction (`0` = unlimited) |
-| `graph_rag_entity_min_frequency` | int | 2 | Prune entities appearing fewer than N times |
-| `raptor_max_levels` | int | 1 | Summary tree depth |
-| `raptor_min_source_size_mb` | float | 5.0 | Skip RAPTOR for sources smaller than this |
-| `bloom_filter_hash_store` | bool | false | Use a bloom filter for dedup hash membership testing (saves ~6MB RAM per 100k docs; opt-in) |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rag.top_k` | int | `10` | Chunks retrieved per query (recommended: 5–30) |
+| `rag.similarity_threshold` | float | `0.3` | Min cosine similarity to include a chunk (`0.0`–`1.0`) |
+| `rag.hybrid_search` | bool | `true` | Combine vector + BM25 sparse retrieval |
+| `rag.hybrid_weight` | float | `0.7` | Hybrid fusion weight (`1.0` = pure vector, `0.0` = pure BM25; only used in `weighted` mode) |
+| `rag.hybrid_mode` | str | `rrf` | Hybrid fusion mode: `rrf` (Reciprocal Rank Fusion, default) or `weighted` |
+| `rag.rerank` | bool | `false` | BGE cross-encoder reranker |
+| `rag.rerank_top_k` | int | `5` | Max results to return after re-ranking |
+| `rag.sentence_window` | bool | `false` | Expand retrieved chunks with surrounding sentences |
+| `rag.sentence_window_size` | int | `3` | Sentences of context on each side (recommended: 1–5) |
+| `rag.mmr` | bool | `false` | Maximal Marginal Relevance deduplication — reorders and removes near-duplicate chunks |
+| `rag.mmr_lambda` | float | `0.5` | MMR diversity–relevance trade-off (`1.0` = pure relevance, `0.0` = pure diversity) |
+| `rag.parent_doc` | bool | `false` | Small-to-big retrieval (index child chunks, return parent passages) |
+| `rag.parent_chunk_size` | int | `1500` | Parent passage size in tokens when `parent_doc` is enabled |
+| `rag.cite` | bool | `true` | Include inline `[Document N]` citations in answers |
+| `rag.discuss` | bool | `true` | Allow general-knowledge fallback when KB has no hits (`discussion_fallback`) |
+| `rag.query_cache` | bool | `false` | In-memory query result caching |
+| `rag.query_cache_size` | int | `128` | Maximum cached entries |
+| `rag.query_cache_ttl` | int | `1800` | Cache entry expiry in seconds (`0` = no expiry) |
+| `rag.dedup_on_ingest` | bool | `true` | Skip ingest for content already in the knowledge base (SHA-256 dedup) |
+| `rag.query_router` | str | `heuristic` | Multi-class query router: `heuristic` (zero latency), `llm` (one classifier call), `off` |
+| `rag.truth_grounding` | bool | `false` | Enable Brave web search fallback (requires `BRAVE_API_KEY`) |
+| `rag.ingest_engine` | str | `python` | Ingest pipeline engine: `python` or `rust` |
+| `rag.bm25_engine` | str | `python` | BM25 index engine: `python` or `rust` |
+| `rag.symbol_index_engine` | str | `python` | Symbol index engine: `python` or `rust` |
+| `rag.rust_fallback_enabled` | bool | `true` | Fall back to Python engine if Rust fails |
+| `rag.rust_batch_size` | int | `512` | Batch size for Rust ingest operations |
 
-### 6.5 Web Search / CRAG-Lite
+### 6.5 Query Transformation Settings
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `web_search.enabled` | bool | `false` | Enable Brave Search web fallback |
-| `web_search.brave_api_key` | string | — | Brave API key (or set `BRAVE_API_KEY` env var) |
+YAML section: `query_transformations:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `query_transformations.hyde` | bool | `false` | Hypothetical document embedding — generates a hypothetical answer and retrieves by its embedding |
+| `query_transformations.multi_query` | bool | `false` | Generate 3 query paraphrases and merge results (adds 1 LLM call) |
+| `query_transformations.step_back` | bool | `false` | Abstract query to a higher-level concept before retrieval (adds 1 LLM call) |
+| `query_transformations.query_decompose` | bool | `false` | Split compound query into sub-questions (adds 1 LLM call) |
+| `query_transformations.discussion_fallback` | bool | `true` | Fall back to general LLM answer when retrieval confidence is low |
+
+### 6.6 Chunking Settings
+
+YAML section: `chunk:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `chunk.strategy` | str | `semantic` | Chunking strategy: `recursive`, `semantic`, `markdown`, or `cosine_semantic` |
+| `chunk.size` | int | `1000` | Target chunk size in tokens (recommended: 400–2000) |
+| `chunk.overlap` | int | `200` | Token overlap between adjacent chunks (recommended: 50–400) |
+| `chunk.cosine_semantic_threshold` | float | `0.7` | Cosine similarity threshold for `cosine_semantic` strategy |
+| `chunk.cosine_semantic_max_size` | int | `500` | Max chunk size in tokens for `cosine_semantic` strategy |
+| `chunk.parent_chunk_size` | int | `1500` | Parent passage size when using small-to-big retrieval |
+
+### 6.7 Reranker Settings
+
+YAML section: `rerank:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rerank.enabled` | bool | `false` | Enable cross-encoder reranking |
+| `rerank.provider` | str | `cross-encoder` | Reranker provider: `cross-encoder` or `llm` |
+| `rerank.model` | str | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Reranker model. Use `BAAI/bge-reranker-v2-m3` for SOTA multilingual accuracy |
+| `rerank.top_k` | int | `5` | Max results to return after re-ranking |
+
+### 6.8 Graph RAG Settings
+
+YAML section: `rag:` (graph_rag_* keys)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rag.graph_rag` | bool | `false` | Enable GraphRAG entity-centric retrieval (config.yaml default; dataclass default is `true`) |
+| `rag.graph_rag_mode` | str | `local` | Traversal mode: `local` (entity/relation context), `global` (community summaries), `hybrid` (both) |
+| `rag.graph_rag_depth` | str | `standard` | Extraction tier: `light` (regex, no LLM), `standard` (LLM-based NER), `deep` (standard + claims) |
+| `rag.graph_rag_budget` | int | `3` | Max graph-expanded chunks injected beyond normal `top_k` |
+| `rag.graph_rag_relations` | bool | `true` | Extract SUBJECT\|RELATION\|OBJECT triples during ingest |
+| `rag.graph_rag_relation_budget` | int | `30` | Max chunks per batch for relation extraction (`0` = unlimited) |
+| `rag.graph_rag_community` | bool | `true` | Build Louvain/Leiden community summaries |
+| `rag.graph_rag_community_backend` | str | `louvain` | Community detection algorithm: `louvain` (safe default), `leidenalg`, or `auto` |
+| `rag.graph_rag_entity_min_frequency` | int | `2` | Prune entities appearing in fewer than N chunks (`1` = no pruning) |
+| `rag.graph_rag_max_hops` | int | `2` | Max relation-hop depth from a matched entity (`0` = direct only) |
+| `rag.graph_rag_hop_decay` | float | `0.7` | Score multiplier per hop (1-hop = 0.7×, 2-hop = 0.49×) |
+| `rag.graph_rag_distance_weighted` | bool | `true` | Use Dijkstra weighted traversal (false = plain BFS) |
+| `rag.graph_rag_global_top_communities` | int | `0` | Cap communities entering map-reduce (`0` = no cap) |
+| `rag.graph_rag_auto_route` | str | `off` | Auto-route queries based on complexity: `off`, `heuristic`, or `llm` |
+| `rag.graph_rag_ner_backend` | str | `llm` | NER backend: `llm` (default) or `gliner` (no LLM for entity extraction) |
+| `rag.graph_rag_relation_backend` | str | `llm` | Relation extraction backend: `llm` or `rebel` |
+| `rag.graph_rag_entity_resolve` | bool | `false` | Merge near-duplicate entity names via cosine similarity |
+| `rag.graph_backend` | str | `graphrag` | Graph backend: `graphrag` (default) or `dynamic` (SQLite-WAL temporal graph) |
+| `rag.code_graph` | bool | `false` | Build File/Symbol nodes with CONTAINS/IMPORTS edges from code chunk metadata |
+| `rag.code_graph_bridge` | bool | `false` | Add MENTIONED_IN edges linking prose chunks to code symbols |
+
+### 6.9 RAPTOR Settings
+
+YAML section: `rag:` (raptor_* keys)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rag.raptor` | bool | `false` | Enable RAPTOR hierarchical summarisation nodes at ingest (config.yaml default; dataclass default is `true`) |
+| `rag.raptor_chunk_group_size` | int | `5` | Consecutive chunks grouped per RAPTOR summary |
+| `rag.raptor_max_levels` | int | `2` | Recursive summarization depth (note: previous docs incorrectly stated `1`) |
+| `rag.raptor_min_source_size_mb` | float | `5.0` | Skip RAPTOR for sources smaller than this MB (`0` = no filter) |
+| `rag.raptor_cache_summaries` | bool | `true` | Skip LLM when window content unchanged |
+| `rag.raptor_drilldown` | bool | `true` | Replace summary hits with leaf chunks at retrieval time |
+| `rag.raptor_drilldown_top_k` | int | `5` | Max leaf chunks substituted per summary hit |
+
+### 6.10 Context Compression Settings
+
+YAML section: `context_compression:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `context_compression.enabled` | bool | `false` | Enable LLM context compression post-retrieval |
+| `context_compression.strategy` | str | `sentence` | Compression algorithm: `none`, `sentence` (LLM extraction), or `llmlingua` (requires `pip install 'axon[llmlingua]'`) |
+| `context_compression.token_budget` | int | `0` | Target output tokens for `llmlingua` (`0` = model default ratio) |
+
+### 6.11 CRAG-Lite & Web Search Settings
+
+YAML section: `rag:` / `web_search:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
 | `rag.crag_lite` | bool | `false` | Activate CRAG-Lite corrective retrieval |
 | `rag.crag_lite_confidence_threshold` | float | `0.4` | Below this score, CRAG-Lite triggers fallback |
-| `rag.truth_grounding` | bool | `false` | When CRAG-Lite fires, escalate to Brave web search |
+| `rag.truth_grounding` | bool | `false` | Escalate to Brave web search when CRAG-Lite fires |
+| `web_search.enabled` | bool | `false` | Enable Brave Search web fallback |
+| `web_search.brave_api_key` | str | `""` | Brave API key (also: `BRAVE_API_KEY` env var) |
+| `web_search.num_results` | int | `10` | Web search results per query |
 
-Obtain a Brave API key at `https://brave.com/search/api/`. The free tier allows 2,000 queries/month.
+### 6.12 Offline / Air-gapped Settings
 
-### 6.6 Offline / Air-gapped Mode
+YAML section: `offline:`
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `offline.enabled` | bool | `false` | Block all outbound calls (HF Hub, cloud LLMs, web search); disables RAPTOR/GraphRAG automatically |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `offline.enabled` | bool | `false` | Block all outbound calls (HF Hub, cloud LLMs, web search); also disables RAPTOR/GraphRAG |
 | `offline.local_assets_only` | bool | `false` | Block HF Hub downloads only; RAPTOR/GraphRAG remain enabled with a local Ollama |
-| `offline.local_models_dir` | string | `""` | Root directory for all pre-downloaded HF model files |
-| `offline.embedding_models_dir` | string | `""` | sentence-transformers / fastembed model root (overrides `local_models_dir`) |
-| `offline.hf_models_dir` | string | `""` | GLiNER, REBEL, LLMLingua, and cross-encoder reranker model root |
-| `offline.tokenizer_cache_dir` | string | `""` | tiktoken BPE encoding cache directory |
-| `llm.models_dir` | string | `""` | Ollama model root directory |
+| `offline.local_models_dir` | str | `""` | Root directory for all pre-downloaded HF model files |
+| `offline.embedding_models_dir` | str | `""` | sentence-transformers / fastembed model root (overrides `local_models_dir`) |
+| `offline.hf_models_dir` | str | `""` | GLiNER, REBEL, LLMLingua, and cross-encoder reranker model root |
+| `offline.tokenizer_cache_dir` | str | `""` | tiktoken BPE encoding cache directory |
 
-Example `config.yaml` for a strict air-gap:
+### 6.13 Security Settings
 
-```yaml
-offline:
-  enabled: true
-  local_models_dir: "/mnt/aimodels"
-  embedding_models_dir: /mnt/aimodels/embedding
-  hf_models_dir: /mnt/aimodels/hf
-  tokenizer_cache_dir: /mnt/aimodels/tiktoken
-llm:
-  models_dir: /mnt/aimodels/ollama
-```
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api.key` | str | `""` | API key required on protected endpoints (empty = no auth) |
+| `api.allow_origins` | list | `[]` | CORS origins allowed by the REST API server |
 
-**Compatible providers:** LLM: `ollama`, `vllm` · Embedding: `sentence_transformers`, `fastembed`, `ollama` · Vector store: `lancedb`, `chroma`
+### 6.14 API Server Settings
 
-**Incompatible:** `openai`, `gemini`, `grok`, `github_copilot`, `ollama_cloud`, Brave web search
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api.key` | str | `""` | Bearer token required for write endpoints |
+| `api.allow_origins` | list | `[]` | CORS allowed origins (e.g. `["http://localhost:3000"]`) |
 
-See [OFFLINE_GUIDE.md](OFFLINE_GUIDE.md) for the full setup walkthrough, model pre-download instructions, and troubleshooting.
+Environment variables for the API server:
 
-### 6.7 Shell Passthrough Policy
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AXON_HOST` | `127.0.0.1` | Bind address for `axon-api` |
+| `AXON_PORT` | `8000` | Listen port for `axon-api` |
 
-Controls what `! <command>` runs in the REPL.
+### 6.15 Mount & Share Settings
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `repl.shell_passthrough` | string | `local_only` | `local_only` — allow only for local writable projects · `always` — allow for all projects (not recommended in shared deployments) · `off` — disable `!` passthrough entirely |
+YAML section: top-level (or under `rag:`)
 
-### 6.8 AxonStore (Multi-User Sharing)
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mount_refresh_mode` | str | `switch` | Staleness detection for shared mounts: `off` (never auto-refresh), `switch` (cache on project switch, TTL-based re-check), `per_query` (re-read marker before every retrieval, adds ~1 ms/query) |
+| `mount_refresh_ttl_s` | int | `300` | Seconds before a `switch`-mode mount auto-refreshes during a query |
+| `mount_sync_retry_max` | int | `5` | Max mid-sync retry attempts before raising `MountSyncPendingError` |
+| `mount_sync_retry_backoff_s` | float | `0.5` | Base backoff seconds between sync retries (exponential: `backoff * 2 ** attempt`) |
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `store.base` | string | `~/.axon` | Shared filesystem path for the AxonStore (also: `AXON_STORE_BASE` env var) |
+### 6.16 Store Settings
+
+YAML section: `store:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `store.base` | str | `~/.axon` | Shared filesystem path for the AxonStore (also: `AXON_STORE_BASE` env var) |
 
 See [AXON_STORE.md](AXON_STORE.md) for the full sharing lifecycle.
 
-### 6.9 Environment Variables — Complete List
+### 6.17 REPL Settings
+
+YAML section: `repl:`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `repl.shell_passthrough` | str | `local_only` | Controls `!<cmd>` shell passthrough: `local_only` (allow for local/default projects only), `always` (all projects), `off` (disabled) |
+
+### 6.18 Concurrency & Performance
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_workers` | int | `8` | Thread pool size for all background ingest and retrieval tasks |
+| `graph_rag_map_workers` | int | `0` | Dedicated pool for GraphRAG map-reduce phase (`0` = share `max_workers`) |
+| `ingest_batch_mode` | bool | `false` | Defer BM25, entity graph, and relation graph saves to `finalize_ingest()`. Reduces O(N²) disk writes to O(1) per session |
+| `max_chunks_per_source` | int | `0` | Per-source chunk count cap after splitting (`0` = unlimited) |
+| `bloom_filter_hash_store` | bool | `false` | Use a bloom filter for dedup hash membership testing (saves ~6MB RAM at 100k docs; ~0.1% false-positive rate) |
+
+### 6.19 Environment Variables
 
 | Variable | Used By | Description |
 |----------|---------|-------------|
-| `OLLAMA_HOST` | LLM + embedding | Ollama server URL (default: `http://localhost:11434`) |
+| `OLLAMA_HOST` | LLM + embedding | Ollama server URL (default: `http://localhost:11434`; also accepted: `OLLAMA_BASE_URL`) |
 | `OPENAI_API_KEY` | LLM + embedding | OpenAI API key |
 | `XAI_API_KEY` | LLM | xAI Grok API key (also accepted: `GROK_API_KEY`) |
 | `GEMINI_API_KEY` | LLM | Google Gemini API key |
 | `GITHUB_COPILOT_PAT` | LLM | Copilot OAuth token (also: `GITHUB_TOKEN`) |
+| `VLLM_BASE_URL` | LLM | vLLM server base URL |
 | `OLLAMA_CLOUD_URL` | LLM | Remote Ollama endpoint URL |
 | `OLLAMA_CLOUD_KEY` | LLM | Remote Ollama API key |
+| `OLLAMA_MODELS` | LLM | Ollama model root directory |
 | `BRAVE_API_KEY` | Web search | Brave Search API key |
 | `AXON_STORE_BASE` | Sharing | AxonStore shared filesystem path |
+| `AXON_PROJECTS_ROOT` | Projects | Override the projects root directory directly |
 | `AXON_HOST` | API server | API server bind address (default: `127.0.0.1`) |
 | `AXON_PORT` | API server | API server port (default: `8000`) |
 | `RAG_INGEST_BASE` | Security | Restrict ingest to this directory tree (default: cwd) |
-| `LOG_LEVEL` | Logging | `DEBUG \| INFO \| WARNING \| ERROR` (default: `INFO`) |
+| `AXON_DEBUG` | Logging | Set to any non-empty value to enable DEBUG-level console logging |
 | `PYTHONUTF8` | Windows | Set to `1` to force UTF-8 mode on Windows |
-
-### 6.10 Concurrency & Performance Tuning
-
-Axon handles concurrency at two independent levels.
-
-#### Web-server level (I/O concurrency)
-
-The API server is built on **FastAPI + Uvicorn**, with all endpoints written as `async def`.
-
-This means the server can accept and process hundreds of concurrent HTTP requests without blocking —
-
-a query, an ingest job, and a share operation can all run simultaneously on a single process.
-
-Start the server with multiple OS-level workers for true multi-process parallelism:
-
-```bash
-uvicorn axon.api:app --host 0.0.0.0 --port 8000 --workers 4
-# or via the CLI entry-point env vars:
-AXON_HOST=0.0.0.0 AXON_PORT=8000 axon-api
-```
-
-#### Engine level (CPU thread concurrency)
-
-Heavy work (chunking, embedding calls, BM25 indexing, GraphRAG extraction) runs inside a
-
-**shared background thread pool** inside `AxonBrain`.  The pool size is controlled by:
-
-| `config.yaml` key | Default | Description |
-|-------------------|---------|-------------|
-| `max_workers` | `8` | Thread pool size for all background ingest and retrieval tasks |
-| `graph_rag_map_workers` | `0` | Dedicated pool for GraphRAG map-reduce phase (`0` = share `max_workers`) |
-
-```yaml
-# Scale up on a 32-core server
-max_workers: 16
-# Isolate GraphRAG map-reduce so large graph jobs don't starve normal queries
-graph_rag_map_workers: 8
-```
-
-**When to adjust `max_workers`:**
-
-| Machine | Recommended value |
-|---------|------------------|
-| Laptop / CI (8 cores) | `4`–`8` (default) |
-| Workstation (16–32 cores) | `12`–`24` |
-| Server (32+ cores, multiple users) | `24`–`32` |
-
-**When to set `graph_rag_map_workers`:**
-
-Set this when running GraphRAG community finalization (`axon-api` or `/graph/finalize`) on
-
-a machine that also serves live query traffic.  A dedicated pool ensures map-reduce LLM
-
-batches do not block incoming search requests.
 
 ---
 
@@ -728,17 +875,6 @@ batches do not block incoming search requests.
 ```bash
 curl http://localhost:8000/health
 curl http://localhost:8000/governance/overview
-```
-
-`/governance/overview` returns:
-
-```json
-{
-  "active_projects": 3,
-  "session_count": 12,
-  "active_leases": 0,
-  "maintenance_projects": []
-}
 ```
 
 ### 7.2 Audit Query Activity
@@ -772,18 +908,14 @@ curl -X POST http://localhost:8000/governance/project/maintenance \
 ### 7.4 Force-Expire a Stuck Session
 
 ```bash
-# List active sessions
 curl http://localhost:8000/governance/copilot/sessions
-# Force-expire
 curl -X POST http://localhost:8000/governance/copilot/session/<session_id>/expire
 ```
 
 ### 7.5 Rebuild GraphRAG Communities
 
 ```bash
-# Check if rebuild needed
 curl http://localhost:8000/graph/status
-# Trigger rebuild
 curl -X POST http://localhost:8000/graph/finalize
 ```
 
@@ -791,20 +923,20 @@ curl -X POST http://localhost:8000/graph/finalize
 
 ## 8. Surface Capability Matrix
 
-Which operations are available on which surface:
-
 | Capability | API | REPL | CLI | MCP |
 |-----------|-----|------|-----|-----|
 | Query (synthesis) | ✓ | ✓ | ✓ | ✓ |
 | Query (streaming) | ✓ | — | ✓ | — |
 | Search (raw) | ✓ | ✓ | — | ✓ |
+| Dry-run retrieval | ✓ | — | ✓ | — |
 | Ingest text | ✓ | — | — | ✓ |
 | Ingest file/dir | ✓ | ✓ | ✓ | ✓ |
 | Ingest URL | ✓ | ✓ | — | ✓ |
-| Smart refresh | ✓ | ✓ | — | — |
-| Stale detection | ✓ | ✓ | — | ✓ |
+| Ingest upload | ✓ | — | — | — |
+| Smart refresh | ✓ | ✓ | ✓ | ✓ |
+| Stale detection | ✓ | ✓ | ✓ | ✓ |
 | Collection inspect | ✓ | ✓ | ✓ | ✓ |
-| Delete documents | ✓ | — | — | ✓ |
+| Delete documents | ✓ | — | ✓ | ✓ |
 | Clear knowledge base | ✓ | ✓ | — | ✓ |
 | Project list | ✓ | ✓ | ✓ | ✓ |
 | Project switch | ✓ | ✓ | ✓ | ✓ |
@@ -812,17 +944,26 @@ Which operations are available on which surface:
 | Project delete | ✓ | ✓ | ✓ | ✓ |
 | Config read | ✓ | ✓ | — | ✓ |
 | Config update | ✓ | ✓ | — | ✓ |
-| Session list | ✓ | ✓ | — | ✓ |
+| Config validate | ✓ | — | ✓ | — |
+| Session list | ✓ | ✓ | ✓ | ✓ |
 | Session load | ✓ | ✓ | — | ✓ |
-| Share generate | ✓ | ✓ | — | ✓ |
-| Share redeem | ✓ | ✓ | — | ✓ |
-| Share revoke | ✓ | ✓ | — | — |
-| Share list | ✓ | ✓ | — | ✓ |
-| AxonStore init | ✓ | ✓ | — | ✓ |
-| Graph status | ✓ | ✓ | — | ✓ |
-| Graph finalize | ✓ | ✓ | — | ✓ |
+| Share generate | ✓ | ✓ | ✓ | ✓ |
+| Share redeem | ✓ | ✓ | ✓ | ✓ |
+| Share revoke | ✓ | ✓ | ✓ | ✓ |
+| Share list | ✓ | ✓ | ✓ | ✓ |
+| Share extend | ✓ | — | — | ✓ |
+| AxonStore init | ✓ | ✓ | ✓ | ✓ |
+| Sealed store bootstrap | ✓ | — | ✓ | ✓ |
+| Sealed store unlock/lock | ✓ | — | ✓ | ✓ |
+| Project seal | ✓ | — | ✓ | ✓ |
+| Mount refresh | ✓ | ✓ | — | ✓ |
+| Graph status | ✓ | ✓ | ✓ | ✓ |
+| Graph finalize | ✓ | ✓ | ✓ | ✓ |
 | Graph data | ✓ | — | — | ✓ |
-| Graph visualize | ✓ | ✓ | — | — |
+| Graph visualize | ✓ | ✓ | ✓ | — |
+| Graph backend status | ✓ | — | — | ✓ |
+| Optimize index | — | — | ✓ | — |
+| Migrate vectors | — | — | ✓ | — |
 | Maintenance state | ✓ | — | — | — |
 | Lease registry | ✓ | — | — | ✓ |
 | Governance audit | ✓ | — | — | — |
@@ -830,11 +971,8 @@ Which operations are available on which surface:
 ---
 
 *See [API_REFERENCE.md](API_REFERENCE.md) for full request/response schemas.*
-
 *See [MCP_TOOLS.md](MCP_TOOLS.md) for MCP tool signatures.*
-
 *See [GOVERNANCE_CONSOLE.md](GOVERNANCE_CONSOLE.md) for the full audit and monitoring runbook.*
-
 *See [EVALUATION.md](EVALUATION.md) for RAGAS metrics, smoke tests, and building testsets.*
-
 *See [OFFLINE_GUIDE.md](OFFLINE_GUIDE.md) for air-gap setup, model pre-download, and local-assets-only mode.*
+*See [SHARE_MOUNT_SEALED.md](SHARE_MOUNT_SEALED.md) for the sealed-mount encrypted-at-rest sharing system.*

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -256,8 +256,8 @@ make lint
 
 ## Resources
 
-- [Contributing Guide](CONTRIBUTING.md)
-- [Security Policy](SECURITY.md)
+- [Contributing Guide](../CONTRIBUTING.md)
+- [Security Policy](../SECURITY.md)
 
 ## Getting Help
 

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -638,7 +638,7 @@ echo "Setup complete! Edit .env and run: make test"
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) file.
+MIT License - See [LICENSE](../LICENSE) file.
 
 ---
 

--- a/docs/SHARE_MOUNT_SEALED.md
+++ b/docs/SHARE_MOUNT_SEALED.md
@@ -118,7 +118,7 @@ Wrapping = AES-256-KW (RFC 5649) — small (40 bytes per wrap), constant time, w
 
 | Key | Owner storage | Grantee storage |
 |---|---|---|
-| **Master** | OS keyring (DPAPI on Windows, Keychain on macOS, Secret Service on Linux) with passphrase fallback at `~/.axon/.security/master.enc` | (Grantees never see the master key) |
+| **Master** | OS keyring (DPAPI on Windows, Keychain on macOS, Secret Service on Linux) with passphrase fallback at `~/.axon/AxonStore/<username>/.security/master.enc` | (Grantees never see the master key) |
 | **Project DEK (encrypted with master)** | `~/.axon/AxonStore/<owner>/<project>/.security/dek.wrapped` | (Not stored — derived from share material at mount time) |
 | **Project DEK (encrypted with per-share KEK)** | `~/.axon/AxonStore/<owner>/<project>/.security/shares/<key_id>.wrapped` | Bytes synced to grantee via OneDrive; same path on grantee side |
 | **Share token (used to derive KEK)** | (Owner generates, transmits via share_string) | OS keyring at `axon.share.<key_id>` after redemption |
@@ -304,8 +304,8 @@ later phases add reach and polish.
 | **2** | **Ephemeral cache subsystem** + **TQDB sealed read** + **LanceDB sealed read** — owner can `axon project seal <name>` on either backend; mount flow reads from the cache; cache wiped on close; PID-based crash recovery. Both backends in one PR (cache makes them backend-agnostic). | Open |
 | **3** | Sealed-share generation + redemption flow — fill in `generate_sealed_share` / `redeem_sealed_share` stubs; grantee can query a sealed project on a shared filesystem | Open |
 | **4** | Revocation: soft `revoke` (manifest mark) + hard `revoke --rotate` (re-encrypt + per-share KEK regeneration); progress UX for hard; tests covering both flows + cached-bytes-after-rotate negative case | Open |
-| **5** | Cross-interface surfaces — REST `/store/seal`, `/share/generate?sealed=true&ttl_days=N`, `/share/revoke?rotate=true`; MCP tools (`seal_project`, `share_project sealed=true`, `revoke_share rotate=true`); REPL `/store seal <name>`, `/share generate --sealed`, `/share revoke --rotate`; CLI flags; docs (`SHARE_MOUNT.md` rewrite + cross-link) | Open |
-| **6** | Passphrase fallback for headless / no-keyring environments (Phase 1 deferred from §5.3) | Open |
+| **5** | Cross-interface surfaces — REST `/store/seal`, `/share/generate?sealed=true&ttl_days=N`, `/share/revoke?rotate=true`; MCP tools (`seal_project`, `share_project sealed=true`, `revoke_share rotate=true`); REPL `/store seal <name>`, `/share generate --sealed`, `/share revoke --rotate`; CLI flags; docs (`SHARE_MOUNT.md` rewrite + cross-link) | ✅ **SHIPPED** |
+| **6** | Passphrase fallback for headless / no-keyring environments (Phase 1 deferred from §5.3) | ✅ **SHIPPED** |
 | **7** | Verification: extend `SHARE_MOUNT_SMOKE.md` with sealed-store steps; real two-machine OneDrive run before tagging | Open |
 
 Each phase has its own GitHub issue (templated after #51–#54).
@@ -355,9 +355,6 @@ the default; until then both recipes coexist.
   fine for v1.
 - **Post-quantum crypto.** AES-256-GCM is the line; PQC is its own
   decade.
-- **Streaming encryption** (decrypt as bytes are read from disk
-  block-by-block). Decrypt-into-memory is simpler and v1 has the RAM
-  budget.
 - **Multi-owner / write access for grantees.** Mounts stay read-only
   by design.
 - **Key escrow / recovery** (e.g. Shamir-secret-sharing the master

--- a/src/axon/config.py
+++ b/src/axon/config.py
@@ -503,7 +503,7 @@ class AxonConfig:
     # Saves ~6 MB RAM at 100k docs at the cost of a ~0.1% false-positive rate
     # (a chunk that was never ingested may be silently skipped). Opt-in; disabled by default.
     bloom_filter_hash_store: bool = False
-    # Graph backend selector: "graphrag" (default) or "dynamic" (SQLite-WAL temporal graph)
+    # Graph backend selector: "graphrag" (default) or "dynamic" (SQLite temporal graph, DELETE journal mode)
     graph_backend: str = "graphrag"
     # Rust engine selectors (per pipeline stage)
     ingest_engine: str = "python"

--- a/src/axon/dynamic_graph/__init__.py
+++ b/src/axon/dynamic_graph/__init__.py
@@ -1,4 +1,4 @@
-"""Dynamic graph package — SQLite-WAL temporal knowledge graph (v0.3)."""
+"""Dynamic graph package — SQLite temporal knowledge graph, DELETE journal mode (v0.3)."""
 from axon.dynamic_graph.models import (
     Entity,
     Episode,

--- a/src/axon/graph_backends/base.py
+++ b/src/axon/graph_backends/base.py
@@ -3,7 +3,7 @@
 This module defines the stable interface all graph backends must satisfy.
 Concrete implementations live in sibling modules:
   - graphrag_backend.py  (existing GraphRAG, shipped in v0.1)
-  - dynamic_graph_backend.py  (SQLite-WAL temporal graph, planned for v0.3)
+  - dynamic_graph_backend.py  (SQLite temporal graph, DELETE journal mode, v0.3)
 """
 from __future__ import annotations
 

--- a/src/axon/graph_backends/factory.py
+++ b/src/axon/graph_backends/factory.py
@@ -7,7 +7,7 @@ Usage::
 
 The backend type is determined by ``brain.config.graph_backend``:
   - ``"graphrag"`` (default) → :class:`GraphRagBackend`
-  - ``"dynamic_graph"`` → :class:`DynamicGraphBackend` (SQLite-WAL, v0.3)
+  - ``"dynamic_graph"`` → :class:`DynamicGraphBackend` (SQLite, DELETE journal mode, v0.3)
 
 Adding a new backend type: register it in ``_BACKEND_REGISTRY`` below.
 """

--- a/src/axon/mcp_server.py
+++ b/src/axon/mcp_server.py
@@ -681,7 +681,7 @@ async def graph_backend_status() -> Any:
     Reports which backend is active (graphrag or dynamic), whether it is
     ready, and backend-specific health metrics (entity count, edge count,
     node counts, etc.).  Use this to distinguish between the GraphRAG
-    community-graph backend and the dynamic SQLite-WAL graph backend.
+    community-graph backend and the dynamic SQLite graph backend.
     """
     return await _get("/graph/backend/status")
 
@@ -695,6 +695,154 @@ async def get_active_leases() -> Any:
     state (wait for active_leases to reach 0 first).
     """
     return await _get("/registry/leases")
+
+
+# ---------------------------------------------------------------------------
+# Governance tools (SP-B1 parity sweep — previously REST/VS Code panel only)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def governance_overview() -> Any:
+    """Return aggregated operator status: projects, graph, write-leases, shares, and Copilot.
+    Use this as a single-call health snapshot before performing administrative operations
+    such as maintenance-state changes, graph rebuilds, or share revocations.
+    """
+    return await _get("/governance/overview")
+
+
+@mcp.tool()
+async def governance_audit(
+    project: str | None = None,
+    action: str | None = None,
+    surface: str | None = None,
+    status: str | None = None,
+    since: str | None = None,
+    limit: int = 50,
+) -> Any:
+    """Return audit log entries matching the given filters, newest first.
+    Args:
+        project: Filter by project name (exact match).
+        action: Filter by action string, e.g. ``"ingest"`` or ``"share_generate"``.
+        surface: Filter by surface, e.g. ``"api"``, ``"mcp"``, ``"repl"``.
+        status: Filter by status, e.g. ``"success"`` or ``"error"``.
+        since: ISO-8601 lower bound for the event timestamp, e.g. ``"2026-01-01T00:00:00"``.
+        limit: Maximum events to return (1-1000, default 50).
+    """
+    params: list[str] = []
+    if project:
+        params.append(f"project={project}")
+    if action:
+        params.append(f"action={action}")
+    if surface:
+        params.append(f"surface={surface}")
+    if status:
+        params.append(f"status={status}")
+    if since:
+        params.append(f"since={since}")
+    params.append(f"limit={limit}")
+    qs = "&".join(params)
+    return await _get(f"/governance/audit?{qs}")
+
+
+@mcp.tool()
+async def governance_sessions(limit: int = 20) -> Any:
+    """Return active and recent Copilot bridge sessions.
+    Useful for diagnosing stuck or orphaned Copilot agent sessions.
+    Args:
+        limit: Maximum number of recent sessions to return (default 20, max 100).
+    """
+    return await _get(f"/governance/copilot/sessions?limit={limit}")
+
+
+@mcp.tool()
+async def governance_projects() -> Any:
+    """Return all projects with their maintenance state and graph statistics.
+    Includes active_leases, maintenance_state, entity_count, and community_count
+    for each project. Use before entering maintenance mode to confirm leases are drained.
+    """
+    return await _get("/governance/projects")
+
+
+@mcp.tool()
+async def governance_graph_rebuild() -> Any:
+    """Trigger an audited graph community rebuild via the governance operator endpoint.
+    Equivalent to graph_finalize() but writes an audit-log entry and enforces write-lease
+    checks. Prefer this over graph_finalize() in automated operator pipelines.
+    Returns job metadata including the number of community summaries produced.
+    """
+    return await _post("/governance/graph/rebuild", {})
+
+
+# ---------------------------------------------------------------------------
+# Streaming query (SP-B1 parity sweep — previously REST/CLI only)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def query_stream(
+    query: str,
+    top_k: int | None = None,
+    filters: dict | None = None,
+    project: str | None = None,
+) -> Any:
+    """Ask a question and receive a full streamed answer accumulated into one response.
+    Internally calls the ``/query/stream`` SSE endpoint and collects all tokens
+    before returning, so MCP clients that do not support incremental delivery still
+    receive the complete answer in a single tool result.
+    Use ``query_knowledge`` for a blocking single-round-trip query; use this tool
+    when the server response is expected to be long (> 1000 tokens) or when the
+    LLM provider has a long first-token latency and you want a progress signal.
+    Args:
+        query: The question to ask.
+        top_k: Number of chunks to retrieve for context (overrides global setting).
+        filters: Optional metadata filters for retrieval.
+        project: Expected active project. Returns 409 if it does not match
+            the brain's current active project. Use switch_project first.
+    """
+    if top_k is not None and top_k < 1:
+        raise ValueError("top_k must be >= 1")
+    body: dict = {"query": query}
+    if top_k is not None:
+        body["top_k"] = top_k
+    if filters:
+        body["filters"] = filters
+    if project:
+        body["project"] = project
+    # Use a longer timeout for streaming; accumulate SSE chunks.
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        accumulated: list[str] = []
+        async with client.stream(
+            "POST", f"{API_BASE}/query/stream", json=body, headers=_headers()
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if line.startswith("data:"):
+                    chunk = line[5:].strip()
+                    if chunk and chunk != "[DONE]":
+                        accumulated.append(chunk)
+    return {"answer": "".join(accumulated), "streamed": True}
+
+
+# ---------------------------------------------------------------------------
+# Mount refresh with project targeting (SP-B1 parity sweep)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def mount_refresh(project: str | None = None) -> Any:
+    """Re-read the owner's version marker for a mounted share project.
+    If *project* is supplied and the active project differs, switches to *project*
+    first. No-op when the target project is not a mount (``mounts/<name>``).
+    Use after the owner has re-ingested content and synced the share directory,
+    to make queries reflect the latest knowledge without restarting the server.
+    Args:
+        project: The mount project to refresh, e.g. ``"mounts/alice_research"``.
+            Omit to refresh the currently active project (must already be a mount).
+    """
+    if project:
+        await _post("/project/switch", {"project_name": project})
+    return await _post("/mount/refresh", {})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,775 @@
+"""
+tests/test_agent.py
+
+Unit tests for src/axon/agent.py — dispatch_tool, individual tool handlers,
+run_agent_loop, REPL_TOOLS schema, and helper utilities.
+
+Mocking strategy:
+  - brain: unittest.mock.MagicMock() with specific attributes set directly
+  - LLM: MagicMock() for complete_with_tools / complete
+  - File I/O: tmp_path pytest fixture + real Path writes
+  - Loaders / external modules: patched at import site
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from axon.agent import (
+    _DESTRUCTIVE_TOOLS,
+    REPL_TOOLS,
+    WEBAPP_TOOLS,
+    ToolCall,
+    _tool_get_config,
+    _tool_get_stale_docs,
+    _tool_graph_finalize,
+    _tool_graph_status,
+    _tool_list_knowledge,
+    _tool_list_projects,
+    _tool_read_file,
+    _tool_search_knowledge,
+    _tool_switch_project,
+    _tool_update_settings,
+    _tool_write_file,
+    dispatch_tool,
+    run_agent_loop,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_brain(**kwargs):
+    """Return a MagicMock AxonBrain with sensible defaults."""
+    brain = MagicMock()
+    brain._active_project = "default"
+    brain._ingested_hashes = set()
+    brain._entity_graph = {}
+    brain._relation_graph = {}
+    brain._community_summaries = {}
+    brain._community_build_in_progress = False
+    brain._community_graph_dirty = False
+    brain._doc_versions = {}
+    brain._own_bm25 = MagicMock()
+    brain._own_vector_store = MagicMock()
+    for k, v in kwargs.items():
+        setattr(brain, k, v)
+    return brain
+
+
+def _make_config(**kwargs):
+    """Return a simple dataclass config for get_config tests."""
+
+    @dataclasses.dataclass
+    class FakeCfg:
+        top_k: int = 5
+        hybrid_search: bool = True
+        rerank: bool = False
+        hyde: bool = False
+        graph_rag: bool = False
+        raptor: bool = False
+        similarity_threshold: float = 0.0
+        multi_query: bool = False
+        step_back: bool = False
+        query_decompose: bool = False
+        compress_context: bool = False
+        truth_grounding: bool = False
+        discussion_fallback: bool = False
+        sentence_window: bool = False
+        sentence_window_size: int = 2
+        dedup_on_ingest: bool = True
+        pdf_vision_ocr: bool = True
+
+    cfg = FakeCfg()
+    for k, v in kwargs.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# REPL_TOOLS schema sanity
+# ---------------------------------------------------------------------------
+
+
+class TestReplTools:
+    def test_repl_tools_is_list(self):
+        assert isinstance(REPL_TOOLS, list)
+        assert len(REPL_TOOLS) > 0
+
+    def test_every_tool_has_function_key(self):
+        for t in REPL_TOOLS:
+            assert t.get("type") == "function"
+            assert "function" in t
+            assert "name" in t["function"]
+
+    def test_destructive_tools_not_in_webapp(self):
+        webapp_names = {t["function"]["name"] for t in WEBAPP_TOOLS}
+        for dt in _DESTRUCTIVE_TOOLS:
+            assert (
+                dt not in webapp_names
+            ), f"Destructive tool '{dt}' must not appear in WEBAPP_TOOLS"
+
+    def test_ingest_path_tool_present(self):
+        names = {t["function"]["name"] for t in REPL_TOOLS}
+        assert "ingest_path" in names
+
+    def test_tool_call_namedtuple_defaults(self):
+        tc = ToolCall(name="foo", args={"k": "v"})
+        assert tc.name == "foo"
+        assert tc.thought_signature is None  # default
+
+
+# ---------------------------------------------------------------------------
+# dispatch_tool — routing
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchToolRouting:
+    def test_unknown_tool_returns_error_string(self):
+        brain = _make_brain()
+        result = dispatch_tool(brain, "nonexistent_tool", {})
+        assert "Unknown tool" in result
+        assert "nonexistent_tool" in result
+
+    def test_destructive_tool_blocked_without_confirm_cb(self):
+        brain = _make_brain()
+        result = dispatch_tool(brain, "clear_project", {}, confirm_cb=None)
+        assert "requires confirmation" in result or "skipped" in result
+
+    def test_destructive_tool_cancelled_when_confirm_returns_false(self):
+        brain = _make_brain()
+        confirm_cb = MagicMock(return_value=False)
+        result = dispatch_tool(
+            brain, "delete_documents", {"source": "foo.pdf"}, confirm_cb=confirm_cb
+        )
+        assert "cancelled" in result.lower()
+
+    def test_destructive_tool_proceeds_when_confirm_returns_true(self):
+        brain = _make_brain()
+        brain.list_documents.return_value = [
+            {"source": "foo.pdf", "chunks": 3, "doc_ids": ["foo.pdf::abc"]}
+        ]
+        brain._ingested_hashes = {"abc"}
+        confirm_cb = MagicMock(return_value=True)
+        result = dispatch_tool(
+            brain, "delete_documents", {"source": "foo.pdf"}, confirm_cb=confirm_cb
+        )
+        assert "Deleted" in result or "chunk" in result
+
+    def test_dispatch_exception_returns_error_string(self):
+        """A tool that raises should not propagate — dispatch_tool catches it."""
+        brain = _make_brain()
+        brain.search_raw.side_effect = RuntimeError("connection refused")
+        result = dispatch_tool(brain, "search_knowledge", {"query": "anything"})
+        assert "failed" in result.lower() or "Search failed" in result
+
+    def test_dispatch_routes_list_knowledge(self):
+        brain = _make_brain()
+        brain.list_documents.return_value = [{"source": "a.txt", "chunks": 2}]
+        result = dispatch_tool(brain, "list_knowledge", {})
+        assert "source(s)" in result
+
+    def test_dispatch_routes_switch_project(self):
+        brain = _make_brain()
+        result = dispatch_tool(brain, "switch_project", {"name": "myproj"})
+        brain.switch_project.assert_called_once_with("myproj")
+        assert "myproj" in result
+
+    def test_dispatch_routes_get_config(self):
+        brain = _make_brain()
+        brain.config = _make_config()
+        result = dispatch_tool(brain, "get_config", {})
+        assert "active_project" in result
+
+    def test_dispatch_routes_graph_status(self):
+        brain = _make_brain()
+        result = dispatch_tool(brain, "graph_status", {})
+        assert "entities" in result
+
+    def test_dispatch_routes_graph_finalize(self):
+        brain = _make_brain()
+        dispatch_tool(brain, "graph_finalize", {})
+        brain.finalize_ingest.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _tool_read_file
+# ---------------------------------------------------------------------------
+
+
+class TestToolReadFile:
+    def test_read_file_success(self, tmp_path):
+        f = tmp_path / "sample.txt"
+        f.write_text("hello world", encoding="utf-8")
+        result = _tool_read_file({"path": str(f)})
+        assert result == "hello world"
+
+    def test_read_file_not_found(self, tmp_path):
+        result = _tool_read_file({"path": str(tmp_path / "missing.txt")})
+        assert "read_file failed" in result or "⚠️" in result
+
+    def test_read_file_truncates_large_content(self, tmp_path):
+        f = tmp_path / "big.txt"
+        big_content = "x" * 10_000
+        f.write_text(big_content, encoding="utf-8")
+        result = _tool_read_file({"path": str(f)})
+        assert "truncated" in result
+        assert len(result) < len(big_content)
+
+    def test_read_file_empty_path_returns_error(self):
+        result = _tool_read_file({"path": ""})
+        assert "⚠️" in result or "failed" in result
+
+
+# ---------------------------------------------------------------------------
+# _tool_write_file
+# ---------------------------------------------------------------------------
+
+
+class TestToolWriteFile:
+    def test_write_file_success(self, tmp_path):
+        target = tmp_path / "out.txt"
+        result = _tool_write_file({"path": str(target), "content": "test content"})
+        assert "Wrote" in result
+        assert target.read_text(encoding="utf-8") == "test content"
+
+    def test_write_file_append_mode(self, tmp_path):
+        target = tmp_path / "out.txt"
+        target.write_text("first", encoding="utf-8")
+        result = _tool_write_file({"path": str(target), "content": " second", "mode": "a"})
+        assert "Appended" in result
+        assert target.read_text(encoding="utf-8") == "first second"
+
+    def test_write_file_creates_parent_directories(self, tmp_path):
+        target = tmp_path / "deep" / "nested" / "file.txt"
+        result = _tool_write_file({"path": str(target), "content": "data"})
+        assert target.exists()
+        assert "Wrote" in result
+
+    def test_write_file_invalid_mode_falls_back_to_overwrite(self, tmp_path):
+        target = tmp_path / "file.txt"
+        target.write_text("original", encoding="utf-8")
+        _tool_write_file({"path": str(target), "content": "new", "mode": "z"})
+        assert target.read_text(encoding="utf-8") == "new"
+
+
+# ---------------------------------------------------------------------------
+# _tool_list_knowledge
+# ---------------------------------------------------------------------------
+
+
+class TestToolListKnowledge:
+    def test_empty_knowledge_base(self):
+        brain = _make_brain()
+        brain.list_documents.return_value = []
+        result = _tool_list_knowledge(brain, {})
+        assert "empty" in result.lower()
+
+    def test_knowledge_base_with_documents(self):
+        brain = _make_brain()
+        brain.list_documents.return_value = [
+            {"source": "doc_a.pdf", "chunks": 10},
+            {"source": "doc_b.txt", "chunks": 5},
+        ]
+        result = _tool_list_knowledge(brain, {})
+        assert "doc_a.pdf" in result
+        assert "doc_b.txt" in result
+        assert "2 source(s)" in result
+
+    def test_list_knowledge_switches_project_and_restores(self):
+        brain = _make_brain()
+        brain._active_project = "proj-a"
+        brain.list_documents.return_value = []
+        _tool_list_knowledge(brain, {"project": "proj-b"})
+        # Should have switched to proj-b, then restored proj-a
+        calls = [c.args[0] for c in brain.switch_project.call_args_list]
+        assert "proj-b" in calls
+
+
+# ---------------------------------------------------------------------------
+# _tool_search_knowledge
+# ---------------------------------------------------------------------------
+
+
+class TestToolSearchKnowledge:
+    def test_search_no_query_returns_error(self):
+        brain = _make_brain()
+        result = _tool_search_knowledge(brain, {"query": ""})
+        assert "No query" in result
+
+    def test_search_returns_results(self):
+        brain = _make_brain()
+        brain.search_raw.return_value = (
+            [
+                {
+                    "text": "relevant chunk",
+                    "score": 0.95,
+                    "metadata": {"source": "x.pdf"},
+                    "id": "1",
+                },
+            ],
+            {},
+            [],
+        )
+        result = _tool_search_knowledge(brain, {"query": "hello"})
+        assert "1 result" in result
+        assert "x.pdf" in result
+
+    def test_search_no_results(self):
+        brain = _make_brain()
+        brain.search_raw.return_value = ([], {}, [])
+        result = _tool_search_knowledge(brain, {"query": "obscure"})
+        assert "No results" in result
+
+    def test_search_exception_returns_error(self):
+        brain = _make_brain()
+        brain.search_raw.side_effect = Exception("db error")
+        result = _tool_search_knowledge(brain, {"query": "test"})
+        assert "Search failed" in result
+
+
+# ---------------------------------------------------------------------------
+# _tool_switch_project
+# ---------------------------------------------------------------------------
+
+
+class TestToolSwitchProject:
+    def test_switch_project_success(self):
+        brain = _make_brain()
+        result = _tool_switch_project(brain, {"name": "analytics"})
+        brain.switch_project.assert_called_once_with("analytics")
+        assert "analytics" in result
+
+    def test_switch_project_no_name_returns_error(self):
+        brain = _make_brain()
+        result = _tool_switch_project(brain, {})
+        assert "No project name" in result
+        brain.switch_project.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _tool_get_config
+# ---------------------------------------------------------------------------
+
+
+class TestToolGetConfig:
+    def test_get_config_includes_active_project(self):
+        brain = _make_brain()
+        brain.config = _make_config()
+        result = _tool_get_config(brain)
+        assert "active_project: default" in result
+
+    def test_get_config_includes_all_fields(self):
+        brain = _make_brain()
+        brain.config = _make_config(top_k=10)
+        result = _tool_get_config(brain)
+        assert "top_k: 10" in result
+
+
+# ---------------------------------------------------------------------------
+# _tool_update_settings
+# ---------------------------------------------------------------------------
+
+
+class TestToolUpdateSettings:
+    def test_update_settings_changes_top_k(self):
+        brain = _make_brain()
+        brain.config = _make_config(top_k=5)
+        result = _tool_update_settings(brain, {"top_k": 15})
+        assert "top_k" in result
+        assert brain.config.top_k == 15
+
+    def test_update_settings_no_change(self):
+        brain = _make_brain()
+        brain.config = _make_config(top_k=5)
+        result = _tool_update_settings(brain, {"top_k": 5})
+        assert "No settings changed" in result
+
+    def test_update_settings_empty_args(self):
+        brain = _make_brain()
+        brain.config = _make_config()
+        result = _tool_update_settings(brain, {})
+        assert "No settings changed" in result
+
+    def test_update_settings_bool_field(self):
+        brain = _make_brain()
+        brain.config = _make_config(rerank=False)
+        result = _tool_update_settings(brain, {"rerank": True})
+        assert brain.config.rerank is True
+        assert "rerank" in result
+
+
+# ---------------------------------------------------------------------------
+# _tool_graph_status
+# ---------------------------------------------------------------------------
+
+
+class TestToolGraphStatus:
+    def test_graph_status_empty_graph(self):
+        brain = _make_brain()
+        result = _tool_graph_status(brain)
+        assert "entities: 0" in result
+        assert "relations: 0" in result
+
+    def test_graph_status_with_data(self):
+        brain = _make_brain()
+        brain._entity_graph = {"EntityA": {}, "EntityB": {}}
+        brain._relation_count = 5
+        result = _tool_graph_status(brain)
+        assert "entities: 2" in result
+
+    def test_graph_status_shows_rebuild_flag(self):
+        brain = _make_brain()
+        brain._community_build_in_progress = True
+        result = _tool_graph_status(brain)
+        assert "True" in result
+
+
+# ---------------------------------------------------------------------------
+# _tool_graph_finalize
+# ---------------------------------------------------------------------------
+
+
+class TestToolGraphFinalize:
+    def test_graph_finalize_success(self):
+        brain = _make_brain()
+        brain._community_summaries = {"c1": {}, "c2": {}}
+        result = _tool_graph_finalize(brain)
+        brain.finalize_ingest.assert_called_once()
+        assert "complete" in result.lower()
+
+    def test_graph_finalize_exception_returns_error(self):
+        brain = _make_brain()
+        brain.finalize_ingest.side_effect = RuntimeError("graph error")
+        result = _tool_graph_finalize(brain)
+        assert "failed" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _tool_list_projects
+# ---------------------------------------------------------------------------
+
+
+class TestToolListProjects:
+    def test_list_projects_no_projects(self):
+        with patch("axon.agent._tool_list_projects") as mock_fn:
+            mock_fn.return_value = "No projects found."
+            result = mock_fn()
+        assert "No projects" in result
+
+    def test_list_projects_returns_names(self):
+        with patch("axon.projects.list_projects") as mock_lp:
+            mock_lp.return_value = [
+                {"name": "proj-a", "description": "first", "children": []},
+                {"name": "proj-b", "description": "", "children": []},
+            ]
+            result = _tool_list_projects()
+        assert "proj-a" in result
+        assert "proj-b" in result
+        assert "2 project(s)" in result
+
+    def test_list_projects_empty(self):
+        with patch("axon.projects.list_projects") as mock_lp:
+            mock_lp.return_value = []
+            result = _tool_list_projects()
+        assert "No projects" in result
+
+
+# ---------------------------------------------------------------------------
+# _tool_get_stale_docs
+# ---------------------------------------------------------------------------
+
+
+class TestToolGetStaleDocs:
+    def test_no_doc_versions_tracked(self):
+        brain = _make_brain()
+        brain._doc_versions = {}
+        result = _tool_get_stale_docs(brain, {})
+        assert "No ingestion history" in result
+
+    def test_no_stale_docs_when_all_recent(self):
+        from datetime import datetime, timezone
+
+        brain = _make_brain()
+        now_iso = datetime.now(timezone.utc).isoformat()
+        brain._doc_versions = {"doc.txt": {"ingested_at": now_iso, "content_hash": "abc"}}
+        result = _tool_get_stale_docs(brain, {"days": 30})
+        assert "No stale" in result
+
+    def test_stale_docs_detected(self):
+        brain = _make_brain()
+        brain._doc_versions = {
+            "old_doc.txt": {"ingested_at": "2020-01-01T00:00:00+00:00", "content_hash": "xyz"}
+        }
+        result = _tool_get_stale_docs(brain, {"days": 30})
+        assert "old_doc.txt" in result
+        assert "stale" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _tool_ingest_url (via dispatch_tool)
+# ---------------------------------------------------------------------------
+
+
+class TestToolIngestUrl:
+    def test_invalid_url_returns_error(self):
+        brain = _make_brain()
+        result = dispatch_tool(brain, "ingest_url", {"url": "ftp://bad.url"})
+        assert "Invalid URL" in result or "must start with http" in result
+
+    def test_empty_url_returns_error(self):
+        brain = _make_brain()
+        result = dispatch_tool(brain, "ingest_url", {"url": ""})
+        assert "No URL provided" in result
+
+    def test_url_load_exception_returns_error(self):
+        brain = _make_brain()
+        with patch("axon.loaders.URLLoader") as mock_loader_cls:
+            mock_loader_cls.return_value.load.side_effect = Exception("timeout")
+            result = dispatch_tool(brain, "ingest_url", {"url": "https://example.com"})
+        assert "Failed to fetch" in result or "failed" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _tool_add_text (via dispatch_tool)
+# ---------------------------------------------------------------------------
+
+
+class TestToolAddText:
+    def test_add_text_empty_returns_error(self):
+        brain = _make_brain()
+        with patch("axon.loaders.SmartTextLoader"):
+            result = dispatch_tool(brain, "add_text", {"text": ""})
+        assert "No text provided" in result
+
+    def test_add_text_success(self):
+        brain = _make_brain()
+        mock_loader = MagicMock()
+        mock_loader.load_text.return_value = [{"text": "hello", "metadata": {}}]
+        with patch("axon.agent.SmartTextLoader", return_value=mock_loader, create=True):
+            with patch("axon.loaders.SmartTextLoader", return_value=mock_loader):
+                dispatch_tool(brain, "add_text", {"text": "hello world"})
+        # brain.ingest should have been called
+        brain.ingest.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _tool_delete_documents (via dispatch_tool)
+# ---------------------------------------------------------------------------
+
+
+class TestToolDeleteDocuments:
+    def test_delete_documents_no_source_returns_error(self):
+        brain = _make_brain()
+        confirm_cb = MagicMock(return_value=True)
+        result = dispatch_tool(brain, "delete_documents", {"source": ""}, confirm_cb=confirm_cb)
+        assert "No source" in result
+
+    def test_delete_documents_source_not_found(self):
+        brain = _make_brain()
+        brain.list_documents.return_value = []
+        confirm_cb = MagicMock(return_value=True)
+        result = dispatch_tool(
+            brain, "delete_documents", {"source": "gone.pdf"}, confirm_cb=confirm_cb
+        )
+        assert "No documents found" in result
+
+    def test_delete_documents_success(self):
+        brain = _make_brain()
+        brain.list_documents.return_value = [
+            {"source": "target.pdf", "chunks": 2, "doc_ids": ["target.pdf::h1", "target.pdf::h2"]}
+        ]
+        brain._ingested_hashes = {"h1", "h2"}
+        confirm_cb = MagicMock(return_value=True)
+        result = dispatch_tool(
+            brain, "delete_documents", {"source": "target.pdf"}, confirm_cb=confirm_cb
+        )
+        assert "Deleted" in result
+        brain._own_vector_store.delete_by_ids.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# run_agent_loop
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentLoop:
+    def _make_llm(self):
+        llm = MagicMock()
+        return llm
+
+    def test_plain_text_response_returns_immediately(self):
+        llm = self._make_llm()
+        llm.complete_with_tools.return_value = "Here is your answer."
+        brain = _make_brain()
+        result = run_agent_loop(llm, brain, "hello", [])
+        assert result == "Here is your answer."
+
+    def test_tool_call_then_text_response(self):
+        llm = self._make_llm()
+        brain = _make_brain()
+        brain.list_documents.return_value = []
+        # First call returns a ToolCall, second returns plain text
+        llm.complete_with_tools.side_effect = [
+            [ToolCall(name="list_knowledge", args={})],
+            "Knowledge base is empty.",
+        ]
+        result = run_agent_loop(llm, brain, "what do you know?", [])
+        assert "Knowledge base" in result or "empty" in result.lower() or isinstance(result, str)
+
+    def test_max_steps_triggers_final_summary(self):
+        llm = self._make_llm()
+        brain = _make_brain()
+        brain.list_documents.return_value = []
+        # Always return a tool call to exhaust max_steps
+        llm.complete_with_tools.return_value = [ToolCall(name="list_knowledge", args={})]
+        llm.complete.return_value = "Summary response."
+        run_agent_loop(llm, brain, "keep going", [], max_steps=2)
+        llm.complete.assert_called()
+
+    def test_identical_retry_loop_breaks_early(self):
+        llm = self._make_llm()
+        brain = _make_brain()
+        brain.list_documents.return_value = []
+        # Simulate LLM stuck in retry loop: same tool call repeatedly
+        llm.complete_with_tools.return_value = [ToolCall(name="list_knowledge", args={})]
+        llm.complete.return_value = "I'll stop retrying."
+        result = run_agent_loop(llm, brain, "list stuff", [], max_steps=10)
+        # Should have exited early via the identical-retry guard
+        assert isinstance(result, str)
+
+    def test_step_cb_called_for_each_tool(self):
+        llm = self._make_llm()
+        brain = _make_brain()
+        brain.list_documents.return_value = [{"source": "x.txt", "chunks": 1}]
+        llm.complete_with_tools.side_effect = [
+            [ToolCall(name="list_knowledge", args={})],
+            "Done.",
+        ]
+        step_cb = MagicMock()
+        run_agent_loop(llm, brain, "list", [], step_cb=step_cb)
+        step_cb.assert_called()
+        name_called = step_cb.call_args[0][0]
+        assert name_called == "list_knowledge"
+
+    def test_custom_tools_override_defaults(self):
+        llm = self._make_llm()
+        brain = _make_brain()
+        llm.complete_with_tools.return_value = "ok"
+        custom_tools = [{"type": "function", "function": {"name": "my_tool"}}]
+        run_agent_loop(llm, brain, "hi", [], tools=custom_tools)
+        # Verify llm received custom tools
+        call_args = llm.complete_with_tools.call_args
+        assert call_args[0][1] == custom_tools
+
+    def test_xml_stripped_from_plain_text_response(self):
+        llm = self._make_llm()
+        brain = _make_brain()
+        llm.complete_with_tools.return_value = (
+            "Here is the answer.<tool_calls>some leaked xml</tool_calls> Done."
+        )
+        result = run_agent_loop(llm, brain, "q", [])
+        assert "<tool_calls>" not in result
+
+    def test_step_cb_exception_does_not_abort_loop(self):
+        llm = self._make_llm()
+        brain = _make_brain()
+        brain.list_documents.return_value = []
+        llm.complete_with_tools.side_effect = [
+            [ToolCall(name="list_knowledge", args={})],
+            "Done.",
+        ]
+        bad_cb = MagicMock(side_effect=RuntimeError("cb exploded"))
+        # Should not raise
+        result = run_agent_loop(llm, brain, "list", [], step_cb=bad_cb)
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _make_vision_fn
+# ---------------------------------------------------------------------------
+
+
+class TestMakeVisionFn:
+    def test_returns_none_when_brain_is_none(self):
+        from axon.agent import _make_vision_fn
+
+        assert _make_vision_fn(None) is None
+
+    def test_returns_none_when_pdf_vision_ocr_disabled(self):
+        from axon.agent import _make_vision_fn
+
+        brain = _make_brain()
+        brain.config = _make_config(pdf_vision_ocr=False)
+        result = _make_vision_fn(brain)
+        assert result is None
+
+    def test_returns_none_when_llm_lacks_complete_with_image(self):
+        from axon.agent import _make_vision_fn
+
+        brain = _make_brain()
+        brain.config = _make_config(pdf_vision_ocr=True)
+        brain.llm = MagicMock(spec=[])  # no complete_with_image attribute
+        result = _make_vision_fn(brain)
+        assert result is None
+
+    def test_returns_callable_when_llm_supports_vision(self):
+        from axon.agent import _make_vision_fn
+
+        brain = _make_brain()
+        brain.config = _make_config(pdf_vision_ocr=True)
+        brain.llm = MagicMock()
+        brain.llm.complete_with_image.return_value = "extracted text"
+        fn = _make_vision_fn(brain)
+        assert callable(fn)
+        result = fn(b"fake image bytes")
+        assert result == "extracted text"
+
+    def test_vision_fn_returns_empty_string_on_exception(self):
+        from axon.agent import _make_vision_fn
+
+        brain = _make_brain()
+        brain.config = _make_config(pdf_vision_ocr=True)
+        brain.llm = MagicMock()
+        brain.llm.complete_with_image.side_effect = RuntimeError("vision error")
+        fn = _make_vision_fn(brain)
+        result = fn(b"bytes")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Confirm message formatting for destructive tools
+# ---------------------------------------------------------------------------
+
+
+class TestDestructiveConfirmMessages:
+    """Verify that the confirm_cb receives a sensible message for each destructive tool."""
+
+    @pytest.mark.parametrize(
+        "tool_name,args,expected_fragment",
+        [
+            ("purge_source", {"source": "/data/file.pdf"}, "/data/file.pdf"),
+            ("delete_documents", {"source": "report.pdf"}, "report.pdf"),
+            ("clear_project", {}, "irreversible"),
+            ("delete_project", {"name": "old-proj"}, "old-proj"),
+            ("run_shell", {"command": "ls"}, "ls"),
+        ],
+    )
+    def test_confirm_message_contains_expected_fragment(self, tool_name, args, expected_fragment):
+        brain = _make_brain()
+        # Reject the confirm — we just want to capture the message
+        captured = []
+
+        def confirm_cb(msg):
+            captured.append(msg)
+            return False  # cancel so no side effects
+
+        dispatch_tool(brain, tool_name, args, confirm_cb=confirm_cb)
+        assert captured, f"confirm_cb was never called for '{tool_name}'"
+        assert (
+            expected_fragment in captured[0]
+        ), f"Expected '{expected_fragment}' in confirm message: {captured[0]!r}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -70,6 +70,15 @@ EXPECTED_MCP_TOOL_NAMES = {
     "graph_data",
     "graph_backend_status",
     "get_active_leases",
+    # Governance (added by parity sweep B1)
+    "governance_overview",
+    "governance_audit",
+    "governance_sessions",
+    "governance_projects",
+    "governance_graph_rebuild",
+    # Streaming + mount (added by parity sweep B1)
+    "query_stream",
+    "mount_refresh",
 }
 
 


### PR DESCRIPTION
F1: Complete rewrite of ADMIN_REFERENCE.md â€” 49 missing CLI flags, all missing REPL commands (/agent /debug /theme /config /refresh), all missing config fields (mount_refresh_mode, bm25_engine, etc), raptor_max_levels default corrected (1â†’2), phantom --no-answer removed. 67 REST endpoints + 44 MCP tools documented.

F2: README counts fixed (31â†’39 MCP tools, 54â†’66 endpoints), SHARE_MOUNT_SEALED.md phase status updated (Phase 5+6 marked shipped), master key path corrected, SQLite-WAL myth removed from 5 Python files (actual: journal_mode=DELETE), broken relative links fixed in DEVELOPMENT.md and QUICKREF.md. Part of audit batch F1+F2.