### PR TITLE
feat(security): harden Windows NTFS cache wipe + passphrase minimum length

### DIFF
--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -307,6 +307,31 @@ Do not use Chroma on any shared, network, or cloud-sync path. Chroma is also not
 
 ---
 
+## Security Considerations
+
+### Windows users with highly sensitive data
+
+The encrypted cache is wiped with random-byte overwrite on close, but NTFS copy-on-write and SSD wear-leveling may retain plaintext in freed sectors even after the overwrite completes. On a spinning HDD, Axon also calls `FlushFileBuffers` (Windows API) after each file wipe for best-effort write-through, but this does not guarantee physical sector erasure on SSDs.
+
+For compliance or classified use, take one of the following measures:
+
+- **Enable BitLocker** on the drive containing `%TEMP%` (the default cache location). BitLocker encrypts every sector, so even previously-freed sectors are protected at rest.
+- **Redirect the cache to an encrypted volume** by setting the `AXON_CACHE_DIR` environment variable to a path on a BitLocker drive, a VeraCrypt container, or a RAM disk:
+  ```
+  set AXON_CACHE_DIR=E:\secure-tmp
+  ```
+- **Use a RAM disk** (e.g. ImDisk, RamMap) for `%TEMP%`. A RAM disk never writes to physical storage; cache contents are destroyed when the machine powers off.
+
+Axon logs an INFO-level reminder (`SealedCache: Windows NTFS secure-delete is best-effort`) when it first wipes a cache directory on Windows. This reminder is emitted once per cache directory per process lifetime.
+
+### Passphrase strength
+
+`axon --store-bootstrap` and `axon --store-change-passphrase` require a passphrase of at least 8 characters. This is a minimum floor; a stronger passphrase significantly increases resistance to offline brute-force attacks against the scrypt-wrapped master key (N=2¹⁵, r=8, p=1). A 16+ character random passphrase or a four-word diceware phrase is recommended.
+
+`axon --store-unlock` does not enforce the minimum length so it can distinguish "wrong passphrase" from "too short" without misleading error messages.
+
+---
+
 ## See Also
 
 - [ADMIN_REFERENCE.md](ADMIN_REFERENCE.md) — complete command reference for all share and seal operations

--- a/src/axon/security/cache.py
+++ b/src/axon/security/cache.py
@@ -15,11 +15,14 @@ implemented here:
 - **Cache location**: ``tempfile.mkdtemp(prefix="axon-sealed-")``
   (Linux/macOS uses ``/tmp``; Windows uses ``%LOCALAPPDATA%\\Temp``).
   Per-mount; never shared between projects.
-- **Wipe on close**: every cache file is overwritten with zeros
-  (``O_RDWR`` re-open + ``write(b"\\x00" * size)`` + fsync) before
-  unlink. This won't survive low-level disk forensics on SSDs (TRIM
-  / wear-leveling defeat overwrite), but at the filesystem layer the
-  plaintext is gone.
+- **Wipe on close**: every cache file is overwritten with random bytes
+  (``O_RDWR`` re-open + ``write(os.urandom(...))`` + fsync +
+  ``FlushFileBuffers`` on Windows) before unlink. This won't survive
+  low-level disk forensics on SSDs (TRIM / wear-leveling defeat
+  overwrite) or NTFS copy-on-write sector reuse, but at the filesystem
+  layer the plaintext is gone. On Windows, enable BitLocker on the
+  drive containing ``%TEMP%`` (or redirect via ``AXON_CACHE_DIR``) for
+  full protection of highly sensitive data.
 - **Crash recovery**: every cache dir contains a ``.pid`` sentinel
   with the creating process's PID. :func:`cleanup_orphans` walks the
   temp dir on next AxonBrain boot, finds ``axon-sealed-*`` dirs whose
@@ -37,6 +40,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import threading
 from pathlib import Path
@@ -51,6 +55,11 @@ except ImportError as exc:  # pragma: no cover — import-time guard
     ) from exc
 
 logger = logging.getLogger("Axon")
+
+# Tracks cache dirs for which the Windows NTFS plaintext-persistence warning
+# has already been logged — so we emit it at most once per cache lifetime
+# rather than once per file deleted.
+_windows_warned_paths: set[str] = set()
 
 __all__ = [
     "CACHE_PREFIX",
@@ -108,13 +117,39 @@ def _project_size_bytes(sealed_dir: Path) -> int:
 
 
 def _secure_delete_file(path: Path) -> None:
-    """Overwrite *path* with zeros, fsync, then unlink.
-    Best-effort at the filesystem layer — won't defeat SSD TRIM /
-    wear-leveling, but ensures no readable plaintext bytes remain at
-    the file's logical address before the inode is freed. Errors are
-    silently swallowed (the unlink is the desired post-condition; if
-    we can't even unlink, there's nothing useful to do here).
+    """Overwrite *path* with random bytes, fsync, then unlink.
+
+    Uses ``os.urandom`` for overwrite content instead of zeros — random
+    bytes prevent zero-pattern detection and make statistical recovery
+    harder. On Windows, calls ``FlushFileBuffers`` via ctypes after the
+    Python-level ``fsync`` to maximise the chance that the random data
+    actually reaches the storage device before the file handle is closed.
+
+    **Windows NTFS limitation**: NTFS copy-on-write and SSD TRIM /
+    wear-leveling may redirect writes to new sectors, leaving the old
+    sector content accessible via low-level disk forensics even after
+    this function completes. This implementation is best-effort at the
+    filesystem layer — it ensures no readable plaintext survives at the
+    file's *logical* address. For compliance or classified use, enable
+    BitLocker on the volume containing the cache (see
+    ``docs/SHARING.md#security-considerations``).
+
+    Errors are silently swallowed (the unlink is the desired
+    post-condition; if we can't even unlink, there's nothing useful to
+    do here).
     """
+    # Emit a one-time INFO warning on Windows about the NTFS limitation.
+    if sys.platform == "win32":
+        parent_key = str(path.parent)
+        if parent_key not in _windows_warned_paths:
+            _windows_warned_paths.add(parent_key)
+            logger.info(
+                "SealedCache: Windows NTFS secure-delete is best-effort — "
+                "plaintext may persist in freed sectors on HDDs. "
+                "Enable BitLocker on %s for full protection.",
+                path.parent,
+            )
+
     try:
         size = path.stat().st_size
     except OSError:
@@ -122,19 +157,30 @@ def _secure_delete_file(path: Path) -> None:
     if size > 0:
         try:
             with path.open("r+b") as fh:
-                # Write zeros in 64 KiB chunks so we don't allocate a
-                # huge buffer for huge files.
-                chunk = b"\x00" * min(size, 64 * 1024)
+                # Overwrite with random bytes in 64 KiB chunks to avoid
+                # allocating a large buffer for large files.
+                chunk_size = min(size, 64 * 1024)
                 remaining = size
                 while remaining > 0:
-                    write_len = min(remaining, len(chunk))
-                    fh.write(chunk[:write_len])
+                    write_len = min(remaining, chunk_size)
+                    fh.write(os.urandom(write_len))
                     remaining -= write_len
                 fh.flush()
                 try:
                     os.fsync(fh.fileno())
                 except OSError:
                     pass
+                # On Windows, call FlushFileBuffers for best-effort
+                # write-through to the storage device.
+                if sys.platform == "win32":
+                    try:
+                        import ctypes
+
+                        ctypes.windll.kernel32.FlushFileBuffers(  # type: ignore[attr-defined]
+                            ctypes.get_osfhandle(fh.fileno())
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass  # best-effort; fsync above is the primary mechanism
         except OSError as exc:
             logger.debug("secure-delete overwrite failed for %s: %s", path, exc)
     try:

--- a/src/axon/security/master.py
+++ b/src/axon/security/master.py
@@ -92,6 +92,12 @@ _SCRYPT_P: int = 1
 _SCRYPT_LEN: int = 32  # 256-bit KEK
 _SALT_LEN: int = 32  # 256 bits of salt entropy
 
+# Minimum passphrase length enforced at bootstrap and rotation time.
+# NOT enforced at unlock — unlocking accepts any passphrase so the
+# caller receives BadPassphraseError (wrong passphrase) rather than a
+# misleading "too short" error when the passphrase is simply wrong.
+_MIN_PASSPHRASE_LEN: int = 8
+
 
 class BadPassphraseError(SecurityError):
     """Raised when ``unlock_store`` or ``change_passphrase`` is given a
@@ -264,6 +270,11 @@ def bootstrap_store(user_dir: Path, passphrase: str) -> dict[str, Any]:
     """
     if not passphrase:
         raise BadPassphraseError("passphrase must be a non-empty string")
+    if len(passphrase) < _MIN_PASSPHRASE_LEN:
+        raise BadPassphraseError(
+            f"passphrase must be at least {_MIN_PASSPHRASE_LEN} characters "
+            f"(got {len(passphrase)})"
+        )
     if is_bootstrapped(user_dir):
         raise SecurityError(
             f"Store at {_service(user_dir)} is already bootstrapped. "
@@ -343,6 +354,11 @@ def change_passphrase(user_dir: Path, old_passphrase: str, new_passphrase: str) 
     """
     if not new_passphrase:
         raise BadPassphraseError("new_passphrase must be a non-empty string")
+    if len(new_passphrase) < _MIN_PASSPHRASE_LEN:
+        raise BadPassphraseError(
+            f"new_passphrase must be at least {_MIN_PASSPHRASE_LEN} characters "
+            f"(got {len(new_passphrase)})"
+        )
     record = _read_keyring_record(user_dir)
     if record is None:
         raise SecurityError(f"Store at {_service(user_dir)} is not bootstrapped.")

--- a/tests/test_sealed_cache.py
+++ b/tests/test_sealed_cache.py
@@ -366,3 +366,61 @@ class TestSelfCheck:
         result = _self_check()
         assert result["ok"] is True
         assert "round-trip OK" in result["details"]
+
+
+# ---------------------------------------------------------------------------
+# _secure_delete_file — random-byte overwrite
+# ---------------------------------------------------------------------------
+
+
+class TestSecureDeleteUsesRandomBytes:
+    """Verify that _secure_delete_file writes random (non-zero) bytes."""
+
+    def test_overwrite_content_is_not_all_zeros(self, tmp_path):
+        """The overwrite must use random bytes, not a zero buffer.
+
+        Strategy: intercept ``os.urandom`` to record what bytes were
+        requested, confirm they were non-zero (urandom never returns all
+        zeros for a reasonable-sized request) and that the file was
+        actually overwritten and then removed.
+        """
+        from axon.security.cache import _secure_delete_file
+
+        target = tmp_path / "sensitive.bin"
+        # Write 1 000 bytes so the overwrite loop runs at least one chunk.
+        target.write_bytes(b"SECRET" * 167)
+
+        urandom_calls: list[int] = []
+        real_urandom = os.urandom
+
+        def spy_urandom(n: int) -> bytes:
+            data = real_urandom(n)
+            urandom_calls.append(n)
+            return data
+
+        with patch("axon.security.cache.os.urandom", side_effect=spy_urandom):
+            _secure_delete_file(target)
+
+        # os.urandom must have been called at least once for the overwrite.
+        assert urandom_calls, "os.urandom was never called — overwrite did not run"
+        total_requested = sum(urandom_calls)
+        assert total_requested > 0, "os.urandom was called but requested 0 bytes"
+        # File must be gone after the secure delete.
+        assert not target.exists(), "file was not unlinked after secure delete"
+
+    def test_file_is_unlinked_after_secure_delete(self, tmp_path):
+        from axon.security.cache import _secure_delete_file
+
+        target = tmp_path / "gone.bin"
+        target.write_bytes(b"data")
+        _secure_delete_file(target)
+        assert not target.exists()
+
+    def test_empty_file_is_unlinked_without_overwrite(self, tmp_path):
+        """Zero-size files skip the overwrite loop but must still be removed."""
+        from axon.security.cache import _secure_delete_file
+
+        target = tmp_path / "empty.bin"
+        target.write_bytes(b"")
+        _secure_delete_file(target)
+        assert not target.exists()

--- a/tests/test_sealed_master.py
+++ b/tests/test_sealed_master.py
@@ -90,13 +90,13 @@ class TestBootstrapStore:
         assert is_bootstrapped(user_dir)
 
     def test_bootstrap_caches_master_so_user_is_unlocked_immediately(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         assert is_unlocked(user_dir)
 
     def test_bootstrap_again_raises_security_error(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         with pytest.raises(SecurityError, match="already bootstrapped"):
-            bootstrap_store(user_dir, "pw2")
+            bootstrap_store(user_dir, "passw0rd-2")
 
     def test_empty_passphrase_rejected(self, kr_backend, user_dir):
         with pytest.raises(BadPassphraseError, match="non-empty"):
@@ -105,7 +105,7 @@ class TestBootstrapStore:
     def test_bootstrap_writes_keyring_record_with_schema_version(self, kr_backend, user_dir):
         import json
 
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         record = json.loads(kr_backend.get_password("axon.master.alice", MASTER_USERNAME))
         assert record["v"] == 1
         assert "salt" in record and "wrapped" in record
@@ -118,27 +118,27 @@ class TestBootstrapStore:
 
 class TestUnlockLock:
     def test_unlock_after_bootstrap_with_correct_passphrase(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         lock_store(user_dir)
         assert not is_unlocked(user_dir)
 
-        result = unlock_store(user_dir, "pw")
+        result = unlock_store(user_dir, "passw0rd")
         assert result["unlocked"] is True
         assert is_unlocked(user_dir)
 
     def test_unlock_with_wrong_passphrase_raises(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "right")
+        bootstrap_store(user_dir, "right-pw!")
         lock_store(user_dir)
         with pytest.raises(BadPassphraseError, match="Wrong passphrase"):
-            unlock_store(user_dir, "wrong")
+            unlock_store(user_dir, "wrong-pw!")
         assert not is_unlocked(user_dir)
 
     def test_unlock_before_bootstrap_raises(self, kr_backend, user_dir):
         with pytest.raises(SecurityError, match="not bootstrapped"):
-            unlock_store(user_dir, "pw")
+            unlock_store(user_dir, "passw0rd")
 
     def test_lock_clears_master_cache(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         assert is_unlocked(user_dir)
         result = lock_store(user_dir)
         assert result["locked"] is True
@@ -146,7 +146,7 @@ class TestUnlockLock:
         assert not is_unlocked(user_dir)
 
     def test_lock_idempotent_when_not_unlocked(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         lock_store(user_dir)
         result = lock_store(user_dir)  # again
         assert result["locked"] is True
@@ -160,32 +160,32 @@ class TestUnlockLock:
 
 class TestChangePassphrase:
     def test_rotate_with_correct_old_passphrase(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "old")
+        bootstrap_store(user_dir, "old-passw")
         master_before = get_master_key(user_dir)
-        result = change_passphrase(user_dir, "old", "new")
+        result = change_passphrase(user_dir, "old-passw", "new-passw")
         assert result["rotated"] is True
         # Master is UNCHANGED across passphrase rotation.
         assert get_master_key(user_dir) == master_before
 
     def test_rotate_with_wrong_old_raises(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "old")
+        bootstrap_store(user_dir, "old-passw")
         with pytest.raises(BadPassphraseError, match="Old passphrase"):
-            change_passphrase(user_dir, "wrong-old", "new")
+            change_passphrase(user_dir, "wrong-old", "new-passw")
 
     def test_after_rotate_old_passphrase_no_longer_works(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "old")
-        change_passphrase(user_dir, "old", "new")
+        bootstrap_store(user_dir, "old-passw")
+        change_passphrase(user_dir, "old-passw", "new-passw")
         lock_store(user_dir)
         with pytest.raises(BadPassphraseError):
-            unlock_store(user_dir, "old")
+            unlock_store(user_dir, "old-passw")
         # New one works.
-        unlock_store(user_dir, "new")
+        unlock_store(user_dir, "new-passw")
         assert is_unlocked(user_dir)
 
     def test_empty_new_passphrase_rejected(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "old")
+        bootstrap_store(user_dir, "old-passw")
         with pytest.raises(BadPassphraseError):
-            change_passphrase(user_dir, "old", "")
+            change_passphrase(user_dir, "old-passw", "")
 
 
 # ---------------------------------------------------------------------------
@@ -195,22 +195,22 @@ class TestChangePassphrase:
 
 class TestGetMasterKey:
     def test_returns_32_bytes_when_unlocked(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         master = get_master_key(user_dir)
         assert isinstance(master, bytes)
         assert len(master) == 32
 
     def test_raises_when_locked(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         lock_store(user_dir)
         with pytest.raises(SecurityError, match="locked"):
             get_master_key(user_dir)
 
     def test_master_stable_across_lock_unlock(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         m1 = get_master_key(user_dir)
         lock_store(user_dir)
-        unlock_store(user_dir, "pw")
+        unlock_store(user_dir, "passw0rd")
         m2 = get_master_key(user_dir)
         assert m1 == m2
 
@@ -222,7 +222,7 @@ class TestGetMasterKey:
 
 class TestProjectDek:
     def test_first_call_creates_and_persists_wrapped_dek(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         proj = user_dir / "research"
         proj.mkdir()
         dek = get_or_create_project_dek(user_dir, proj)
@@ -234,7 +234,7 @@ class TestProjectDek:
         assert wrap_path.stat().st_size == 40
 
     def test_idempotent_returns_same_dek(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         proj = user_dir / "research"
         proj.mkdir()
         d1 = get_or_create_project_dek(user_dir, proj)
@@ -242,7 +242,7 @@ class TestProjectDek:
         assert d1 == d2
 
     def test_distinct_projects_get_distinct_deks(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         p1 = user_dir / "p1"
         p2 = user_dir / "p2"
         p1.mkdir()
@@ -252,7 +252,7 @@ class TestProjectDek:
         assert d1 != d2
 
     def test_locked_store_blocks_dek_access(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         lock_store(user_dir)
         proj = user_dir / "research"
         proj.mkdir()
@@ -260,29 +260,29 @@ class TestProjectDek:
             get_or_create_project_dek(user_dir, proj)
 
     def test_dek_survives_passphrase_rotation(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "old")
+        bootstrap_store(user_dir, "old-passw")
         proj = user_dir / "research"
         proj.mkdir()
         dek_before = get_or_create_project_dek(user_dir, proj)
-        change_passphrase(user_dir, "old", "new")
+        change_passphrase(user_dir, "old-passw", "new-passw")
         # DEK should be retrievable AND identical — passphrase rotation
         # doesn't touch project DEKs.
         dek_after = get_or_create_project_dek(user_dir, proj)
         assert dek_before == dek_after
 
     def test_dek_survives_lock_unlock_cycle(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         proj = user_dir / "research"
         proj.mkdir()
         dek1 = get_or_create_project_dek(user_dir, proj)
         lock_store(user_dir)
-        unlock_store(user_dir, "pw")
+        unlock_store(user_dir, "passw0rd")
         dek2 = get_or_create_project_dek(user_dir, proj)
         assert dek1 == dek2
 
     def test_no_partial_wrap_left_after_failed_write(self, kr_backend, user_dir):
         """Atomic per-file write — the .sealing tempfile must not survive."""
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         proj = user_dir / "research"
         proj.mkdir()
         get_or_create_project_dek(user_dir, proj)
@@ -291,7 +291,7 @@ class TestProjectDek:
         assert leftover == []
 
     def test_corrupt_wrapped_dek_raises_security_error(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         proj = user_dir / "research"
         proj.mkdir()
         get_or_create_project_dek(user_dir, proj)
@@ -309,7 +309,7 @@ class TestProjectDek:
 
 class TestGetProjectDekReadOnly:
     def test_raises_when_no_dek_file(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         proj = user_dir / "research"
         proj.mkdir()
         # No DEK created yet.
@@ -317,7 +317,7 @@ class TestGetProjectDekReadOnly:
             get_project_dek(user_dir, proj)
 
     def test_returns_existing_dek_unchanged(self, kr_backend, user_dir):
-        bootstrap_store(user_dir, "pw")
+        bootstrap_store(user_dir, "passw0rd")
         proj = user_dir / "research"
         proj.mkdir()
         original = get_or_create_project_dek(user_dir, proj)
@@ -346,3 +346,51 @@ class TestKeyringRecordValidation:
         )
         with pytest.raises(SecurityError, match="schema_version mismatch"):
             unlock_store(user_dir, "pw")
+
+
+# ---------------------------------------------------------------------------
+# Passphrase minimum-length enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPassphraseMinimumLength:
+    """bootstrap_store and change_passphrase enforce a minimum passphrase
+    length; unlock_store deliberately does NOT so it returns a clear
+    "wrong passphrase" error rather than a misleading "too short" one.
+    """
+
+    def test_bootstrap_rejects_short_passphrase(self, kr_backend, user_dir):
+        """A passphrase shorter than 8 characters is rejected at bootstrap."""
+        with pytest.raises(BadPassphraseError, match="at least 8"):
+            bootstrap_store(user_dir, "short")
+
+    def test_bootstrap_rejects_exactly_seven_chars(self, kr_backend, user_dir):
+        with pytest.raises(BadPassphraseError, match="at least 8"):
+            bootstrap_store(user_dir, "1234567")
+
+    def test_bootstrap_accepts_exactly_eight_chars(self, kr_backend, user_dir):
+        result = bootstrap_store(user_dir, "12345678")
+        assert result["initialized"] is True
+
+    def test_change_passphrase_rejects_short_new_passphrase(self, kr_backend, user_dir):
+        """change_passphrase rejects a new passphrase that is too short."""
+        bootstrap_store(user_dir, "long-enough-old")
+        with pytest.raises(BadPassphraseError, match="at least 8"):
+            change_passphrase(user_dir, "long-enough-old", "short")
+
+    def test_change_passphrase_accepts_eight_char_new_passphrase(self, kr_backend, user_dir):
+        bootstrap_store(user_dir, "long-enough-old")
+        result = change_passphrase(user_dir, "long-enough-old", "new12345")
+        assert result["rotated"] is True
+
+    def test_unlock_accepts_short_passphrase_and_raises_bad_passphrase(self, kr_backend, user_dir):
+        """unlock_store does NOT enforce minimum length — it lets the
+        wrong-passphrase path fire normally so the error message is clear.
+        Passing a short passphrase should raise BadPassphraseError (wrong
+        passphrase), NOT BadPassphraseError (too short).
+        """
+        bootstrap_store(user_dir, "correct-long-pass")
+        lock_store(user_dir)
+        # A short passphrase is just wrong — no "too short" error raised.
+        with pytest.raises(BadPassphraseError, match="Wrong passphrase"):
+            unlock_store(user_dir, "tiny")


### PR DESCRIPTION
Improves secure delete (random-byte overwrite + FlushFileBuffers on Windows + BitLocker warning), adds 8-char minimum passphrase validation at bootstrap/rotation, documents NTFS limitation in SHARING.md. Includes 9 new tests.