### PR TITLE
feat(sealed): grantee DEK file fallback for headless Linux

### DIFF
--- a/src/axon/security/share.py
+++ b/src/axon/security/share.py
@@ -74,7 +74,7 @@ import re as _re
 
 from . import SecurityError
 from . import keyring as _kr
-from .crypto import DEK_LEN
+from .crypto import DEK_LEN, unwrap_key, wrap_key
 from .master import get_master_key, get_project_dek
 from .seal import is_project_sealed
 
@@ -252,6 +252,64 @@ def _resolve_owned_project_dir(project_name: str, user_dir: Path) -> Path:
 def _share_keyring_service(key_id: str) -> str:
     """Per-share keyring service name for the grantee's unwrapped DEK."""
     return f"{SHARE_KEYRING_PREFIX}.{key_id}"
+
+
+# ---------------------------------------------------------------------------
+# Grantee DEK file fallback helpers (headless Linux / Docker / CI)
+# ---------------------------------------------------------------------------
+
+
+def _grantee_dek_fallback_path(user_dir: Path, key_id: str) -> Path:
+    """``<user_dir>/.security/shares/<key_id>.dek.wrapped`` — per-share fallback."""
+    return Path(user_dir) / ".security" / "shares" / f"{key_id}.dek.wrapped"
+
+
+def _write_grantee_dek_fallback(user_dir: Path, key_id: str, dek: bytes) -> None:
+    """Wrap *dek* under the grantee's master key and persist to file atomically.
+
+    Mirrors the pattern used for project DEKs in ``master.py``:
+    ``<project>/.security/dek.wrapped`` (40-byte AES-KW output).  The
+    grantee must have their store unlocked (``axon --store-unlock``) before
+    this is called, because :func:`get_master_key` will raise
+    ``SecurityError`` otherwise.
+    """
+    master = get_master_key(user_dir)
+    wrapped = wrap_key(dek, master)
+    path = _grantee_dek_fallback_path(user_dir, key_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(wrapped)
+        tmp.replace(path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    try:
+        import os as _os
+
+        _os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _read_grantee_dek_fallback(user_dir: Path, key_id: str) -> bytes | None:
+    """Unwrap the DEK from the file fallback using the grantee's master key.
+
+    Returns ``None`` when the fallback file does not exist (analogous to
+    :func:`axon.security.keyring.get_secret` returning None).  Raises
+    :class:`SecurityError` when the file exists but can't be decrypted.
+    """
+    path = _grantee_dek_fallback_path(user_dir, key_id)
+    if not path.is_file():
+        return None
+    master = get_master_key(user_dir)
+    try:
+        return unwrap_key(path.read_bytes(), master)
+    except Exception as exc:
+        raise SecurityError(f"Grantee DEK fallback file is unreadable: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -473,12 +531,35 @@ def redeem_sealed_share(
     service = _share_keyring_service(key_id)
     try:
         _kr.store_secret(service, "dek", base64.b64encode(dek).decode("ascii"))
-    except _kr.KeyringUnavailableError as exc:
-        raise SecurityError(
-            f"Cannot persist sealed-share DEK to OS keyring: {exc}. "
-            "On a headless Linux server, install gnome-keyring or use "
-            "the passphrase fallback (Phase 6)."
-        ) from exc
+    except _kr.KeyringUnavailableError:
+        # Keyring unavailable (headless Linux / Docker / CI) — fall back to
+        # a file wrapped under the grantee's own master key, mirroring the
+        # master.enc dual-write pattern in master.py.
+        try:
+            _write_grantee_dek_fallback(grantee_user_dir, key_id, dek)
+            logger.info(
+                "Grantee DEK for %s persisted to file fallback (keyring unavailable)",
+                key_id,
+            )
+        except SecurityError:
+            raise  # store not bootstrapped or locked — surface as-is
+        except OSError as exc:
+            raise SecurityError(
+                f"Cannot persist grantee DEK for {key_id}: keyring unavailable and "
+                f"file fallback failed: {exc}"
+            ) from exc
+    else:
+        # Keyring is available — also write the file fallback so the DEK
+        # survives a cross-platform copy (mirrors the master.enc dual-write).
+        try:
+            _write_grantee_dek_fallback(grantee_user_dir, key_id, dek)
+        except Exception as _fb_exc:
+            # File fallback is best-effort when keyring is available;
+            # a failure here should not abort a successful keyring write.
+            logger.debug(
+                "Grantee DEK file fallback write failed (keyring write succeeded): %s",
+                _fb_exc,
+            )
     # Build the mount descriptor — same path format as the legacy
     # share path so the rest of the brain doesn't need a special case
     # at list-mounts / list-projects time.
@@ -567,21 +648,50 @@ def _create_sealed_mount_descriptor(
 # ---------------------------------------------------------------------------
 
 
-def get_grantee_dek(key_id: str) -> bytes:
-    """Fetch the grantee's cached DEK for *key_id* from the OS keyring.
+def get_grantee_dek(key_id: str, user_dir: Path | None = None) -> bytes:
+    """Fetch the grantee's cached DEK for *key_id*.
+
+    Resolution order:
+    1. OS keyring (``axon.share.<key_id>`` / ``dek``).
+    2. File fallback at ``<user_dir>/.security/shares/<key_id>.dek.wrapped``
+       (used when keyring is unavailable — headless Linux / Docker / CI).
+
+    Args:
+        key_id: Share key identifier.
+        user_dir: Grantee's AxonStore user directory.  Required when the
+            keyring is unavailable (supplies the master key path for the
+            file fallback).  If ``None`` and the keyring is unavailable,
+            a :class:`SecurityError` is raised with a clear message.
+
     Raises:
-        SecurityError: keyring unavailable, no DEK stored under
-            ``axon.share.<key_id>`` (grantee never redeemed), or the
-            stored value is malformed base64.
+        SecurityError: keyring unavailable and *user_dir* not given (or
+            file fallback also absent), no DEK stored for *key_id*, or
+            the stored value is malformed.
     """
     _validate_key_id(key_id)
     service = _share_keyring_service(key_id)
     try:
         secret = _kr.get_secret(service, "dek")
-    except _kr.KeyringUnavailableError as exc:
-        raise SecurityError(
-            f"OS keyring unavailable; cannot fetch sealed-share DEK for " f"{key_id}: {exc}"
-        ) from exc
+    except _kr.KeyringUnavailableError:
+        # Keyring unavailable — try the file fallback.
+        if user_dir is None:
+            raise SecurityError(
+                f"OS keyring unavailable; cannot fetch sealed-share DEK for "
+                f"{key_id}. Pass user_dir to use the file fallback."
+            )
+        dek = _read_grantee_dek_fallback(Path(user_dir), key_id)
+        if dek is None:
+            raise SecurityError(
+                f"Share DEK for {key_id!r} not found in keyring or file fallback. "
+                "Redeem the share again, or ensure the grantee store is bootstrapped "
+                "and unlocked (axon --store-unlock) before querying."
+            )
+        if len(dek) != DEK_LEN:
+            raise SecurityError(
+                f"Grantee DEK fallback for {key_id} is {len(dek)} bytes "
+                f"(expected {DEK_LEN}); file may be corrupted."
+            )
+        return dek
     if secret is None:
         raise SecurityError(
             f"No sealed-share DEK in keyring for {key_id}. "
@@ -1195,23 +1305,38 @@ def _hard_revoke(
     }
 
 
-def delete_grantee_dek(key_id: str) -> bool:
+def delete_grantee_dek(key_id: str, user_dir: Path | None = None) -> bool:
     """Remove the grantee's cached DEK for *key_id*; True iff one was present.
+
+    Deletes both the OS keyring entry and the file fallback (if present) so
+    cleanup is complete regardless of how the DEK was originally persisted.
+
     Used by Phase 4 revocation cleanup. Best-effort — a missing
     entry returns False without raising, so callers can use this as
     an idempotent cleanup hook. The keyring layer itself silently
     no-ops on missing-key delete, so we have to probe first to
     distinguish "deleted something" from "nothing was there".
+
+    Args:
+        key_id: Share key identifier.
+        user_dir: Grantee's AxonStore user directory.  When provided, the
+            file fallback at ``<user_dir>/.security/shares/<key_id>.dek.wrapped``
+            is also deleted (best-effort).
     """
     if not key_id:
         return False
     service = _share_keyring_service(key_id)
+    had_secret = False
     try:
         had_secret = _kr.get_secret(service, "dek") is not None
-        if not had_secret:
-            return False
-        _kr.delete_secret(service, "dek")
-        return True
+        if had_secret:
+            _kr.delete_secret(service, "dek")
     except Exception as exc:
-        logger.debug("delete_grantee_dek(%s) failed: %s", key_id, exc)
-        return False
+        logger.debug("delete_grantee_dek(%s) keyring op failed: %s", key_id, exc)
+    # Also clean up the file fallback, regardless of keyring availability.
+    had_file = False
+    if user_dir is not None:
+        fb_path = _grantee_dek_fallback_path(Path(user_dir), key_id)
+        had_file = fb_path.is_file()
+        fb_path.unlink(missing_ok=True)
+    return had_secret or had_file

--- a/tests/test_grantee_dek_fallback.py
+++ b/tests/test_grantee_dek_fallback.py
@@ -1,0 +1,323 @@
+"""Grantee DEK file fallback for headless Linux / Docker / CI.
+
+Verifies that ``axon.security.share`` falls back to a file at
+``<user_dir>/.security/shares/<key_id>.dek.wrapped`` when the OS keyring
+is unavailable, mirroring the master.enc dual-write pattern.
+
+Skips when the ``cryptography`` / ``keyring`` packages aren't installed.
+"""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("cryptography")
+pytest.importorskip("keyring")
+
+from axon.security import SecurityError  # noqa: E402
+from axon.security import keyring as _kr  # noqa: E402
+from axon.security.share import (  # noqa: E402
+    _grantee_dek_fallback_path,
+    _read_grantee_dek_fallback,
+    _write_grantee_dek_fallback,
+    delete_grantee_dek,
+    get_grantee_dek,
+    redeem_sealed_share,
+)
+
+# ---------------------------------------------------------------------------
+# Constants / helpers
+# ---------------------------------------------------------------------------
+
+_TEST_MASTER = b"\xab" * 32  # 32-byte fake master key
+_TEST_DEK = b"\xcd" * 32  # 32-byte fake DEK
+_KEY_ID = "testkey01"
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user_dir(tmp_path):
+    ud = tmp_path / "bob"
+    ud.mkdir()
+    return ud
+
+
+@pytest.fixture
+def kr_unavailable():
+    """Patch keyring so every call raises KeyringUnavailableError."""
+
+    def _raise(*args, **kwargs):
+        raise _kr.KeyringUnavailableError("no keyring backend (headless test)")
+
+    with (
+        patch.object(_kr, "store_secret", side_effect=_raise),
+        patch.object(_kr, "get_secret", side_effect=_raise),
+        patch.object(_kr, "delete_secret", side_effect=_raise),
+        patch.object(_kr, "is_available", return_value=False),
+    ):
+        yield
+
+
+@pytest.fixture
+def master_unlocked(user_dir):
+    """Patch get_master_key to return _TEST_MASTER without a real store."""
+    with patch("axon.security.share.get_master_key", return_value=_TEST_MASTER):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the private helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackPathHelper:
+    def test_path_format(self, user_dir):
+        p = _grantee_dek_fallback_path(user_dir, _KEY_ID)
+        assert p.parent.name == "shares"
+        assert p.parent.parent.name == ".security"
+        assert p.name == f"{_KEY_ID}.dek.wrapped"
+
+
+class TestWriteAndReadFallback:
+    def test_write_then_read_roundtrip(self, user_dir, master_unlocked):
+        _write_grantee_dek_fallback(user_dir, _KEY_ID, _TEST_DEK)
+        recovered = _read_grantee_dek_fallback(user_dir, _KEY_ID)
+        assert recovered == _TEST_DEK
+
+    def test_read_returns_none_when_absent(self, user_dir, master_unlocked):
+        assert _read_grantee_dek_fallback(user_dir, _KEY_ID) is None
+
+    def test_write_creates_parent_dirs(self, user_dir, master_unlocked):
+        _write_grantee_dek_fallback(user_dir, _KEY_ID, _TEST_DEK)
+        assert _grantee_dek_fallback_path(user_dir, _KEY_ID).is_file()
+
+    def test_write_is_atomic_via_tmp(self, user_dir, master_unlocked):
+        """Verifies that a .tmp file is not left behind after a write."""
+        _write_grantee_dek_fallback(user_dir, _KEY_ID, _TEST_DEK)
+        path = _grantee_dek_fallback_path(user_dir, _KEY_ID)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        assert not tmp.exists()
+
+    def test_read_raises_security_error_on_corrupt_file(self, user_dir, master_unlocked):
+        path = _grantee_dek_fallback_path(user_dir, _KEY_ID)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"not-valid-aes-kw-data")
+        with pytest.raises(SecurityError, match="unreadable"):
+            _read_grantee_dek_fallback(user_dir, _KEY_ID)
+
+    def test_store_locked_raises_security_error(self, user_dir):
+        """If get_master_key raises (store locked), write should surface it."""
+        with patch("axon.security.share.get_master_key", side_effect=SecurityError("locked")):
+            with pytest.raises(SecurityError, match="locked"):
+                _write_grantee_dek_fallback(user_dir, _KEY_ID, _TEST_DEK)
+
+
+# ---------------------------------------------------------------------------
+# get_grantee_dek: file fallback path
+# ---------------------------------------------------------------------------
+
+
+class TestGetGranteeDek:
+    def test_returns_dek_from_file_when_keyring_absent(
+        self, user_dir, kr_unavailable, master_unlocked
+    ):
+        _write_grantee_dek_fallback(user_dir, _KEY_ID, _TEST_DEK)
+        dek = get_grantee_dek(_KEY_ID, user_dir=user_dir)
+        assert dek == _TEST_DEK
+
+    def test_raises_if_keyring_absent_and_no_user_dir(self, kr_unavailable):
+        with pytest.raises(SecurityError, match="Pass user_dir"):
+            get_grantee_dek(_KEY_ID)
+
+    def test_raises_if_keyring_absent_and_file_missing(
+        self, user_dir, kr_unavailable, master_unlocked
+    ):
+        with pytest.raises(SecurityError, match="not found in keyring or file fallback"):
+            get_grantee_dek(_KEY_ID, user_dir=user_dir)
+
+    def test_returns_dek_from_keyring_when_available(self, user_dir):
+        """Keyring path is unaffected — returns base64-decoded secret."""
+        encoded = _b64(_TEST_DEK)
+        with patch.object(_kr, "get_secret", return_value=encoded):
+            dek = get_grantee_dek(_KEY_ID, user_dir=user_dir)
+        assert dek == _TEST_DEK
+
+    def test_raises_on_missing_keyring_entry(self, user_dir):
+        with patch.object(_kr, "get_secret", return_value=None):
+            with pytest.raises(SecurityError, match="No sealed-share DEK"):
+                get_grantee_dek(_KEY_ID, user_dir=user_dir)
+
+
+# ---------------------------------------------------------------------------
+# delete_grantee_dek: file cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteGranteeDek:
+    def test_delete_removes_fallback_file(self, user_dir, master_unlocked):
+        _write_grantee_dek_fallback(user_dir, _KEY_ID, _TEST_DEK)
+        path = _grantee_dek_fallback_path(user_dir, _KEY_ID)
+        assert path.is_file()
+        with patch.object(_kr, "get_secret", return_value=None):
+            result = delete_grantee_dek(_KEY_ID, user_dir=user_dir)
+        assert result is True
+        assert not path.is_file()
+
+    def test_delete_returns_false_when_nothing_present(self, user_dir):
+        with patch.object(_kr, "get_secret", return_value=None):
+            result = delete_grantee_dek(_KEY_ID, user_dir=user_dir)
+        assert result is False
+
+    def test_delete_without_user_dir_does_not_raise(self):
+        """Caller may omit user_dir; keyring-only cleanup should still work."""
+        with patch.object(_kr, "get_secret", return_value=_b64(_TEST_DEK)):
+            with patch.object(_kr, "delete_secret"):
+                result = delete_grantee_dek(_KEY_ID)
+        assert result is True
+
+    def test_delete_cleans_file_even_when_keyring_unavailable(
+        self, user_dir, kr_unavailable, master_unlocked
+    ):
+        _write_grantee_dek_fallback(user_dir, _KEY_ID, _TEST_DEK)
+        path = _grantee_dek_fallback_path(user_dir, _KEY_ID)
+        assert path.is_file()
+        result = delete_grantee_dek(_KEY_ID, user_dir=user_dir)
+        assert result is True
+        assert not path.is_file()
+
+
+# ---------------------------------------------------------------------------
+# redeem_sealed_share: file fallback integration
+# ---------------------------------------------------------------------------
+
+
+def _make_share_string(
+    owner_user_dir: Path,
+    project_dir: Path,
+    key_id: str,
+) -> str:
+    """Build a minimal sealed share_string pointing at a pre-created wrap file."""
+    import secrets as _secrets
+
+    from cryptography.hazmat.primitives.keywrap import aes_key_wrap
+
+    from axon.security.share import (
+        SEALED_SHARE_PREFIX,
+        _derive_share_kek,
+    )
+
+    token_bytes = _secrets.token_bytes(32)
+    kek = _derive_share_kek(token_bytes, key_id)
+    wrapped_dek = aes_key_wrap(kek, _TEST_DEK)
+    wrap_path = project_dir / ".security" / "shares" / f"{key_id}.wrapped"
+    wrap_path.parent.mkdir(parents=True, exist_ok=True)
+    wrap_path.write_bytes(wrapped_dek)
+
+    owner_name = owner_user_dir.name
+    owner_store_path = str(owner_user_dir.parent)
+    raw = f"{SEALED_SHARE_PREFIX}:{key_id}:{token_bytes.hex()}:{owner_name}:myproject:{owner_store_path}"
+    return base64.urlsafe_b64encode(raw.encode()).decode("ascii")
+
+
+class TestRedeemWritesFallback:
+    def test_redeem_writes_dek_to_file_when_keyring_unavailable(
+        self, user_dir, kr_unavailable, master_unlocked
+    ):
+        # owner lives alongside grantee (user_dir = bob) in the same tmp_path
+        owner_dir = user_dir.parent / "owner"
+        owner_dir.mkdir()
+        project_dir = owner_dir / "myproject"
+        project_dir.mkdir(parents=True)
+        grantee_dir = user_dir
+
+        share_string = _make_share_string(owner_dir, project_dir, _KEY_ID)
+
+        # Mock mounts module so the descriptor write doesn't need full store.
+        mock_descriptor = {
+            "mount_name": "owner_myproject",
+            "mount_type": "sealed",
+            "state": "active",
+        }
+        with patch(
+            "axon.security.share._create_sealed_mount_descriptor",
+            return_value=mock_descriptor,
+        ):
+            result = redeem_sealed_share(grantee_dir, share_string)
+
+        assert result["key_id"] == _KEY_ID
+        fb_path = _grantee_dek_fallback_path(grantee_dir, _KEY_ID)
+        assert fb_path.is_file(), "Fallback file should be created when keyring unavailable"
+
+    def test_redeem_raises_if_store_not_bootstrapped_and_keyring_unavailable(
+        self, user_dir, kr_unavailable
+    ):
+        """If the grantee's master store is locked/not-bootstrapped, a clear
+        SecurityError should surface (not a silent failure)."""
+        owner_dir = user_dir.parent / "owner"
+        owner_dir.mkdir()
+        project_dir = owner_dir / "myproject"
+        project_dir.mkdir(parents=True)
+        grantee_dir = user_dir
+
+        share_string = _make_share_string(owner_dir, project_dir, _KEY_ID)
+
+        with (
+            patch("axon.security.share.get_master_key", side_effect=SecurityError("locked")),
+            patch("axon.security.share._create_sealed_mount_descriptor", return_value={}),
+        ):
+            with pytest.raises(SecurityError, match="locked"):
+                redeem_sealed_share(grantee_dir, share_string)
+
+    def test_redeem_dual_writes_when_keyring_available(self, user_dir, master_unlocked):
+        """When keyring IS available, file fallback should ALSO be written."""
+        owner_dir = user_dir.parent / "owner"
+        owner_dir.mkdir()
+        project_dir = owner_dir / "myproject"
+        project_dir.mkdir(parents=True)
+        grantee_dir = user_dir
+
+        share_string = _make_share_string(owner_dir, project_dir, _KEY_ID)
+
+        with (
+            patch.object(_kr, "store_secret"),  # keyring succeeds
+            patch("axon.security.share._create_sealed_mount_descriptor", return_value={}),
+        ):
+            redeem_sealed_share(grantee_dir, share_string)
+
+        fb_path = _grantee_dek_fallback_path(grantee_dir, _KEY_ID)
+        assert fb_path.is_file(), "File fallback should be written even when keyring succeeds"
+
+
+# ---------------------------------------------------------------------------
+# Full headless round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessRoundTrip:
+    def test_dek_round_trip_headless(self, user_dir, kr_unavailable, master_unlocked):
+        """Redeem with keyring absent → get_grantee_dek with keyring absent."""
+        owner_dir = user_dir.parent / "owner"
+        owner_dir.mkdir()
+        project_dir = owner_dir / "myproject"
+        project_dir.mkdir(parents=True)
+        grantee_dir = user_dir
+
+        share_string = _make_share_string(owner_dir, project_dir, _KEY_ID)
+
+        with patch("axon.security.share._create_sealed_mount_descriptor", return_value={}):
+            redeem_sealed_share(grantee_dir, share_string)
+
+        # DEK should be retrievable via file fallback.
+        recovered_dek = get_grantee_dek(_KEY_ID, user_dir=grantee_dir)
+        assert recovered_dek == _TEST_DEK

--- a/tests/test_sealed_share_e2e.py
+++ b/tests/test_sealed_share_e2e.py
@@ -1,0 +1,338 @@
+"""E2E integration test for the full sealed-share roundtrip.
+
+Exercises the complete chain in a single test:
+  owner seals project → generates share string →
+  grantee redeems → grantee switches to mount → grantee queries → results returned.
+
+This is the P0 missing test before v0.3.0 release.  All crypto and
+file I/O is real; only LLM calls, embedding calls, and the OS keyring
+are replaced with lightweight test doubles.
+
+Run with:
+    python -m pytest tests/test_sealed_share_e2e.py -v --no-cov -s
+"""
+from __future__ import annotations
+
+import getpass
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("cryptography")
+pytest.importorskip("keyring")
+
+# ---------------------------------------------------------------------------
+# In-memory keyring — same pattern as test_sealed_share.py / test_project_seal.py
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryKeyring:
+    priority = 1
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, username, secret):
+        self._store[(service, username)] = secret
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def delete_password(self, service, username):
+        import keyring.errors
+
+        if (service, username) not in self._store:
+            raise keyring.errors.PasswordDeleteError("not found")
+        del self._store[(service, username)]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def kr_backend():
+    """Shared in-memory keyring used by both owner and grantee operations."""
+    backend = _InMemoryKeyring()
+    with patch("axon.security.keyring._keyring.get_keyring", return_value=backend):
+        from axon.security import master as _master_mod
+
+        _master_mod._unlocked_masters.clear()
+        yield backend
+        _master_mod._unlocked_masters.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DIM = 384  # embedding dimension used throughout
+
+
+def _deterministic_embed(texts):
+    """Return fixed-length vectors — all docs look the same to the ANN index
+    so every result is equally "close" to the query, which is fine for
+    verifying the retrieval pipeline runs end-to-end."""
+    return [[0.1] * _DIM for _ in texts]
+
+
+def _canned_llm_response(*_args, **_kwargs):
+    return "The knowledge base contains information about quantum entanglement."
+
+
+def _make_brain_config(axon_store_base: Path, vs_path: Path, bm25_path: Path):
+    """Return a minimal AxonConfig whose projects_root is derived from
+    *axon_store_base* (the only way to control the path without fighting
+    __post_init__'s unconditional override of ``projects_root``)."""
+    from axon.config import AxonConfig
+
+    return AxonConfig(
+        axon_store_base=str(axon_store_base),
+        vector_store_path=str(vs_path),
+        bm25_path=str(bm25_path),
+        vector_store="turboquantdb",
+        # Disable expensive optional strategies to keep the test fast.
+        raptor=False,
+        graph_rag=False,
+        hybrid_search=False,
+        rerank=False,
+        hyde=False,
+        multi_query=False,
+        query_router="off",
+        # Disable query cache so every query hits the retrieval pipeline.
+        query_cache=False,
+    )
+
+
+def _make_brain(cfg):
+    """Construct a real AxonBrain with mocked LLM + embedding."""
+    from axon.main import AxonBrain
+
+    with (
+        patch("axon.main.OpenEmbedding") as MockEmb,
+        patch("axon.main.OpenLLM") as MockLLM,
+        patch("axon.main.OpenReranker"),
+    ):
+        mock_emb = MockEmb.return_value
+        mock_emb.embed.side_effect = _deterministic_embed
+        mock_emb.embed_query.return_value = [0.1] * _DIM
+        mock_emb.dim = _DIM
+
+        mock_llm = MockLLM.return_value
+        mock_llm.generate.side_effect = _canned_llm_response
+        mock_llm.complete.side_effect = _canned_llm_response
+
+        brain = AxonBrain(cfg)
+        # Patch the live attributes so query() also uses the mocks.
+        brain.embedding = mock_emb
+        brain.llm = mock_llm
+        return brain
+
+
+def _ingest_research_docs(brain) -> None:
+    """Ingest three short documents into the active project."""
+    docs = [
+        {
+            "id": "doc1",
+            "text": "Quantum entanglement is a phenomenon where particles become correlated.",
+            "metadata": {"source": "physics.txt"},
+        },
+        {
+            "id": "doc2",
+            "text": "The double-slit experiment demonstrates wave-particle duality.",
+            "metadata": {"source": "physics.txt"},
+        },
+        {
+            "id": "doc3",
+            "text": "Schrödinger's cat is a thought experiment about quantum superposition.",
+            "metadata": {"source": "physics.txt"},
+        },
+    ]
+    brain.ingest(docs)
+
+
+# ---------------------------------------------------------------------------
+# The integration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_sealed_share_e2e_roundtrip(kr_backend, tmp_path):
+    """Full sealed-share E2E roundtrip.
+
+    Uses a single ``tmp_path`` so both owner and grantee stores sit on
+    the same filesystem (simulates OneDrive / shared drive sync without
+    needing a real network).
+
+    The OS username is used as the owner name because AxonConfig always
+    derives ``projects_root`` from ``{axon_store_base}/AxonStore/{os_username}``.
+    The grantee uses a separate ``axon_store_base`` directory but shares
+    access to the owner's project directory via the filesystem.
+
+    Phase 1 — Owner setup, ingest, seal
+    Phase 2 — Share generation
+    Phase 3 — Grantee redeem
+    Phase 4 — Grantee query via sealed mount
+    """
+    from axon.security.master import bootstrap_store, unlock_store
+    from axon.security.seal import is_project_sealed
+    from axon.security.share import generate_sealed_share, redeem_sealed_share
+
+    _username = getpass.getuser()
+
+    # Owner's store base: tmp_path/owner_store → projects_root = tmp_path/owner_store/AxonStore/<username>
+    owner_store_base = tmp_path / "owner_store"
+    owner_store_base.mkdir()
+    owner_user_dir = owner_store_base / "AxonStore" / _username
+    owner_user_dir.mkdir(parents=True)
+
+    # Grantee's store base: tmp_path/grantee_store → projects_root = tmp_path/grantee_store/AxonStore/<username>
+    grantee_store_base = tmp_path / "grantee_store"
+    grantee_store_base.mkdir()
+    grantee_user_dir = grantee_store_base / "AxonStore" / _username
+    grantee_user_dir.mkdir(parents=True)
+
+    # ------------------------------------------------------------------
+    # Phase 1a: bootstrap owner's store (derives master key)
+    # ------------------------------------------------------------------
+    bootstrap_store(owner_user_dir, "owner-secret-pw")
+    # bootstrap_store leaves the store unlocked on some paths but we
+    # explicitly unlock to guarantee process-local master cache is warm.
+    unlock_store(owner_user_dir, "owner-secret-pw")
+
+    # ------------------------------------------------------------------
+    # Phase 1b: build owner AxonBrain, create + ingest "research" project
+    # ------------------------------------------------------------------
+    owner_default_vs = owner_user_dir / "_default_vs"
+    owner_default_bm25 = owner_user_dir / "_default_bm25"
+    owner_default_vs.mkdir()
+    owner_default_bm25.mkdir()
+
+    owner_cfg = _make_brain_config(
+        axon_store_base=owner_store_base,
+        vs_path=owner_default_vs,
+        bm25_path=owner_default_bm25,
+    )
+    # Sanity check: AxonConfig derivation lands on the right user dir.
+    assert (
+        Path(owner_cfg.projects_root) == owner_user_dir
+    ), f"projects_root mismatch: {owner_cfg.projects_root} != {owner_user_dir}"
+
+    owner_brain = _make_brain(owner_cfg)
+    try:
+        # Create the "research" project under the owner's store.
+        from axon.projects import ensure_project
+
+        ensure_project("research")
+        owner_brain.switch_project("research")
+        _ingest_research_docs(owner_brain)
+    finally:
+        owner_brain.close()
+
+    # ------------------------------------------------------------------
+    # Phase 1c: seal the research project (real AES-GCM encryption)
+    # ------------------------------------------------------------------
+    from axon.projects import project_dir
+    from axon.security.seal import project_seal
+
+    research_dir = project_dir("research")
+    seal_result = project_seal("research", owner_user_dir)
+    assert seal_result["status"] == "sealed", f"Expected sealed, got: {seal_result['status']}"
+    assert is_project_sealed(research_dir), "Project directory must carry the sealed marker"
+
+    # ------------------------------------------------------------------
+    # Phase 2: owner generates a sealed share
+    # ------------------------------------------------------------------
+    share_result = generate_sealed_share(
+        owner_user_dir,
+        "research",
+        grantee=_username,
+        key_id="ssk_e2e_test1",
+    )
+    share_string = share_result["share_string"]
+    assert share_result["sealed"] is True
+    assert share_result["key_id"] == "ssk_e2e_test1"
+    assert share_result["owner"] == _username
+    assert share_result["project"] == "research"
+
+    # ------------------------------------------------------------------
+    # Phase 3: grantee redeems share (no master bootstrap needed)
+    # ------------------------------------------------------------------
+    # redeem_sealed_share only needs the OS keyring to stash the DEK —
+    # it does NOT require a bootstrapped master store on the grantee side.
+
+    redeem_result = redeem_sealed_share(grantee_user_dir, share_string)
+    assert redeem_result["sealed"] is True
+    assert redeem_result["key_id"] == "ssk_e2e_test1"
+    assert redeem_result["owner"] == _username
+    assert redeem_result["project"] == "research"
+    mount_name = redeem_result["mount_name"]
+    assert mount_name, "redeem_sealed_share must return a mount_name"
+
+    # Verify the mount descriptor was written and validates correctly.
+    from axon.mounts import list_mount_descriptors, load_mount_descriptor, validate_mount_descriptor
+
+    desc = load_mount_descriptor(grantee_user_dir, mount_name)
+    assert desc is not None, "mount.json must exist after redeem"
+    valid, reason = validate_mount_descriptor(desc)
+    assert valid, f"Sealed mount descriptor failed canonical validation: {reason}"
+    assert desc["mount_type"] == "sealed"
+    assert desc["share_key_id"] == "ssk_e2e_test1"
+    assert desc["readonly"] is True
+    assert desc["state"] == "active"
+    assert desc["revoked"] is False
+
+    mounts_listed = list_mount_descriptors(grantee_user_dir)
+    assert any(
+        d.get("mount_name") == mount_name for d in mounts_listed
+    ), f"Mount '{mount_name}' must appear in list_mount_descriptors"
+
+    # ------------------------------------------------------------------
+    # Phase 4: grantee brain switches to sealed mount and runs a query
+    # ------------------------------------------------------------------
+    grantee_default_vs = grantee_user_dir / "_default_vs"
+    grantee_default_bm25 = grantee_user_dir / "_default_bm25"
+    grantee_default_vs.mkdir()
+    grantee_default_bm25.mkdir()
+
+    grantee_cfg = _make_brain_config(
+        axon_store_base=grantee_store_base,
+        vs_path=grantee_default_vs,
+        bm25_path=grantee_default_bm25,
+    )
+    assert (
+        Path(grantee_cfg.projects_root) == grantee_user_dir
+    ), f"grantee projects_root mismatch: {grantee_cfg.projects_root} != {grantee_user_dir}"
+
+    grantee_brain = _make_brain(grantee_cfg)
+    try:
+        # switch_project("mounts/<mount_name>") triggers the two-phase flow:
+        #   1. load_mount_descriptor → finds mount_type="sealed"
+        #   2. stashes _pending_seal_mount on the brain
+        #   3. close() → wipes prior _sealed_cache
+        #   4. _mount_sealed_project() → get_grantee_dek() → materialize_for_read()
+        #   5. config paths updated to the ephemeral plaintext cache dir
+        #   6. OpenVectorStore + BM25Retriever opened from decrypted cache
+        grantee_brain.switch_project(f"mounts/{mount_name}")
+
+        # The sealed cache slot must be populated after switch.
+        assert (
+            grantee_brain._sealed_cache is not None
+        ), "grantee brain must hold a sealed cache after switch_project on a sealed mount"
+
+        # Run a query against the decrypted content.
+        # query() calls _execute_retrieval + LLM generate; the LLM mock
+        # returns the canned answer string so we verify the pipeline
+        # completes without error and returns something non-empty.
+        answer = grantee_brain.query("What is quantum entanglement?")
+        assert isinstance(answer, str) and answer, "query() must return a non-empty string answer"
+    finally:
+        grantee_brain.close()
+
+    # After close() the sealed cache must be wiped.
+    assert (
+        grantee_brain._sealed_cache is None
+    ), "close() must set _sealed_cache to None after releasing the sealed mount"


### PR DESCRIPTION
Implements Phase 6 for grantees: when the OS keyring is unavailable (headless Linux, Docker, CI/CD), wrap the share DEK under the grantee master key and persist to .security/shares/<key_id>.dek.wrapped. Mirrors the master.enc dual-write pattern. Adds 20 new tests.