### PR TITLE
web(brand): prominent Axon icon in hero + README + PNG favicon fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/brand/axon-icon.svg" alt="Axon" width="96" height="96" />
+  <!-- Decorative — the wordmark below carries the brand name for screen readers -->
+  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/brand/axon-icon.svg" alt="" width="96" height="96" />
 </div>
 
 <div align="center">
@@ -7,7 +8,7 @@
 </div>
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/repl-animation.gif" alt="Axon REPL" width="400" />
+  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/repl-animation.gif" alt="Axon REPL — first-run wizard, ingest, and a cited query in action" width="400" />
 
   <h3>Your documents, answerable. On your hardware.</h3>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <div align="center">
+  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/brand/axon-icon.svg" alt="Axon" width="96" height="96" />
+</div>
+
+<div align="center">
   <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/brand/axon-wordmark.svg" alt="Axon" width="320" />
 </div>
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Axon — Private RAG. Local first. Graph native. Agent ready.</title>
     <meta name="description" content="Axon is a private, local-first RAG engine with GraphRAG, sealed sharing, and 48 MCP tools. Drop in PDFs, code, and notebooks; ask anything; get cited answers from a local LLM. Nothing leaves your machine.">
+    <!-- Favicon: SVG primary (modern browsers) + PNG fallback (older clients,
+         crawlers, social previews that don't render SVG). -->
     <link rel="icon" type="image/svg+xml" href="docs/assets/brand/axon-favicon.svg">
-    <link rel="alternate icon" href="docs/assets/brand/axon-favicon.svg">
-    <link rel="apple-touch-icon" href="docs/assets/brand/axon-icon.svg">
+    <link rel="icon" type="image/png" sizes="32x32" href="docs/assets/axon-mark.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="docs/assets/axon-mark.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="docs/assets/axon-mark.png">
+    <link rel="mask-icon" href="docs/assets/brand/axon-favicon.svg" color="#00d4b4">
     <meta name="theme-color" content="#050a14">
     <meta property="og:title" content="Axon — Private RAG. Local first. Graph native.">
     <meta property="og:description" content="Drop in PDFs, code, and notebooks; ask anything; get cited answers from a local LLM. 48 MCP tools, sealed cloud-drive sharing, GraphRAG. MIT licensed.">
-    <meta property="og:image" content="docs/assets/brand/axon-icon.svg">
+    <meta property="og:image" content="docs/assets/axon-mark.png">
+    <meta property="og:image:type" content="image/png">
     <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:image" content="docs/assets/axon-mark.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=Syne+Mono&family=JetBrains+Mono:wght@400;500;600&family=Instrument+Sans:ital,wght@0,300;0,400;0,500;1,300&family=Instrument+Serif:ital@0;1&family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..900,0..100;1,9..144,400..900,0..100&display=swap" rel="stylesheet">
@@ -755,6 +762,65 @@
             position: relative; z-index: 10;
             padding-top: 110px; padding-bottom: 70px;
         }
+        /* Hero brand mark — primary icon presence on the page */
+        .hero-mark {
+            display: inline-block;
+            color: var(--teal);
+            margin-bottom: 24px;
+            text-decoration: none;
+            transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+                        filter 0.4s ease;
+            filter: drop-shadow(0 0 18px rgba(0,212,180,0.35));
+        }
+        .hero-mark:hover {
+            transform: rotate(60deg) scale(1.06);
+            filter: drop-shadow(0 0 32px rgba(0,212,180,0.65));
+        }
+        .hero-mark svg {
+            width: 76px; height: 76px;
+            display: block;
+        }
+        .hero-mark .hm-branch {
+            stroke-dasharray: 32;
+            stroke-dashoffset: 32;
+            animation: hm-draw 1.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+        }
+        .hero-mark .hm-b1 { animation-delay: 0.2s; }
+        .hero-mark .hm-b2 { animation-delay: 0.4s; }
+        .hero-mark .hm-b3 { animation-delay: 0.6s; }
+        .hero-mark .hm-terminals circle {
+            opacity: 0;
+            animation: hm-fade-in 0.4s ease-out forwards;
+        }
+        .hero-mark .hm-terminals circle:nth-child(1) { animation-delay: 0.6s; }
+        .hero-mark .hm-terminals circle:nth-child(2) { animation-delay: 0.8s; }
+        .hero-mark .hm-terminals circle:nth-child(3) { animation-delay: 1.0s; }
+        .hero-mark .hm-core {
+            transform-origin: 50px 50px;
+            animation: hm-pulse 3s ease-in-out infinite;
+            animation-delay: 1.2s;
+        }
+        @keyframes hm-draw {
+            to { stroke-dashoffset: 0; }
+        }
+        @keyframes hm-fade-in {
+            to { opacity: 1; }
+        }
+        @keyframes hm-pulse {
+            0%, 100% { transform: scale(1); opacity: 1; }
+            50%      { transform: scale(0.85); opacity: 0.8; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .hero-mark .hm-branch { stroke-dashoffset: 0; animation: none; }
+            .hero-mark .hm-terminals circle { opacity: 1; animation: none; }
+            .hero-mark .hm-core { animation: none; }
+            .hero-mark:hover { transform: none; }
+        }
+        @media (max-width: 640px) {
+            .hero-mark svg { width: 56px; height: 56px; }
+            .hero-mark { margin-bottom: 18px; }
+        }
+
         .version-tag {
             display: inline-flex; align-items: center; gap: 9px;
             border: 1px solid var(--border);
@@ -1902,6 +1968,26 @@
 
 <!-- Hero -->
 <header class="container">
+    <!-- Axon brand mark — large, animated. Sits above the version tag and
+         the H1 title so the icon has a primary visual presence on the page,
+         not just in the nav corner. Stroke pulses on first paint. -->
+    <a href="#" class="hero-mark reveal active" aria-label="Axon home">
+        <svg viewBox="0 0 100 100" fill="none" stroke="currentColor" aria-hidden="true">
+            <polygon points="50,7 87,28 87,72 50,93 13,72 13,28" stroke-width="5" stroke-linejoin="round"/>
+            <g stroke-width="5" stroke-linecap="round">
+                <line x1="50" y1="50" x2="50" y2="22" class="hm-branch hm-b1"/>
+                <line x1="50" y1="50" x2="74" y2="64" class="hm-branch hm-b2"/>
+                <line x1="50" y1="50" x2="26" y2="64" class="hm-branch hm-b3"/>
+            </g>
+            <g fill="currentColor" class="hm-terminals">
+                <circle cx="50" cy="22" r="6"/>
+                <circle cx="74" cy="64" r="6"/>
+                <circle cx="26" cy="64" r="6"/>
+            </g>
+            <circle cx="50" cy="50" r="9" fill="currentColor" class="hm-core"/>
+        </svg>
+    </a>
+
     <div class="version-tag reveal active">
         <div class="version-dot"></div>
         v0.3.2 <span class="vt-sep">/</span> <span class="vt-meta">now on PyPI</span>

--- a/index.html
+++ b/index.html
@@ -15,11 +15,14 @@
     <meta name="theme-color" content="#050a14">
     <meta property="og:title" content="Axon — Private RAG. Local first. Graph native.">
     <meta property="og:description" content="Drop in PDFs, code, and notebooks; ask anything; get cited answers from a local LLM. 48 MCP tools, sealed cloud-drive sharing, GraphRAG. MIT licensed.">
-    <meta property="og:image" content="docs/assets/axon-mark.png">
+    <!-- Social preview parsers (Slack, Discord, Twitter, etc.) require absolute
+         HTTPS URLs for og:image / twitter:image. Relative paths silently fail. -->
+    <meta property="og:image" content="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/axon-mark.png">
     <meta property="og:image:type" content="image/png">
+    <meta property="og:url" content="https://jyunming.github.io/Axon/">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:image" content="docs/assets/axon-mark.png">
+    <meta name="twitter:image" content="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/axon-mark.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=Syne+Mono&family=JetBrains+Mono:wght@400;500;600&family=Instrument+Sans:ital,wght@0,300;0,400;0,500;1,300&family=Instrument+Serif:ital@0;1&family=Fraunces:ital,opsz,wght,SOFT@0,9..144,400..900,0..100;1,9..144,400..900,0..100&display=swap" rel="stylesheet">
@@ -811,10 +814,13 @@
             50%      { transform: scale(0.85); opacity: 0.8; }
         }
         @media (prefers-reduced-motion: reduce) {
+            .hero-mark { transition: none; filter: none; }
             .hero-mark .hm-branch { stroke-dashoffset: 0; animation: none; }
             .hero-mark .hm-terminals circle { opacity: 1; animation: none; }
             .hero-mark .hm-core { animation: none; }
-            .hero-mark:hover { transform: none; }
+            /* Disable BOTH transform AND the filter-glow change on hover —
+               a transitioning glow on hover is still motion. */
+            .hero-mark:hover { transform: none; filter: none; }
         }
         @media (max-width: 640px) {
             .hero-mark svg { width: 56px; height: 56px; }
@@ -1970,8 +1976,12 @@
 <header class="container">
     <!-- Axon brand mark — large, animated. Sits above the version tag and
          the H1 title so the icon has a primary visual presence on the page,
-         not just in the nav corner. Stroke pulses on first paint. -->
-    <a href="#" class="hero-mark reveal active" aria-label="Axon home">
+         not just in the nav corner.
+         Geometry inlined intentionally (NOT <img src=axon-icon.svg>) so the
+         entrance animation can target the individual <line>/<circle>/<g>
+         children with CSS classes. Keep this geometry in sync with the
+         shared docs/assets/brand/axon-icon.svg if either changes. -->
+    <a href="#" class="hero-mark reveal active" aria-label="Axon — scroll to top">
         <svg viewBox="0 0 100 100" fill="none" stroke="currentColor" aria-hidden="true">
             <polygon points="50,7 87,28 87,72 50,93 13,72 13,28" stroke-width="5" stroke-linejoin="round"/>
             <g stroke-width="5" stroke-linecap="round">


### PR DESCRIPTION
## Summary

The redesigned landing page already had an SVG favicon link, but feedback was that **the icon doesn't have enough visible presence on the page itself** — it's only in the small nav corner. This PR makes the brand mark the primary visual anchor.

## Changes

### Landing page — prominent hero mark
- New 76px (56px on mobile) Axon hex-mark **above the version tag**, before the H1 title — first thing visitors see
- Animated entrance: branches stroke-draw on first paint (1.6 s cubic-bezier), terminal dots fade in sequentially, center cell-body pulses
- Hover: rotates 60° with intensified teal halo (`drop-shadow` from 0.35 → 0.65 alpha)
- Wrapped in `<a href="#">` — the mark is the click target back to top
- Honors `prefers-reduced-motion` (instant render, no hover transform)

### Favicon — broader compat
The SVG-only favicon link worked in modern browsers but failed on older clients, link previewers, and indexers. Now ships:
- **SVG primary** (modern browsers — sharp at any size)
- **PNG 16x16 / 32x32 / 180x180** fallback (older browsers, social cards, link previewers) — uses existing `docs/assets/axon-mark.png`
- **mask-icon** for Safari pinned tabs (teal `#00d4b4`)
- **og:image** switched from SVG to PNG so Slack/Discord/Twitter actually render a preview
- Added `twitter:card` metadata

### README header
- Add a 96px standalone icon **above the wordmark** so the brand mark has its own visual moment (the wordmark is text-forward; the icon alone is what readers recognise on PyPI / GitHub previews / social shares)

## Test plan

- [ ] Reload landing page in browser — icon appears above "v0.3.2" pill, animates on first paint
- [ ] Hard refresh (Ctrl+Shift+R) — favicon visible in browser tab
- [ ] PR description / Slack / Discord preview shows the PNG icon (og:image)
- [ ] README header on GitHub: 96px icon → wordmark → REPL gif (visual stack)
- [ ] Mobile viewport: hero mark is 56px, doesn't crowd the H1
- [ ] `prefers-reduced-motion: reduce` → no entrance animation, no hover rotate

🤖 Generated with [Claude Code](https://claude.com/claude-code)