### PR TITLE
docs: add SPLADE sparse retrieval + HTTP 429/413 error entries

### DIFF
--- a/docs/ADMIN_REFERENCE.md
+++ b/docs/ADMIN_REFERENCE.md
@@ -309,7 +309,7 @@ axon> Compare @report.pdf with @notes.docx
 
 ## 4. REST API Reference
 
-**67 endpoints** across 9 route files. Base URL: `http://localhost:8000` (default).
+**68 endpoints** across 12 route files. Base URL: `http://localhost:8000` (default).
 
 Interactive docs: `/docs` (Swagger UI), `/redoc`.
 
@@ -317,7 +317,11 @@ Interactive docs: `/docs` (Swagger UI), `/redoc`.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/health` | Liveness probe — returns `{"status": "ok", "project": "<active-project>"}` |
+| `GET` | `/health/live` | Liveness probe — always returns `{"status": "alive"}` with `200` while the process is running; does not check brain state |
+| `GET` | `/health/ready` | Readiness probe — returns `{"status": "ok", "project": "<active-project>"}` with `200` when ready; returns `{"status": "initializing"}` with `503` during cold start |
+| `GET` | `/health` | Backward-compatible alias for `/health/ready` |
+
+> **Kubernetes:** use `livenessProbe → /health/live` and `readinessProbe → /health/ready`.
 
 ### 4.2 Query & Search
 
@@ -463,6 +467,18 @@ Always check `/registry/leases` before transitioning to `readonly`. Wait for `ac
 | `POST` | `/llm/copilot/result/{task_id}` | Report Copilot LLM task result |
 
 These endpoints are used internally by the VS Code extension. External callers should use `/query` instead.
+
+### 4.10 Metrics
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/metrics` | Prometheus exposition format metrics (`text/plain; version=0.0.4`); returns `503` if `prometheus-client` is not installed |
+
+Exposed metrics: `axon_requests_total` (Counter, labels: `path/method/status`), `axon_request_duration_seconds` (Histogram, labels: `path/method`), `axon_query_total` (Counter, labels: `project/surface`), `axon_ingest_total` (Counter, labels: `project/surface`), `axon_brain_ready` (Gauge — `1` when brain is initialised).
+
+> **Rate limiting:** `/share`, `/ingest`, and `/security` endpoints enforce per-IP rate limiting (default: 10 requests per 60-second window). Requests exceeding the limit receive HTTP `429 Too Many Requests`.
+
+> **Request ID tracking:** every API response includes an `X-Request-ID` header. Governance write routes also emit this value into the audit trail for end-to-end log correlation.
 
 ---
 
@@ -649,6 +665,9 @@ YAML section: `rag:`
 | `rag.hybrid_search` | bool | `true` | Combine vector + BM25 sparse retrieval |
 | `rag.hybrid_weight` | float | `0.7` | Hybrid fusion weight (`1.0` = pure vector, `0.0` = pure BM25; only used in `weighted` mode) |
 | `rag.hybrid_mode` | str | `rrf` | Hybrid fusion mode: `rrf` (Reciprocal Rank Fusion, default) or `weighted` |
+| `rag.sparse_retrieval` | bool | `false` | Enable SPLADE learned sparse retrieval alongside dense+BM25 (requires `pip install 'axon-rag[sparse]'`) |
+| `rag.sparse_model` | str | `naver/splade-cocondenser-ensembledistil` | HuggingFace model ID for the SPLADE sparse encoder |
+| `rag.sparse_weight` | float | `0.3` | Weight applied to sparse scores during hybrid fusion (`0.0`–`1.0`); values outside this range are rejected at startup |
 | `rag.rerank` | bool | `false` | BGE cross-encoder reranker |
 | `rag.rerank_top_k` | int | `5` | Max results to return after re-ranking |
 | `rag.sentence_window` | bool | `false` | Expand retrieved chunks with surrounding sentences |
@@ -797,6 +816,8 @@ YAML section: `offline:`
 |-------|------|---------|-------------|
 | `api.key` | str | `""` | Bearer token required for write endpoints |
 | `api.allow_origins` | list | `[]` | CORS allowed origins (e.g. `["http://localhost:3000"]`) |
+| `api.max_upload_bytes` | int | `524288000` | Maximum file size per `/ingest/upload` multipart upload in bytes (default 500 MiB); requests exceeding this receive HTTP `413` |
+| `api.max_files_per_request` | int | `1000` | Maximum files per `/ingest/upload` batch request; requests exceeding this receive HTTP `422` |
 
 Environment variables for the API server:
 

--- a/docs/ADVANCED_RAG.md
+++ b/docs/ADVANCED_RAG.md
@@ -180,7 +180,57 @@ response includes a `diagnostics` object containing `confidence`, `fallback_trig
 
 ---
 
-## 10. RAPTOR — Hierarchical Clustering Summaries
+## 10. Sparse Retrieval (SPLADE)
+
+**Config:** `retrieval.sparse_retrieval: true`
+
+SPLADE (SParse Lexical AnD Expansion) is a learned sparse neural retrieval method that
+complements the existing dense (embedding) + BM25 hybrid by capturing exact lexical matches
+that dense vectors can miss. Where a dense vector summarises meaning holistically, SPLADE
+produces a high-dimensional sparse vector over the full vocabulary — each non-zero dimension
+corresponds to a vocabulary token weighted by its relevance to the passage. Queries and
+documents are matched by dot product over these sparse vectors.
+
+**When to use:** Queries that use domain-specific terminology, product names, acronyms, or
+rare tokens that embeddings may not capture reliably. Technical and code-heavy corpora
+where exact token overlap is a strong relevance signal.
+
+**How to enable (`config.yaml`):**
+```yaml
+retrieval:
+  sparse_retrieval: true
+  sparse_model: "naver/splade-cocondenser-ensembledistil"  # default
+  sparse_weight: 0.3  # weight in score fusion (0.0–1.0)
+```
+
+`sparse_weight` controls the blend between dense and sparse scores during fusion.
+A value of `0.3` means 30% sparse, 70% dense. Increase toward `0.5` if exact-term
+precision matters more; decrease toward `0.1` for general prose corpora.
+
+**Requirements:**
+
+```bash
+pip install "axon-rag[sparse]"
+```
+
+This installs `transformers>=4.40` and `torch>=2.0`. `torch` is unpinned so your
+environment can select the correct CPU, CUDA, or ROCm wheel.
+
+**Performance note:** The first query (or the first `add` call at ingest time) loads the
+SPLADE checkpoint from HuggingFace Hub into memory — approximately 500 MB. Subsequent
+queries are fast. The model is cached in the default HuggingFace Hub location
+(`~/.cache/huggingface/hub`). If `transformers` or `torch` are not installed, Axon logs
+a warning and the pipeline falls back to dense + BM25 without raising an error.
+
+**Accuracy note:** SPLADE provides the most benefit on technical or code corpora where
+queries contain specific tokens (model names, API identifiers, error codes). The marginal
+benefit on general prose is smaller because dense embeddings already capture paraphrasing
+and synonymy well. Profile A and B configurations (see §13) do not need sparse retrieval;
+it is worth adding when exact-term recall is demonstrably low.
+
+---
+
+## 11. RAPTOR — Hierarchical Clustering Summaries
 
 **Flag:** `raptor: true` (also set at ingest time)
 **CLI:** `axon --raptor --ingest ./docs/`
@@ -207,7 +257,7 @@ Query time cost is negligible.
 
 ---
 
-## 11. GraphRAG — Entity Graph with Community Summaries
+## 12. GraphRAG — Entity Graph with Community Summaries
 
 **Flag:** `graph_rag: true` (also set at ingest time)
 **CLI:** `axon --graph-rag "your query"`
@@ -258,7 +308,7 @@ low (graph lookup + community snippet injection).
 
 ---
 
-## 12. Recommended Configurations
+## 13. Recommended Configurations
 
 ### Profile A — Default (fastest, no graph overhead)
 
@@ -372,7 +422,7 @@ where answer quality is paramount over latency.*
 
 ---
 
-## 13. Smart Query Routing
+## 14. Smart Query Routing
 
 **Config:** `query_router: heuristic` (default) or `query_router: llm`
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -13,7 +13,31 @@ For interactive exploration, open `http://localhost:8000/docs` (Swagger UI) or
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/health` | Returns `{"status": "ok", "project": "<active-project>"}` — use for liveness probes; returns `503` while the brain is initialising |
+| `GET` | `/health/live` | Liveness probe — returns `{"status": "alive"}` with `200` as long as the ASGI process is responding; does **not** check whether the brain is initialised |
+| `GET` | `/health/ready` | Readiness probe — returns `{"status": "ok", "project": "<active-project>"}` with `200` only when the brain is fully initialised; returns `{"status": "initializing"}` with `503` during cold start |
+| `GET` | `/health` | Backward-compatible alias for `/health/ready` — returns the same payload; preserved so existing uptime checkers and VS Code extension probes continue to work |
+
+> **Kubernetes usage:** point `livenessProbe` at `/health/live` (restart only on a fully wedged process) and `readinessProbe` at `/health/ready` (hold traffic until the brain and vector store are ready).
+
+---
+
+## Metrics
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/metrics` | Prometheus exposition format metrics (`text/plain; version=0.0.4`) — returns `503` with a plain message if `prometheus-client` is not installed |
+
+**Exposed metrics:**
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `axon_requests_total` | Counter | `path`, `method`, `status` | Total HTTP requests handled; lets operators alert on 5xx spikes per route |
+| `axon_request_duration_seconds` | Histogram | `path`, `method` | Wall-clock request latency; enables p50/p95 dashboards |
+| `axon_query_total` | Counter | `project`, `surface` | Total RAG queries; tracks volume per project and calling surface (`api`, `mcp`, `repl`, etc.) |
+| `axon_ingest_total` | Counter | `project`, `surface` | Total ingest requests per project and surface |
+| `axon_brain_ready` | Gauge | — | `1` when `axon.api.brain` is initialised, `0` otherwise; refreshed on every scrape |
+
+`prometheus-client` ships in the base `axon-rag` dependency set (`>=0.20`), so the `503` fallback is not expected under normal install conditions.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -56,7 +56,7 @@ Axon/
 ├── src/axon/          # Main package
 │   ├── main.py             # Core RAG engine
 │   ├── api.py              # FastAPI app factory and route registration
-│   ├── api_routes/         # Route handlers (54 endpoints across 8 files)
+│   ├── api_routes/         # Route handlers (68 endpoints across 12 files)
 │   ├── webapp.py           # Streamlit UI
 │   ├── loaders.py          # Document loaders
 │   ├── retrievers.py       # Search implementations

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -274,6 +274,76 @@ llm:
 
 ---
 
+## API: HTTP 429 Too Many Requests
+
+**Error:**
+```
+Error: HTTP 429 Too Many Requests
+{"detail": "Rate limit exceeded. Retry after 60s."}
+```
+
+**Cause:** Per-IP rate limiting is enforced on `/share/*`, `/ingest/*`, and `/security/*`
+endpoints. The default limit is 10 requests per 60-second window. Bulk operations that
+send many requests in a short period will trigger this limit.
+
+**Fix:**
+- Wait 60 seconds before retrying.
+- For bulk ingest operations, use the batched ingest endpoint to send multiple files in a
+  single request rather than one request per file.
+- To raise the default limits for trusted environments, increase them in `config.yaml`:
+  ```yaml
+  api:
+    rate_limit_requests: 50      # requests per window (default: 10)
+    rate_limit_window_seconds: 60
+  ```
+
+---
+
+## API: HTTP 413 Request Entity Too Large
+
+**Error:**
+```
+Error: HTTP 413 Request Entity Too Large
+{"detail": "Upload exceeds maximum size of 500 MiB"}
+```
+
+**Cause:** The uploaded file or batch exceeds `max_upload_bytes` (default 500 MiB) or
+`max_files_per_request` (default 1000 files). Both limits were added to harden the ingest
+API against oversized payloads.
+
+**Fix:**
+- Split large batches into smaller ones below the 500 MiB threshold.
+- To raise the limits for trusted environments, adjust them in `config.yaml`:
+  ```yaml
+  api:
+    max_upload_bytes: 1073741824   # 1 GiB
+    max_files_per_request: 5000
+  ```
+
+---
+
+## API: HTTP 422 Unprocessable Entity on Long Queries
+
+**Error:**
+```
+Error: HTTP 422 Unprocessable Entity
+{"detail": [{"loc": ["body", "query"], "msg": "ensure this value has at most 4096 characters"}]}
+```
+
+**Cause:** The query text exceeds the `max_length` field validation added to the request
+schema. This prevents excessively long strings from being passed through the pipeline.
+
+**Fix:**
+- Shorten the query to under 4096 characters, or rephrase it as a more focused question.
+- For programmatic use cases that genuinely need longer input, increase the field limit
+  in `config.yaml`:
+  ```yaml
+  api:
+    max_query_length: 8192   # characters (default: 4096)
+  ```
+
+---
+
 ## `pip install axon[graphrag]` fails with `gensim` build error
 
 **Error:**


### PR DESCRIPTION
- ADVANCED_RAG.md: new Sparse Retrieval (SPLADE) section with config, requirements, performance notes
- TROUBLESHOOTING.md: add HTTP 429 rate-limit and HTTP 413 upload-size error entries