### PR TITLE
docs(v0.4.0): remove stale 'ttl_days silently ignored' language

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -433,7 +433,7 @@ Requires the `[sealed]` extra (already bundled in `[starter]`).
 | `POST` | `/share/generate` | Generate a read-only share key. Auto-detects sealed vs plaintext based on whether the project is sealed |
 | `POST` | `/share/redeem` | Mount a shared project using a share string |
 | `POST` | `/share/revoke` | Revoke a share by `key_id`. Pass `rotate: true` for hard revoke (rotates DEK) |
-| `POST` | `/share/extend` | Push out the expiry of an issued share. **Plaintext shares only** — sealed `ssk_` shares don't currently honour `ttl_days` (silently ignored at generate; v0.4.0 candidate). Body: `{key_id, ttl_days}` |
+| `POST` | `/share/extend` | Push out the expiry of an issued share. **Plaintext shares only.** For sealed (`ssk_`) shares, mint a fresh share with the desired `ttl_days` and revoke the old one — sealed expiry lives in a signed sidecar that the owner cannot extend without rotating the share. Body: `{key_id, ttl_days}` |
 | `GET`  | `/share/list` | List outgoing shares (sharing) and incoming mounts (shared) |
 
 **`POST /store/init` body:**
@@ -449,11 +449,12 @@ Requires the `[sealed]` extra (already bundled in `[starter]`).
 {
   "project": "my-project",             // required — project to share
   "grantee": "alice",                  // required — identifier of the recipient
-  "ttl_days": null                     // optional integer days until expiry (default: null = no expiry).
-                                       // Honoured for plaintext shares (sk_); silently ignored for sealed (ssk_).
+  "ttl_days": null                     // optional positive integer (days until expiry, default null = no expiry).
+                                       // v0.4.0: honoured by BOTH sealed (ssk_) and plaintext (sk_) shares.
+                                       // ttl_days <= 0 returns 422.
 }
 ```
-Response carries `key_id` (`sk_` for plaintext, `ssk_` for sealed), `share_string` (base64 envelope; sealed ones decode to `SEALED1:...`), and `expires_at` (ISO 8601 if `ttl_days` was set on a plaintext share, else `null`).
+Response carries `key_id` (`sk_` for plaintext, `ssk_` for sealed), `share_string` (base64 envelope; sealed ones decode to `SEALED1:...` for unsigned shares or `SEALED2:...` when minted on an unlocked store with `ttl_days`), and `expires_at` (ISO 8601 Z-suffixed UTC when `ttl_days` was set, else `null`). For sealed shares, an Ed25519-signed expiry sidecar is written next to the wrap and a TTL check fires on every grantee mount; an expired share auto-destroys the local DEK + cache + mount descriptor on next mount attempt.
 
 **`POST /share/redeem` body:**
 ```json

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -433,7 +433,7 @@ Requires the `[sealed]` extra (already bundled in `[starter]`).
 | `POST` | `/share/generate` | Generate a read-only share key. Auto-detects sealed vs plaintext based on whether the project is sealed |
 | `POST` | `/share/redeem` | Mount a shared project using a share string |
 | `POST` | `/share/revoke` | Revoke a share by `key_id`. Pass `rotate: true` for hard revoke (rotates DEK) |
-| `POST` | `/share/extend` | Push out the expiry of an issued share. **Plaintext shares only.** For sealed (`ssk_`) shares, mint a fresh share with the desired `ttl_days` and revoke the old one — sealed expiry lives in a signed sidecar that the owner cannot extend without rotating the share. Body: `{key_id, ttl_days}` |
+| `POST` | `/share/extend` | Push out the expiry of an issued share. **Plaintext shares only.** Sealed (`ssk_`) `key_id`s are not in the plaintext share manifest and currently return `404 Key not found`. To extend a sealed share, mint a fresh sealed share with the desired `ttl_days` and revoke the old one — sealed expiry lives in an Ed25519-signed sidecar that cannot be re-signed in place. Body: `{key_id, ttl_days}` |
 | `GET`  | `/share/list` | List outgoing shares (sharing) and incoming mounts (shared) |
 
 **`POST /store/init` body:**
@@ -454,7 +454,7 @@ Requires the `[sealed]` extra (already bundled in `[starter]`).
                                        // ttl_days <= 0 returns 422.
 }
 ```
-Response carries `key_id` (`sk_` for plaintext, `ssk_` for sealed), `share_string` (base64 envelope; sealed ones decode to `SEALED1:...` for unsigned shares or `SEALED2:...` when minted on an unlocked store with `ttl_days`), and `expires_at` (ISO 8601 Z-suffixed UTC when `ttl_days` was set, else `null`). For sealed shares, an Ed25519-signed expiry sidecar is written next to the wrap and a TTL check fires on every grantee mount; an expired share auto-destroys the local DEK + cache + mount descriptor on next mount attempt.
+Response carries `key_id` (`sk_` for plaintext, `ssk_` for sealed), `share_string` (base64 envelope; v0.4.0+ sealed shares always decode to `SEALED2:...` — the legacy 6-field `SEALED1:...` format is accepted on redeem but no longer emitted), and `expires_at` (ISO 8601 Z-suffixed UTC when `ttl_days` was set, else `null`). When `ttl_days` is set on a sealed share, an Ed25519-signed expiry sidecar is written next to the wrap and a TTL check fires on every grantee mount; an expired share auto-destroys the local DEK + cache + mount descriptor on next mount attempt.
 
 **`POST /share/redeem` body:**
 ```json

--- a/docs/AXON_STORE.md
+++ b/docs/AXON_STORE.md
@@ -148,14 +148,14 @@ curl -X POST http://localhost:8000/share/generate \
 
 The `share_string` is a base64 envelope:
 - Plaintext: base64 of an HMAC-signed payload
-- Sealed (no TTL, store locked at mint, or any pre-v0.4.0 share): base64 of `SEALED1:<key_id>:<token_hex>:<owner>:<project>:<store_path>`
-- Sealed (v0.4.0, store unlocked at mint with `ttl_days`): base64 of `SEALED2:<key_id>:<token_hex>:<owner>:<project>:<store_path>:<owner_pubkey_hex>` — carries the Ed25519 verifier so the grantee can validate the expiry sidecar without owner round-trip
+- Sealed (v0.4.0+, default for all newly minted sealed shares): base64 of `SEALED2:<key_id>:<token_hex>:<owner>:<project>:<store_path>:<owner_pubkey_hex>` — the trailing field is the owner's Ed25519 signing pubkey so the grantee can verify the expiry sidecar (when present) without an owner round-trip
+- Sealed legacy (`SEALED1:` — 6 fields, no embedded pubkey): only emitted by pre-v0.4.0 builds. Still accepted on redeem for backward compatibility. Will not carry an expiry sidecar.
 
 Send it out-of-band (Signal, encrypted email — never the same channel as the data). All shares are **read-only** — there is no `write_access` capability.
 
 ### Extending an existing share
 
-Call `POST /share/extend` (or REPL `/share extend <key_id> --ttl-days N`) to push out the expiry of a share that's already issued — useful when a contractor's engagement is renewed without re-issuing keys. **Plaintext shares (`sk_`) only.** For sealed (`ssk_`) shares, the expiry lives in an Ed25519-signed sidecar; extending it would require re-signing under the owner's signing key and re-uploading. The supported flow for renewing a sealed share is to mint a fresh one with a longer `ttl_days` and revoke the old `key_id` once the grantee has switched over. Calling `/share/extend` on an `ssk_` key is a no-op or 422 (depending on whether the legacy manifest contains the key) — the call never modifies the signed sidecar.
+Call `POST /share/extend` (or REPL `/share extend <key_id> --ttl-days N`) to push out the expiry of a share that's already issued — useful when a contractor's engagement is renewed without re-issuing keys. **Plaintext shares (`sk_`) only.** Sealed (`ssk_`) `key_id`s are not in the plaintext share manifest, so the route returns `404 Key not found`. To renew a sealed share, mint a fresh one with the desired `ttl_days` and revoke the old `key_id` once the grantee has switched over — sealed expiry lives in an Ed25519-signed sidecar that cannot be re-signed in place.
 
 ---
 

--- a/docs/AXON_STORE.md
+++ b/docs/AXON_STORE.md
@@ -118,7 +118,7 @@ Two share modes ship in v0.3.x:
 |-----------|------|---------|-------------|
 | `project` | string | required | Name of the project to share |
 | `grantee` | string | required | OS username of the recipient |
-| `ttl_days` | int \| null | `null` | Days from creation until the share expires. `null` = no expiry. **Currently honoured only for plaintext (`sk_`) shares** — the sealed (`ssk_`) branch silently ignores `ttl_days` at generate time (wiring it through is a v0.4.0 candidate; track via the planned TTL-gated sealed-share design). |
+| `ttl_days` | int \| null | `null` | Positive integer days from creation until the share expires. `null` = no expiry. **v0.4.0:** honoured by both sealed (`ssk_`) and plaintext (`sk_`) shares. For sealed shares this writes an Ed25519-signed expiry sidecar next to the wrap; the grantee's mount fails with `ShareExpiredError` after expiry and auto-destroys the local DEK + cache + mount descriptor. `ttl_days <= 0` returns 422. |
 
 > See [SHARING.md](SHARING.md) for the full sealed-share threat model, sync-folder prerequisites, and the `pip install "axon-rag[sealed]"` (or `[starter]`) extras.
 
@@ -132,11 +132,11 @@ curl -X POST http://localhost:8000/share/generate \
 # Response: {"share_string": "eyJ...", "key_id": "sk_a1b2c3d4", "project": "my-project", "grantee": "bob", "owner": "<your-username>", "expires_at": null}
 
 # Sealed share (project sealed) — same call, sealed envelope returned.
-# Note: ttl_days is currently silently ignored on the sealed branch.
+# v0.4.0: ttl_days is honoured for sealed shares via signed expiry sidecar.
 curl -X POST http://localhost:8000/share/generate \
   -H "Content-Type: application/json" \
-  -d '{"project": "research", "grantee": "alice"}'
-# Response: {"share_string": "U0VBTEVE...", "key_id": "ssk_a4f9c1d2", "project": "research", "grantee": "alice", "owner": "<your-username>", "security_mode": "sealed_v1"}
+  -d '{"project": "research", "grantee": "alice", "ttl_days": 30}'
+# Response: {"share_string": "U0VBTEVE...", "key_id": "ssk_a4f9c1d2", "project": "research", "grantee": "alice", "owner": "<your-username>", "security_mode": "sealed_v1", "expires_at": "2026-06-03T01:00:00Z"}
 ```
 
 **REPL:**
@@ -148,13 +148,14 @@ curl -X POST http://localhost:8000/share/generate \
 
 The `share_string` is a base64 envelope:
 - Plaintext: base64 of an HMAC-signed payload
-- Sealed: base64 of `SEALED1:<key_id>:<token_hex>:<owner>:<project>:<store_path>`
+- Sealed (no TTL, store locked at mint, or any pre-v0.4.0 share): base64 of `SEALED1:<key_id>:<token_hex>:<owner>:<project>:<store_path>`
+- Sealed (v0.4.0, store unlocked at mint with `ttl_days`): base64 of `SEALED2:<key_id>:<token_hex>:<owner>:<project>:<store_path>:<owner_pubkey_hex>` — carries the Ed25519 verifier so the grantee can validate the expiry sidecar without owner round-trip
 
 Send it out-of-band (Signal, encrypted email — never the same channel as the data). All shares are **read-only** — there is no `write_access` capability.
 
 ### Extending an existing share
 
-Call `POST /share/extend` (or REPL `/share extend <key_id> --ttl-days N`) to push out the expiry of a share that's already issued — useful when a contractor's engagement is renewed without re-issuing keys. **Plaintext shares (`sk_`) only** — the sealed branch tracks expiry through a separate sidecar mechanism (v0.4.0 candidate); calling extend on an `ssk_` key currently no-ops or returns a 422 depending on whether the legacy manifest contains the key.
+Call `POST /share/extend` (or REPL `/share extend <key_id> --ttl-days N`) to push out the expiry of a share that's already issued — useful when a contractor's engagement is renewed without re-issuing keys. **Plaintext shares (`sk_`) only.** For sealed (`ssk_`) shares, the expiry lives in an Ed25519-signed sidecar; extending it would require re-signing under the owner's signing key and re-uploading. The supported flow for renewing a sealed share is to mint a fresh one with a longer `ttl_days` and revoke the old `key_id` once the grantee has switched over. Calling `/share/extend` on an `ssk_` key is a no-op or 422 (depending on whether the legacy manifest contains the key) — the call never modifies the signed sidecar.
 
 ---
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -304,7 +304,7 @@ Initialize the AxonStore on first use, or move it to a different base path (e.g.
 
 ### `share_project`
 
-Generate a share key allowing another user to access one of your projects. The returned `share_string` should be sent to the recipient out-of-band. All shares are read-only. Sealed-share auto-detection: if the project was encrypted via `seal_project`, returns a `SEALED1:` envelope (or `SEALED2:` when the store is unlocked at mint time and `ttl_days` is set, so the envelope can carry the owner's signing pubkey).
+Generate a share key allowing another user to access one of your projects. The returned `share_string` should be sent to the recipient out-of-band. All shares are read-only. Sealed-share auto-detection: if the project was encrypted via `seal_project`, v0.4.0+ always returns a `SEALED2:` envelope (carries the owner's Ed25519 signing pubkey for sidecar verification). The legacy `SEALED1:` 6-field format is still accepted by `redeem_share` for backward compatibility but is no longer emitted.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -344,7 +344,7 @@ Revoke a previously generated share key. For legacy plaintext shares (`sk_` pref
 
 ### `extend_share`
 
-Renew a share key's expiry, or clear it (`ttl_days=null`). Pairs with `share_project(ttl_days=...)` to give owners a hard cutoff for forgotten shares. **Plaintext shares (`sk_`) only.** For sealed shares (`ssk_`), the expiry lives in an Ed25519-signed sidecar and cannot be extended in place — mint a fresh sealed share with the desired `ttl_days` and revoke the old one.
+Renew a share key's expiry, or clear it (`ttl_days=null`). Pairs with `share_project(ttl_days=...)` to give owners a hard cutoff for forgotten shares. **Plaintext shares (`sk_`) only.** Sealed (`ssk_`) `key_id`s are not in the plaintext share manifest and currently return `404 Key not found`. To renew a sealed share, mint a fresh one with the desired `ttl_days` and revoke the old `key_id` — sealed expiry lives in an Ed25519-signed sidecar that cannot be re-signed in place.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -304,15 +304,15 @@ Initialize the AxonStore on first use, or move it to a different base path (e.g.
 
 ### `share_project`
 
-Generate a share key allowing another user to access one of your projects. The returned `share_string` should be sent to the recipient out-of-band. All shares are read-only. Sealed-share auto-detection: if the project was encrypted via `seal_project`, returns a `SEALED1:` envelope.
+Generate a share key allowing another user to access one of your projects. The returned `share_string` should be sent to the recipient out-of-band. All shares are read-only. Sealed-share auto-detection: if the project was encrypted via `seal_project`, returns a `SEALED1:` envelope (or `SEALED2:` when the store is unlocked at mint time and `ttl_days` is set, so the envelope can carry the owner's signing pubkey).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `project` | string | required | Project to share (must exist) |
 | `grantee` | string | required | OS username of the recipient |
-| `ttl_days` | int | `null` | Optional time-to-live in days; `null` means no expiry |
+| `ttl_days` | int | `null` | Optional positive integer days until expiry; `null` means no expiry. **v0.4.0:** honoured for both plaintext (`sk_`) and sealed (`ssk_`) shares. For sealed shares, writes an Ed25519-signed expiry sidecar; the grantee's mount fails with `ShareExpiredError` after expiry and auto-destroys the local DEK + cache + mount descriptor on the next mount attempt. `ttl_days <= 0` is rejected. |
 
-**Returns:** `{"share_string": "axon-share:v1:...", "key_id": "..."}`
+**Returns:** `{"share_string": "axon-share:v1:...", "key_id": "...", "expires_at": "..."}` (`expires_at` is Z-suffixed UTC ISO 8601 when `ttl_days` was set; absent or null otherwise).
 
 ### `redeem_share`
 
@@ -344,7 +344,7 @@ Revoke a previously generated share key. For legacy plaintext shares (`sk_` pref
 
 ### `extend_share`
 
-Renew a share key's expiry, or clear it (`ttl_days=null`). Pairs with `share_project(ttl_days=...)` to give owners a hard cutoff for forgotten shares.
+Renew a share key's expiry, or clear it (`ttl_days=null`). Pairs with `share_project(ttl_days=...)` to give owners a hard cutoff for forgotten shares. **Plaintext shares (`sk_`) only.** For sealed shares (`ssk_`), the expiry lives in an Ed25519-signed sidecar and cannot be extended in place — mint a fresh sealed share with the desired `ttl_days` and revoke the old one.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -131,7 +131,7 @@ Step 5: Generate a sealed share for the grantee
 axon --share-generate research alice
 ```
 
-Axon detects that the project is sealed and automatically generates a sealed share (key ID starts with `ssk_`). The printed share string begins with `SEALED1:` (no TTL) or `SEALED2:` (v0.4.0 — TTL set on an unlocked store, envelope carries the owner's signing pubkey). Send it to the grantee out-of-band.
+Axon detects that the project is sealed and automatically generates a sealed share (key ID starts with `ssk_`). v0.4.0+ always emits a `SEALED2:` envelope carrying the owner's Ed25519 signing pubkey (used to verify the optional expiry sidecar). The legacy `SEALED1:` 6-field format is still accepted on redeem for backward compatibility with pre-v0.4.0 strings, but is no longer minted. Send the share string to the grantee out-of-band.
 
 To add an expiry (v0.4.0):
 

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -131,15 +131,15 @@ Step 5: Generate a sealed share for the grantee
 axon --share-generate research alice
 ```
 
-Axon detects that the project is sealed and automatically generates a sealed share (key ID starts with `ssk_`). The printed share string begins with `SEALED1:`. Send it to the grantee out-of-band.
+Axon detects that the project is sealed and automatically generates a sealed share (key ID starts with `ssk_`). The printed share string begins with `SEALED1:` (no TTL) or `SEALED2:` (v0.4.0 — TTL set on an unlocked store, envelope carries the owner's signing pubkey). Send it to the grantee out-of-band.
 
-To add an expiry:
+To add an expiry (v0.4.0):
 
 ```
 axon> /share generate research alice --ttl-days 30
 ```
 
-Wait for the sync folder to upload the new `.security/shares/<key_id>.wrapped` file (about 40 bytes) to the cloud before telling the grantee to redeem.
+This writes two files to the sync folder: the wrapped DEK (`.security/shares/<key_id>.wrapped`, ~40 bytes) and an Ed25519-signed expiry sidecar (`.security/shares/<key_id>.expiry`, ~250 bytes). Wait for both to upload before telling the grantee to redeem. Once the sidecar's `expires_at` passes, the grantee's next mount fails with `ShareExpiredError` and Axon auto-destroys the local DEK + cache + mount descriptor (encrypted source files on the synced FS are never touched).
 
 ### Grantee setup (3 steps)
 


### PR DESCRIPTION
## Summary

Post-v0.4.0 doc audit. After PR #104 shipped TTL-gated sealed shares, four user-facing share docs still claimed sealed shares "silently ignored" `ttl_days` or that wiring was a "v0.4.0 candidate." This PR fixes that drift.

## Files changed
- `docs/API_REFERENCE.md` — `/share/extend` and `/share/generate` body docs.
- `docs/AXON_STORE.md` — ttl_days parameter row, sealed-curl example, share_string section, "Extending an existing share."
- `docs/MCP_TOOLS.md` — `share_project` and `extend_share` tool descriptions.
- `docs/SHARING.md` — sealed share TTL section explains both wrap + signed sidecar files and grantee-side auto-destroy.

No code changes. Doc-only PR; CI path-filter should mark this `paths-ignore`.

## Test plan
- [x] No code touched
- [x] Pre-commit doc hooks green (no python files in diff → all pytest hooks skipped)
- [ ] Manual review for accuracy on each call site

🤖 Generated with [Claude Code](https://claude.com/claude-code)