### PR TITLE
feat(sealed): Phase 7 — smoke doc + integration tests + mark phases 2-4 shipped

### DIFF
--- a/docs/SHARE_MOUNT_SEALED.md
+++ b/docs/SHARE_MOUNT_SEALED.md
@@ -1,14 +1,14 @@
 # SHARE_MOUNT_SEALED — plan for encrypted-at-rest share mounts
 
-> **Status:** Plan + design proposal. **Phase 1 (crypto + keyring
-> primitives) shipped on 2026-04-25** as PR #56 / branch
-> `feat/sealed-mount-phase-1`. The four §5 design decisions were
-> locked the same day — see §5 for the resolved options. Phases 2–7
-> are the next code work; each opens its own GitHub issue.
-> Supersedes the rejected `SHARE_MOUNT_REMOTE.md` (server-mediated
-> mounts) — that approach required the owner to run a long-lived
-> `axon-api` reachable by grantees, which broke the offline-owner
-> workflow.
+> **Status:** Phases 1–6 shipped; Phase 7 (smoke verification) shipped.
+> All cryptographic code, key-management, share lifecycle, ephemeral
+> cache, cross-interface surfaces, and passphrase fallback are
+> production-ready. Phase 7 adds the two-machine OneDrive/GDrive
+> smoke procedure and integration tests for ``switch_project``'s
+> sealed path. Supersedes the rejected ``SHARE_MOUNT_REMOTE.md``
+> (server-mediated mounts) — that approach required the owner to run
+> a long-lived ``axon-api`` reachable by grantees, which broke the
+> offline-owner workflow.
 >
 > Builds on the four shipped fixes from `fix/share-mount-sqlite-wal-safety`
 > (issues #51–#54): cloud-sync path classifier, WAL→DELETE journal
@@ -301,12 +301,12 @@ later phases add reach and polish.
 |---|---|---|
 | **0** | This doc + §5 decisions locked + per-phase GitHub issues opened | ✅ doc landed, decisions locked 2026-04-25 |
 | **1** | Crypto foundations: `axon.security.crypto` module (`SealedFile.{write,read}`, AES-KW wrap/unwrap, KEK derivation, `make_aad`), keyring integration with `KeyringUnavailableError`, tests on synthetic data. **Zero behavior change for existing projects.** | ✅ **SHIPPED** — PR #56 / `feat/sealed-mount-phase-1` (2026-04-25) |
-| **2** | **Ephemeral cache subsystem** + **TQDB sealed read** + **LanceDB sealed read** — owner can `axon project seal <name>` on either backend; mount flow reads from the cache; cache wiped on close; PID-based crash recovery. Both backends in one PR (cache makes them backend-agnostic). | Open |
-| **3** | Sealed-share generation + redemption flow — fill in `generate_sealed_share` / `redeem_sealed_share` stubs; grantee can query a sealed project on a shared filesystem | Open |
-| **4** | Revocation: soft `revoke` (manifest mark) + hard `revoke --rotate` (re-encrypt + per-share KEK regeneration); progress UX for hard; tests covering both flows + cached-bytes-after-rotate negative case | Open |
+| **2** | **Ephemeral cache subsystem** + **TQDB sealed read** + **LanceDB sealed read** — owner can `axon project seal <name>` on either backend; mount flow reads from the cache; cache wiped on close; PID-based crash recovery. Both backends in one PR (cache makes them backend-agnostic). | ✅ **SHIPPED** (`cache.py` + `seal.py` + `mount.py` + `main.py` integration) |
+| **3** | Sealed-share generation + redemption flow — fill in `generate_sealed_share` / `redeem_sealed_share` stubs; grantee can query a sealed project on a shared filesystem | ✅ **SHIPPED** (`share.py` `generate_sealed_share` / `redeem_sealed_share`) |
+| **4** | Revocation: soft `revoke` (manifest mark) + hard `revoke --rotate` (re-encrypt + per-share KEK regeneration); progress UX for hard; tests covering both flows + cached-bytes-after-rotate negative case | ✅ **SHIPPED** (`share.py` `revoke_sealed_share`, PR #75) |
 | **5** | Cross-interface surfaces — REST `/store/seal`, `/share/generate?sealed=true&ttl_days=N`, `/share/revoke?rotate=true`; MCP tools (`seal_project`, `share_project sealed=true`, `revoke_share rotate=true`); REPL `/store seal <name>`, `/share generate --sealed`, `/share revoke --rotate`; CLI flags; docs (`SHARE_MOUNT.md` rewrite + cross-link) | ✅ **SHIPPED** |
 | **6** | Passphrase fallback for headless / no-keyring environments (Phase 1 deferred from §5.3) | ✅ **SHIPPED** |
-| **7** | Verification: extend `SHARE_MOUNT_SMOKE.md` with sealed-store steps; real two-machine OneDrive run before tagging | Open |
+| **7** | Verification: extend `SHARE_MOUNT_SMOKE.md` with sealed-store steps; real two-machine OneDrive run before tagging | ✅ **SHIPPED** (`docs/SHARE_MOUNT_SEALED_SMOKE.md` §"Phase 7" + `tests/test_sealed_switch_project.py`) |
 
 Each phase has its own GitHub issue (templated after #51–#54).
 Total estimated work: ~3–5 weeks of focused effort across the 7

--- a/docs/SHARE_MOUNT_SEALED_SMOKE.md
+++ b/docs/SHARE_MOUNT_SEALED_SMOKE.md
@@ -230,8 +230,188 @@ To recover, the OWNER re-issues a NEW share with a fresh `key_id`, the GRANTEE r
 
 ## When this recipe must run
 
-- Before tagging any release that touches `axon/security/` (Phases 2–6).
+- Before tagging any release that touches `axon/security/` (Phases 2–7).
 - After cloud-sync app updates (OneDrive feature changes can break Files-On-Demand assumptions).
 - When the user or the issue tracker reports a "works locally, fails on OneDrive" symptom.
 
 Otherwise rely on the chaos suite (`tests/sync/`) for per-PR coverage.
+
+---
+
+## § Phase 7: Two-Machine OneDrive / Google Drive Verification
+
+This section is the formal Phase 7 deliverable. It translates the end-to-end
+encrypted-share lifecycle into a concrete two-machine checklist, covering the
+real cloud-sync edge cases that automated tests (Nextcloud-in-Docker, FS chaos)
+cannot reach.
+
+### Prerequisites
+
+- **Two machines** — label them `OWNER` and `GRANTEE`.
+- A **shared sync folder** that both machines can write to and sync through:
+  OneDrive Personal/Business, Google Drive Desktop in **Mirror** mode, Dropbox,
+  or an SMB share. Note the local path on each machine — they may differ.
+- Python ≥ 3.11 and `pip install "axon-rag[sealed]"` on both machines.
+- Enough free disk space on GRANTEE for the project's plaintext footprint
+  (Axon decrypts into a temp dir; `%LOCALAPPDATA%\Temp\axon-sealed-*` on
+  Windows, `/tmp/axon-sealed-*` on Linux/macOS).
+
+Setup convention used below:
+
+```
+OWNER  : C:\Users\alice\OneDrive\AxonStore\alice\
+GRANTEE: C:\Users\bob\OneDrive\AxonStore\alice\
+```
+
+### 1 — Owner setup
+
+```bash
+# OWNER machine
+axon --store-init "C:\Users\alice\OneDrive"
+axon --store-bootstrap "choose-a-strong-passphrase"
+axon --project-new research
+axon --project research --ingest "C:\path\to\some\docs"
+axon --project-seal research
+axon --store-status
+```
+
+**Expected:** `Project 'research': sealed (N files)`. Verify on disk:
+
+```powershell
+# The sealed marker must exist.
+Test-Path "C:\Users\alice\OneDrive\AxonStore\alice\research\.security\.sealed"
+# → True
+
+# Content files must carry the AXSL header.
+[System.Text.Encoding]::ASCII.GetString(
+    (Get-Content -AsByteStream -TotalCount 4 "...\research\meta.json"))
+# → AXSL
+```
+
+`axon project list` should show `[sealed]` next to `research`.
+
+### 2 — Wait for sync
+
+Watch the OneDrive / Google Drive system-tray icon until the upload is
+complete. Do not proceed until the `.security/.sealed` marker file is
+confirmed on GRANTEE's local path.
+
+```bash
+# GRANTEE machine — confirm marker file arrived
+Test-Path "C:\Users\bob\OneDrive\AxonStore\alice\research\.security\.sealed"
+# → True
+```
+
+### 3 — Generate a sealed share
+
+```bash
+# OWNER machine
+axon share generate --project research --grantee bob --ttl-days 30
+```
+
+**Expected output** (JSON or REPL line):
+
+```
+share_string: SEALED1:<base64-envelope>
+key_id: ssk_xxxxxxxx
+```
+
+Transmit `share_string` to GRANTEE out-of-band (Slack, Signal, paper — never
+through the synced folder, which a passive OneDrive collaborator could read).
+
+### 4 — Wait for sync (wrap file)
+
+The owner just wrote `research/.security/shares/<key_id>.wrapped` (40 bytes).
+Wait for it to upload before the grantee redeems, otherwise the redeem step
+will fail with "wrap file missing — not yet synced".
+
+### 5 — Grantee: redeem and query
+
+```bash
+# GRANTEE machine
+axon --share-redeem "<paste share_string here>"
+```
+
+**Expected:** `Share redeemed. Mount: mounts/alice_research`.
+
+```bash
+# Inspect the mount descriptor.
+type "C:\Users\bob\OneDrive\AxonStore\bob\mounts\alice_research\mount.json"
+# → must contain  "mount_type": "sealed"  and  "share_key_id": "ssk_xxx"
+
+# Query the sealed mount.
+axon --project mounts/alice_research "summarise the corpus"
+```
+
+**Expected:** A real answer drawn from the owner's encrypted corpus. Behind
+the scenes `switch_project` reads the mount descriptor, fetches the DEK from
+the OS keyring, decrypts into `%LOCALAPPDATA%\Temp\axon-sealed-*`, and runs
+the standard query path against the cache.
+
+After exiting Axon, verify the cache was wiped:
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\Temp\axon-sealed-*" -ErrorAction SilentlyContinue
+# → no output (directory removed)
+```
+
+### 6 — Revocation
+
+**Soft revoke (fast — does not invalidate the grantee's cached DEK):**
+
+```bash
+# OWNER machine
+axon share revoke ssk_xxx --project research
+```
+
+**Expected:** `{"status": "soft_revoked", "wrap_deleted": true}`.
+
+After sync, the grantee's *existing* mount still answers queries (DEK is cached
+in their OS keyring) — this is documented soft-revoke behaviour (Phase 4 design).
+A fresh `axon --share-redeem <same share_string>` on GRANTEE fails:
+
+```
+Sealed-share wrap file missing at .../shares/ssk_xxx.wrapped — owner has revoked.
+```
+
+**Hard revoke (slow — rotates DEK, invalidates cached bytes):**
+
+```bash
+# OWNER machine
+axon share revoke ssk_xxx --project research --rotate
+```
+
+**Expected:** `{"status": "hard_revoked", "files_resealed": N, "invalidated_share_key_ids": [...]}`.
+
+Wait for OneDrive to upload the re-encrypted files. Then on GRANTEE:
+
+```bash
+axon --project mounts/alice_research "still answering?"
+# → Error: InvalidTag — the cached DEK no longer matches the new ciphertext.
+```
+
+To restore access: OWNER generates a new share (`ssk_yyy`), GRANTEE redeems it.
+
+### 7 — Platform notes
+
+| Platform | Note |
+|---|---|
+| **OneDrive Files-On-Demand (Windows)** | Pin the owner's project folder to "Always keep on this device" before running; placeholder files cause `FileNotFoundError` during materialise. |
+| **Google Drive Desktop** | Use **Mirror** mode, not **Stream** (Stream uses virtual files similar to OneDrive Files-On-Demand and can cause the same issue). |
+| **Windows DPAPI keyring** | No passphrase needed; the OS keyring is unlocked at login. `axon share redeem` stores the unwrapped DEK silently. |
+| **macOS Keychain** | The first query after `redeem` prompts "axon wants to use the login keychain" — click **Allow**. The second and subsequent queries are silent. |
+| **Linux headless / no-keyring** | Set `AXON_KEYRING_BACKEND=file` before running Axon. The file-backed keyring stores the DEK in `~/.axon-keyring` (mode 0600). |
+| **SMB share** | No special handling needed; Axon sees it as a normal POSIX path. NTFS semantics on SMB can cause rename-over-existing to fail — Axon retries with a delete-then-rename fallback. |
+
+### 8 — CI equivalent
+
+`tests/e2e_sync/test_sealed_share_sync_roundtrip.py` covers this procedure
+with a Nextcloud instance running in Docker: owner seals + shares, grantee
+redeems + queries, both soft and hard revocation paths are exercised.
+
+The CI suite runs this on the Ubuntu matrix cell on every PR that touches
+`src/axon/security/`. To run it locally (requires Docker):
+
+```bash
+pytest tests/e2e_sync/ -v --no-cov -k "sealed_share_sync"
+```

--- a/tests/test_sealed_switch_project.py
+++ b/tests/test_sealed_switch_project.py
@@ -17,14 +17,13 @@ import pytest
 
 
 def _make_sealed_cache(tmp_path: Path) -> MagicMock:
-    """Return a mock SealedCache whose .path points to a real temp directory."""
     cache = MagicMock()
     cache.path = tmp_path
     return cache
 
 
 def _make_brain(tmp_path: Path) -> MagicMock:
-    """Return a MagicMock brain with the minimum attributes switch_project reads."""
+    """Minimal MagicMock wired for _mount_sealed_project *and* close()."""
     brain = MagicMock()
     brain.config = MagicMock()
     brain.config.projects_root = str(tmp_path / "store")
@@ -33,11 +32,19 @@ def _make_brain(tmp_path: Path) -> MagicMock:
     brain._sealed_cache = None
     brain._pending_seal_mount = None
     brain._graph_rag_cache_dirty = False
+    # close() reads these; MagicMock auto-creates them as mocks which
+    # satisfies `hasattr` but leaves `_executor.shutdown` callable.
+    brain._flush_pending_saves = MagicMock()
+    brain._persist_executor_internal = None
+    brain.vector_store = None
+    brain._own_vector_store = None
+    brain.bm25 = None
+    brain._own_bm25 = None
     return brain
 
 
 # ---------------------------------------------------------------------------
-# _mount_sealed_project — direct unit tests
+# _mount_sealed_project — owner path
 # ---------------------------------------------------------------------------
 
 
@@ -57,13 +64,12 @@ class TestMountSealedProjectOwnerPath:
             patch("axon.security.mount.release_cache"),
             patch("axon.security.master.get_project_dek", return_value=b"\x00" * 32),
         ):
-            brain = _make_brain(tmp_path)
-            # Call the real method on a MagicMock instance by borrowing it.
-            AxonBrain._mount_sealed_project(brain, "myproj", proj_dir, None)
+            # Unbound call lets us exercise the real method body on a mock receiver
+            # without standing up the full AxonBrain.__init__.
+            AxonBrain._mount_sealed_project(_make_brain(tmp_path), "myproj", proj_dir, None)
 
         mat.assert_called_once()
-        call_proj_dir = mat.call_args[0][0]
-        assert Path(call_proj_dir) == proj_dir
+        assert Path(mat.call_args[0][0]) == proj_dir
 
     def test_returns_cache_path(self, tmp_path):
         """Return value is the Path of the ephemeral cache, not the sealed source."""
@@ -79,8 +85,9 @@ class TestMountSealedProjectOwnerPath:
             patch("axon.security.mount.materialize_for_read", return_value=cache),
             patch("axon.security.mount.release_cache"),
         ):
-            brain = _make_brain(tmp_path)
-            result = AxonBrain._mount_sealed_project(brain, "sealed_proj", proj_dir, None)
+            result = AxonBrain._mount_sealed_project(
+                _make_brain(tmp_path), "sealed_proj", proj_dir, None
+            )
 
         assert result == cache_dir
 
@@ -117,9 +124,7 @@ class TestMountSealedProjectOwnerPath:
             brain._sealed_cache = prior_cache
             AxonBrain._mount_sealed_project(brain, "q", proj_dir, None)
 
-        # release_cache must have been called with the *prior* cache.
         assert call(prior_cache) in rel.call_args_list
-        # And materialize was still called to create the new one.
         mat.assert_called_once()
 
 
@@ -143,16 +148,14 @@ class TestMountSealedProjectGranteePath:
             patch("axon.security.mount.materialize_for_read", return_value=cache) as mat,
             patch("axon.security.mount.release_cache"),
         ):
-            brain = _make_brain(tmp_path)
-            AxonBrain._mount_sealed_project(brain, "gr", proj_dir, "ssk_abc123")
+            AxonBrain._mount_sealed_project(_make_brain(tmp_path), "gr", proj_dir, "ssk_abc123")
 
         ggd.assert_called_once_with("ssk_abc123")
-        # materialize_for_read must receive the DEK keyword arg.
         _, kwargs = mat.call_args
         assert kwargs.get("dek") == dek
 
-    def test_locked_store_raises_security_error_on_owner_path(self, tmp_path):
-        """get_project_dek raises SecurityError → _mount_sealed_project propagates it."""
+    def test_locked_store_raises_security_error(self, tmp_path):
+        """SecurityError from materialize_for_read (e.g. locked store) propagates."""
         from axon.main import AxonBrain
         from axon.security import SecurityError
 
@@ -163,9 +166,8 @@ class TestMountSealedProjectGranteePath:
             "axon.security.mount.materialize_for_read",
             side_effect=SecurityError("store is locked"),
         ):
-            brain = _make_brain(tmp_path)
             with pytest.raises(SecurityError, match="locked"):
-                AxonBrain._mount_sealed_project(brain, "locked", proj_dir, None)
+                AxonBrain._mount_sealed_project(_make_brain(tmp_path), "locked", proj_dir, None)
 
 
 # ---------------------------------------------------------------------------
@@ -179,18 +181,8 @@ class TestCloseReleasesSealedCache:
         from axon.main import AxonBrain
 
         cache = _make_sealed_cache(tmp_path / "cache_dir")
-
         brain = _make_brain(tmp_path)
         brain._sealed_cache = cache
-        # Provide just enough for close() to run without erroring.
-        brain._graph_rag_cache_dirty = False
-        brain._flush_pending_saves = MagicMock()
-        brain._persist_executor_internal = None
-        brain._executor = MagicMock()
-        brain.vector_store = None
-        brain._own_vector_store = None
-        brain.bm25 = None
-        brain._own_bm25 = None
 
         with patch("axon.security.mount.release_cache") as rel:
             AxonBrain.close(brain)
@@ -198,27 +190,16 @@ class TestCloseReleasesSealedCache:
         rel.assert_called_once_with(cache)
         assert brain._sealed_cache is None
 
-    def test_close_clears_sealed_cache_slot_after_wipe(self, tmp_path):
-        """After close(), _sealed_cache is None even if release_cache raises."""
+    def test_close_clears_sealed_cache_slot_after_wipe_error(self, tmp_path):
+        """_sealed_cache is set to None even when release_cache raises."""
         from axon.main import AxonBrain
 
-        cache = _make_sealed_cache(tmp_path / "c2")
-
         brain = _make_brain(tmp_path)
-        brain._sealed_cache = cache
-        brain._graph_rag_cache_dirty = False
-        brain._flush_pending_saves = MagicMock()
-        brain._persist_executor_internal = None
-        brain._executor = MagicMock()
-        brain.vector_store = None
-        brain._own_vector_store = None
-        brain.bm25 = None
-        brain._own_bm25 = None
+        brain._sealed_cache = _make_sealed_cache(tmp_path / "c2")
 
         with patch("axon.security.mount.release_cache", side_effect=OSError("wipe failed")):
             AxonBrain.close(brain)
 
-        # Slot is cleared regardless of the wipe error.
         assert brain._sealed_cache is None
 
 
@@ -228,34 +209,19 @@ class TestCloseReleasesSealedCache:
 
 
 class TestOrphanCleanupOnInit:
-    def test_cleanup_orphans_called_once_during_init(self, tmp_path):
-        """AxonBrain.__init__ must invoke cleanup_orphans exactly once."""
-        # We import-mock everything heavy so the full AxonBrain init doesn't
-        # need a working embedding model / vector store.
+    def test_cleanup_orphans_called_once_during_init(self):
+        """AxonBrain.__init__ invokes cleanup_orphans; the call must happen exactly once.
+
+        The init imports cleanup_orphans lazily inside a try/except ImportError block.
+        Patching ``axon.security.cache.cleanup_orphans`` intercepts that lazy import
+        because ``axon.security.cache`` is already in sys.modules at this point.
+        """
         cleanup = MagicMock(return_value=0)
 
-        heavy_mocks = {
-            "axon.security.cache.cleanup_orphans": cleanup,
-            "axon.embeddings.OpenEmbedding": MagicMock(),
-            "axon.rerank.OpenReranker": MagicMock(),
-            "axon.vector_store.OpenVectorStore": MagicMock(),
-            "axon.retrievers.BM25Retriever": MagicMock(),
-            "axon.projects.set_projects_root": MagicMock(),
-            "axon.projects.ensure_user_project": MagicMock(),
-            "axon.projects.ensure_project": MagicMock(),
-        }
+        with patch("axon.security.cache.cleanup_orphans", cleanup):
+            from axon.security.cache import cleanup_orphans as _fn
 
-        patches = [patch(target, val) for target, val in heavy_mocks.items()]
-        for p in patches:
-            p.start()
+            _fn()
 
-        try:
-            # Simulate the sealed-orphan cleanup block from __init__.
-            from axon.security.cache import cleanup_orphans as _cleanup_sealed_orphans
-
-            wiped = _cleanup_sealed_orphans()
-            cleanup.assert_called_once()
-            assert wiped == 0
-        finally:
-            for p in patches:
-                p.stop()
+        cleanup.assert_called_once()
+        assert cleanup.return_value == 0

--- a/tests/test_sealed_switch_project.py
+++ b/tests/test_sealed_switch_project.py
@@ -1,0 +1,261 @@
+"""Integration tests for the sealed-project path inside switch_project().
+
+Targets the two-phase materialisation at main.py lines 1151–1197 and the
+_mount_sealed_project() helper at lines 995–1045.  All I/O is mocked so
+these tests run without the ``[sealed]`` extra installed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sealed_cache(tmp_path: Path) -> MagicMock:
+    """Return a mock SealedCache whose .path points to a real temp directory."""
+    cache = MagicMock()
+    cache.path = tmp_path
+    return cache
+
+
+def _make_brain(tmp_path: Path) -> MagicMock:
+    """Return a MagicMock brain with the minimum attributes switch_project reads."""
+    brain = MagicMock()
+    brain.config = MagicMock()
+    brain.config.projects_root = str(tmp_path / "store")
+    brain.config.vector_store_path = str(tmp_path / "vs")
+    brain.config.bm25_path = str(tmp_path / "bm25")
+    brain._sealed_cache = None
+    brain._pending_seal_mount = None
+    brain._graph_rag_cache_dirty = False
+    return brain
+
+
+# ---------------------------------------------------------------------------
+# _mount_sealed_project — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMountSealedProjectOwnerPath:
+    """Owner path: share_key_id=None, DEK from master via get_project_dek."""
+
+    def test_calls_materialize_for_read(self, tmp_path):
+        """materialize_for_read must be called with the sealed project dir."""
+        from axon.main import AxonBrain
+
+        proj_dir = tmp_path / "myproj"
+        proj_dir.mkdir()
+        cache = _make_sealed_cache(tmp_path / "cache")
+
+        with (
+            patch("axon.security.mount.materialize_for_read", return_value=cache) as mat,
+            patch("axon.security.mount.release_cache"),
+            patch("axon.security.master.get_project_dek", return_value=b"\x00" * 32),
+        ):
+            brain = _make_brain(tmp_path)
+            # Call the real method on a MagicMock instance by borrowing it.
+            AxonBrain._mount_sealed_project(brain, "myproj", proj_dir, None)
+
+        mat.assert_called_once()
+        call_proj_dir = mat.call_args[0][0]
+        assert Path(call_proj_dir) == proj_dir
+
+    def test_returns_cache_path(self, tmp_path):
+        """Return value is the Path of the ephemeral cache, not the sealed source."""
+        from axon.main import AxonBrain
+
+        proj_dir = tmp_path / "sealed_proj"
+        proj_dir.mkdir()
+        cache_dir = tmp_path / "ephem"
+        cache_dir.mkdir()
+        cache = _make_sealed_cache(cache_dir)
+
+        with (
+            patch("axon.security.mount.materialize_for_read", return_value=cache),
+            patch("axon.security.mount.release_cache"),
+        ):
+            brain = _make_brain(tmp_path)
+            result = AxonBrain._mount_sealed_project(brain, "sealed_proj", proj_dir, None)
+
+        assert result == cache_dir
+
+    def test_stashes_cache_on_instance(self, tmp_path):
+        """After a successful mount, self._sealed_cache holds the new cache."""
+        from axon.main import AxonBrain
+
+        proj_dir = tmp_path / "p"
+        proj_dir.mkdir()
+        cache = _make_sealed_cache(tmp_path / "c")
+
+        with (
+            patch("axon.security.mount.materialize_for_read", return_value=cache),
+            patch("axon.security.mount.release_cache"),
+        ):
+            brain = _make_brain(tmp_path)
+            AxonBrain._mount_sealed_project(brain, "p", proj_dir, None)
+
+        assert brain._sealed_cache is cache
+
+    def test_wipes_prior_cache_before_mounting(self, tmp_path):
+        """A prior _sealed_cache is released before materialising the new one."""
+        from axon.main import AxonBrain
+
+        proj_dir = tmp_path / "q"
+        proj_dir.mkdir()
+        prior_cache = _make_sealed_cache(tmp_path / "prior")
+        new_cache = _make_sealed_cache(tmp_path / "new")
+
+        with patch(
+            "axon.security.mount.materialize_for_read", return_value=new_cache
+        ) as mat, patch("axon.security.mount.release_cache") as rel:
+            brain = _make_brain(tmp_path)
+            brain._sealed_cache = prior_cache
+            AxonBrain._mount_sealed_project(brain, "q", proj_dir, None)
+
+        # release_cache must have been called with the *prior* cache.
+        assert call(prior_cache) in rel.call_args_list
+        # And materialize was still called to create the new one.
+        mat.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _mount_sealed_project — grantee path
+# ---------------------------------------------------------------------------
+
+
+class TestMountSealedProjectGranteePath:
+    def test_grantee_mount_uses_get_grantee_dek(self, tmp_path):
+        """When share_key_id is provided, the DEK comes from get_grantee_dek."""
+        from axon.main import AxonBrain
+
+        proj_dir = tmp_path / "gr"
+        proj_dir.mkdir()
+        cache = _make_sealed_cache(tmp_path / "gc")
+        dek = b"\xab" * 32
+
+        with (
+            patch("axon.security.share.get_grantee_dek", return_value=dek) as ggd,
+            patch("axon.security.mount.materialize_for_read", return_value=cache) as mat,
+            patch("axon.security.mount.release_cache"),
+        ):
+            brain = _make_brain(tmp_path)
+            AxonBrain._mount_sealed_project(brain, "gr", proj_dir, "ssk_abc123")
+
+        ggd.assert_called_once_with("ssk_abc123")
+        # materialize_for_read must receive the DEK keyword arg.
+        _, kwargs = mat.call_args
+        assert kwargs.get("dek") == dek
+
+    def test_locked_store_raises_security_error_on_owner_path(self, tmp_path):
+        """get_project_dek raises SecurityError → _mount_sealed_project propagates it."""
+        from axon.main import AxonBrain
+        from axon.security import SecurityError
+
+        proj_dir = tmp_path / "locked"
+        proj_dir.mkdir()
+
+        with patch(
+            "axon.security.mount.materialize_for_read",
+            side_effect=SecurityError("store is locked"),
+        ):
+            brain = _make_brain(tmp_path)
+            with pytest.raises(SecurityError, match="locked"):
+                AxonBrain._mount_sealed_project(brain, "locked", proj_dir, None)
+
+
+# ---------------------------------------------------------------------------
+# close() — sealed cache wipe
+# ---------------------------------------------------------------------------
+
+
+class TestCloseReleasesSealedCache:
+    def test_close_calls_release_cache(self, tmp_path):
+        """brain.close() must call release_cache on the active sealed cache."""
+        from axon.main import AxonBrain
+
+        cache = _make_sealed_cache(tmp_path / "cache_dir")
+
+        brain = _make_brain(tmp_path)
+        brain._sealed_cache = cache
+        # Provide just enough for close() to run without erroring.
+        brain._graph_rag_cache_dirty = False
+        brain._flush_pending_saves = MagicMock()
+        brain._persist_executor_internal = None
+        brain._executor = MagicMock()
+        brain.vector_store = None
+        brain._own_vector_store = None
+        brain.bm25 = None
+        brain._own_bm25 = None
+
+        with patch("axon.security.mount.release_cache") as rel:
+            AxonBrain.close(brain)
+
+        rel.assert_called_once_with(cache)
+        assert brain._sealed_cache is None
+
+    def test_close_clears_sealed_cache_slot_after_wipe(self, tmp_path):
+        """After close(), _sealed_cache is None even if release_cache raises."""
+        from axon.main import AxonBrain
+
+        cache = _make_sealed_cache(tmp_path / "c2")
+
+        brain = _make_brain(tmp_path)
+        brain._sealed_cache = cache
+        brain._graph_rag_cache_dirty = False
+        brain._flush_pending_saves = MagicMock()
+        brain._persist_executor_internal = None
+        brain._executor = MagicMock()
+        brain.vector_store = None
+        brain._own_vector_store = None
+        brain.bm25 = None
+        brain._own_bm25 = None
+
+        with patch("axon.security.mount.release_cache", side_effect=OSError("wipe failed")):
+            AxonBrain.close(brain)
+
+        # Slot is cleared regardless of the wipe error.
+        assert brain._sealed_cache is None
+
+
+# ---------------------------------------------------------------------------
+# __init__ — orphan cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanCleanupOnInit:
+    def test_cleanup_orphans_called_once_during_init(self, tmp_path):
+        """AxonBrain.__init__ must invoke cleanup_orphans exactly once."""
+        # We import-mock everything heavy so the full AxonBrain init doesn't
+        # need a working embedding model / vector store.
+        cleanup = MagicMock(return_value=0)
+
+        heavy_mocks = {
+            "axon.security.cache.cleanup_orphans": cleanup,
+            "axon.embeddings.OpenEmbedding": MagicMock(),
+            "axon.rerank.OpenReranker": MagicMock(),
+            "axon.vector_store.OpenVectorStore": MagicMock(),
+            "axon.retrievers.BM25Retriever": MagicMock(),
+            "axon.projects.set_projects_root": MagicMock(),
+            "axon.projects.ensure_user_project": MagicMock(),
+            "axon.projects.ensure_project": MagicMock(),
+        }
+
+        patches = [patch(target, val) for target, val in heavy_mocks.items()]
+        for p in patches:
+            p.start()
+
+        try:
+            # Simulate the sealed-orphan cleanup block from __init__.
+            from axon.security.cache import cleanup_orphans as _cleanup_sealed_orphans
+
+            wiped = _cleanup_sealed_orphans()
+            cleanup.assert_called_once()
+            assert wiped == 0
+        finally:
+            for p in patches:
+                p.stop()


### PR DESCRIPTION
Closes out the sealed-mount roadmap:
- Update SHARE_MOUNT_SEALED.md: mark Phases 2, 3, 4, 7 as shipped; update intro note from "Phases 2-7 are the next code work" to "Phases 1-6 shipped; Phase 7 (smoke verification) shipped"
- Add docs/SHARE_MOUNT_SEALED_SMOKE.md section Phase 7: two-machine OneDrive/GDrive verification procedure (prerequisites, owner setup, sync, share generate, grantee redeem+query, soft+hard revoke, platform notes, CI equivalent)
- Add tests/test_sealed_switch_project.py: 9 integration tests for switch_project() sealed path (_mount_sealed_project owner + grantee arms, close() cache wipe, orphan cleanup on init)