### PR TITLE
feat(v0.4.0 Item 4): metadata leakage hardening (4a + 4c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+### 🔒 Security — Item 4: Metadata leakage hardening
+
+Two of three sub-items from the plan; **4b deferred to v0.5.0**.
+
+#### 4a — Hostname → store-scoped UUID node_id
+
+`version.json` markers now stamp the writer's identity with a UUID4 (`owner_node_id`) minted once at store-init time and cached in `store_meta.json::node_id`. The legacy `owner_host` field is retained as an empty string for schema continuity with v0.3.x readers; new writers no longer leak `socket.gethostname()` through the synced filesystem volume. `axon.projects.get_or_create_node_id` migrates pre-v0.4.0 stores in-place on first read. `axon.version_marker` no longer imports `socket` at all.
+
+#### 4c — Random padding in AXSL sealed files (`security.seal_padding_bytes`)
+
+New `AxonConfig.seal_padding_bytes: int = 0` (off by default, fully backward-compatible). When `> 0`, every `SealedFile.write` / `write_stream` / `write_stream_from_path` appends a random number of bytes between `0` and `seal_padding_bytes` (inclusive) **after** the GCM tag. Reader slices the padding off via the new `padding_length` field stamped into 4 bytes of the previously-reserved header region (preserves the 16-byte header size). The bound: a 1024-byte budget hides plaintext length to within ±1 KiB; for share wraps and KEK files (~40 bytes) this is enough to mask whether a wrap is "small metadata" or "an unusual share". Plumbed through `project_seal` so the existing seal pipeline picks up the config; share-wrap and KEK callers can opt in incrementally.
+
+#### 4b — Hashed key_id filenames in `.security/shares/` — DEFERRED to v0.5.0
+
+Implementing this cleanly requires an encrypted index file (so owners can still enumerate shares for `list_sealed_shares` and `hard_revoke`), which is a non-trivial design surface. The existing leak (filenames carry plaintext `key_id`s) remains in v0.4.0; documented as known limitation.
+
+#### Tests
+
+`tests/test_metadata_hardening.py` — 17 tests:
+- 4a: `ensure_user_project` writes `node_id`; `get_or_create_node_id` round-trip + legacy migration; missing `store_meta` → empty string; `version_marker.bump` writes `owner_node_id` + empty `owner_host`; defensive regression against `import socket` re-appearing.
+- 4c: round-trip with padding; baseline file size unchanged when `padding_bytes=0`; padding distribution check (200 writes, no length > 30%); streaming write supports padding; negative `padding_bytes` rejected; truncated trailing padding fails cleanly via `SealedFormatError` instead of misaligned `InvalidTag`.
+- Config: `seal_padding_bytes` default 0; YAML round-trip; negative value rejected at load.
+
 ### 🔒 Security — Item 3: Ephemeral plaintext cache mode
 
 - New `security.seal_cache_ephemeral: bool = false` config (off by default).

--- a/docs/ADMIN_REFERENCE.md
+++ b/docs/ADMIN_REFERENCE.md
@@ -848,6 +848,9 @@ YAML section: top-level (or under `rag:`)
 | `mount_refresh_ttl_s` | int | `300` | Seconds before a `switch`-mode mount auto-refreshes during a query |
 | `mount_sync_retry_max` | int | `5` | Max mid-sync retry attempts before raising `MountSyncPendingError` |
 | `mount_sync_retry_backoff_s` | float | `0.5` | Base backoff seconds between sync retries (exponential: `backoff * 2 ** attempt`) |
+| `keyring_mode` | str | `persistent` | **v0.4.0 Item 2** — DEK storage mode. `persistent` = OS keyring; `session` = process-memory only (wiped at exit); `never` = no caching, re-redeem each mount |
+| `seal_cache_ephemeral` | bool | `false` | **v0.4.0 Item 3** — when true, sealed-project plaintext cache is materialised + wiped per query (re-decrypts each call). Trade-off: ~1 s/query latency vs session-long plaintext window |
+| `seal_padding_bytes` | int | `0` | **v0.4.0 Item 4c** — random trailing-byte budget per sealed file (`0..N` uniform). Defeats the file-size leak (observer otherwise infers plaintext length within ±28 bytes). Hard-capped at 1 MiB to match the reader's sanity bound — larger values are rejected at config load |
 
 ### 6.16 Store Settings
 

--- a/src/axon/config.py
+++ b/src/axon/config.py
@@ -1121,6 +1121,18 @@ class AxonConfig:
                 _spb = int(sec["seal_padding_bytes"])
                 if _spb < 0:
                     raise ValueError(f"security.seal_padding_bytes must be >= 0, got {_spb}")
+                # Cap matches axon.security.crypto._unpack_header's 1 MiB
+                # sanity bound on padding_length. A larger budget would let
+                # writers emit files this build's reader rejects with
+                # SealedFormatError — silent data loss until the next
+                # release bumps the reader's bound.
+                _SEAL_PADDING_HARD_CAP = 1024 * 1024
+                if _spb > _SEAL_PADDING_HARD_CAP:
+                    raise ValueError(
+                        f"security.seal_padding_bytes must be <= "
+                        f"{_SEAL_PADDING_HARD_CAP} (1 MiB), got {_spb}. "
+                        "Larger values would emit files the reader rejects."
+                    )
                 config_dict["seal_padding_bytes"] = _spb
         # Environment Variable Overrides (High Priority --' wins over config.yaml)
         env_ollama_host = os.getenv("OLLAMA_HOST") or os.getenv("OLLAMA_BASE_URL")

--- a/src/axon/config.py
+++ b/src/axon/config.py
@@ -276,6 +276,7 @@ _KNOWN_YAML_KEYS: dict[str, set[str]] = {
         "mount_sync_retry_backoff_s",
         "keyring_mode",
         "seal_cache_ephemeral",
+        "seal_padding_bytes",
     },
 }
 
@@ -857,6 +858,16 @@ class AxonConfig:
     # Each retry waits ``mount_sync_retry_backoff_s * 2 ** attempt`` seconds.
     mount_sync_retry_max: int = 5
     mount_sync_retry_backoff_s: float = 0.5
+    # ── Random padding for sealed files (v0.4.0 Item 4c) ───────────────────
+    # When > 0, every newly-sealed file carries random trailing bytes
+    # whose count is chosen uniformly in ``[0, seal_padding_bytes]``.
+    # Defeats the trivial file-size leak (an observer otherwise infers
+    # plaintext length within ±28 bytes from the on-disk size). Default
+    # 0 = no padding (fully backward-compatible). Tuning: 1024 adds at
+    # most 1 KiB per file — plenty to obscure short payloads (share
+    # wraps, KEK files, expiry sidecars) without meaningfully bloating
+    # vector segments.
+    seal_padding_bytes: int = 0
     # ── Ephemeral plaintext cache (v0.4.0 Item 3) ──────────────────────────
     # When True, a sealed-project query runs in a per-query mount/unmount
     # cycle: SealedCache.create at query start, release_cache at query
@@ -1106,6 +1117,11 @@ class AxonConfig:
                 config_dict["keyring_mode"] = _km
             if "seal_cache_ephemeral" in sec:
                 config_dict["seal_cache_ephemeral"] = bool(sec["seal_cache_ephemeral"])
+            if "seal_padding_bytes" in sec:
+                _spb = int(sec["seal_padding_bytes"])
+                if _spb < 0:
+                    raise ValueError(f"security.seal_padding_bytes must be >= 0, got {_spb}")
+                config_dict["seal_padding_bytes"] = _spb
         # Environment Variable Overrides (High Priority --' wins over config.yaml)
         env_ollama_host = os.getenv("OLLAMA_HOST") or os.getenv("OLLAMA_BASE_URL")
         if env_ollama_host:
@@ -1237,6 +1253,7 @@ class AxonConfig:
             "mount_refresh_ttl_s": flat["mount_refresh_ttl_s"],
             "keyring_mode": flat["keyring_mode"],
             "seal_cache_ephemeral": flat["seal_cache_ephemeral"],
+            "seal_padding_bytes": flat["seal_padding_bytes"],
         }
         if flat.get("axon_store_base"):
             data["store"] = {"base": flat["axon_store_base"]}

--- a/src/axon/main.py
+++ b/src/axon/main.py
@@ -3209,10 +3209,18 @@ Your primary goal is to help the user by answering questions based on the provid
         # in-memory handles need to be reopened. Atomic write — if any
         # part of this fails, the previous marker stays intact.
         try:
+            from axon.projects import get_or_create_node_id
             from axon.version_marker import bump as _bump_marker
 
             _project_dir = Path(self.config.bm25_path).parent
-            _bump_marker(_project_dir)
+            # v0.4.0 Item 4a: stamp the marker with the store's UUID
+            # node_id (no hostname leak through synced volumes).
+            _node_id = ""
+            try:
+                _node_id = get_or_create_node_id(Path(self.config.projects_root))
+            except Exception:
+                pass
+            _bump_marker(_project_dir, node_id=_node_id)
         except Exception as _vm_exc:
             logger.debug("version_marker bump failed (non-fatal): %s", _vm_exc)
         # Explicitly release lease (fallback: _WriteLease.__del__ handles it)

--- a/src/axon/projects.py
+++ b/src/axon/projects.py
@@ -345,6 +345,49 @@ def get_store_id(user_dir: Path) -> str | None:
         return None
 
 
+def get_or_create_node_id(user_dir: Path) -> str:
+    """Return the per-store UUID stored at ``store_meta.json::node_id``.
+
+    v0.4.0 Item 4a. Used by :func:`axon.version_marker.bump` to stamp
+    each ``version.json`` marker with the writer's identity without
+    leaking the OS hostname through the cloud-sync volume.
+
+    Behaviour:
+
+    - Reads ``store_meta.json::node_id`` when present (the common case
+      for stores initialised by v0.4.0+).
+    - For stores migrated from older Axon versions where ``node_id``
+      may be absent, mints a fresh UUID4 in-place and persists it back.
+    - Returns ``""`` (empty string) only when ``store_meta.json`` is
+      entirely missing or malformed; callers can pass that value
+      through to :func:`bump` without crashing the marker write.
+    """
+    import uuid as _uuid
+
+    store_meta = user_dir / "store_meta.json"
+    if not store_meta.exists():
+        return ""
+    try:
+        meta = json.loads(store_meta.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return ""
+    if not isinstance(meta, dict):
+        return ""
+    nid = meta.get("node_id")
+    if isinstance(nid, str) and nid:
+        return nid
+    # Migration: existing v0.3.x store with no node_id field.
+    new_nid = str(_uuid.uuid4())
+    meta["node_id"] = new_nid
+    try:
+        store_meta.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    except OSError:
+        # Persistence failed — return the value anyway so the current
+        # bump can proceed; the next call will retry the write.
+        pass
+    return new_nid
+
+
 def list_descendants(name: str, visited: set[str] | None = None) -> list[str]:
     """Return the full slash-separated names of all descendant projects.
     Uses a recursive DFS that supports up to _MAX_DEPTH levels and includes
@@ -585,12 +628,20 @@ def ensure_user_project(user_dir: Path) -> None:
     # ── Phase 1: store_meta.json ─────────────────────────────────────────────
     store_meta = user_dir / "store_meta.json"
     if not store_meta.exists():
+        import uuid as _uuid
+
         store_meta.write_text(
             json.dumps(
                 {
                     "store_version": 2,
                     "store_scope": "user_scoped",
                     "store_id": build_project_id("store"),
+                    # v0.4.0 Item 4a — random UUID per store. Replaces
+                    # the OS hostname previously written into version.json
+                    # markers; identifies the source of writes for stale-
+                    # ness detection without leaking machine identity to
+                    # anyone watching the synced filesystem.
+                    "node_id": str(_uuid.uuid4()),
                     "created_at": datetime.now(timezone.utc).isoformat(),
                 },
                 indent=2,

--- a/src/axon/security/crypto.py
+++ b/src/axon/security/crypto.py
@@ -85,7 +85,16 @@ DEK_LEN: int = 32  # 256-bit Data Encryption Key
 STREAMING_CHUNK_SIZE: int = 1024 * 1024
 
 # 4-byte magic | 1-byte version | 1-byte cipher_id | 10-byte reserved (zero)
-_HEADER_STRUCT = struct.Struct(">4sBB10x")
+# Header layout (16 bytes, big-endian):
+#   4s  — MAGIC ("AXSL")
+#   B   — schema_version (currently 1)
+#   B   — cipher_id (0 = AES-256-GCM)
+#   I   — padding_length (v0.4.0 Item 4c — uint32 trailing random bytes
+#         appended AFTER the GCM tag; readers slice these off before
+#         calling AESGCM.decrypt). v0.3.x writers leave this 4-byte
+#         region zero — backward-compatible.
+#   6x  — reserved (must be zero)
+_HEADER_STRUCT = struct.Struct(">4sBBI6x")
 
 
 class SealedFormatError(Exception):
@@ -104,16 +113,27 @@ class SealedFormatError(Exception):
 # ---------------------------------------------------------------------------
 
 
-def _pack_header(*, version: int = SCHEMA_VERSION, cipher_id: int = CIPHER_AES_256_GCM) -> bytes:
-    return _HEADER_STRUCT.pack(MAGIC, version, cipher_id)
+def _pack_header(
+    *,
+    version: int = SCHEMA_VERSION,
+    cipher_id: int = CIPHER_AES_256_GCM,
+    padding_length: int = 0,
+) -> bytes:
+    return _HEADER_STRUCT.pack(MAGIC, version, cipher_id, padding_length)
 
 
-def _unpack_header(header: bytes) -> tuple[int, int]:
-    """Return ``(version, cipher_id)``; raise SealedFormatError on mismatch."""
+def _unpack_header(header: bytes) -> tuple[int, int, int]:
+    """Return ``(version, cipher_id, padding_length)``.
+
+    v0.4.0 Item 4c: ``padding_length`` is the count of random bytes
+    appended after the GCM tag. v0.3.x writers leave the 4-byte region
+    zero — old files therefore unpack with ``padding_length=0`` and
+    decrypt unchanged.
+    """
     if len(header) != HEADER_LEN:
         raise SealedFormatError(f"Header must be {HEADER_LEN} bytes, got {len(header)}")
     try:
-        magic, version, cipher_id = _HEADER_STRUCT.unpack(header)
+        magic, version, cipher_id, padding_length = _HEADER_STRUCT.unpack(header)
     except struct.error as exc:
         raise SealedFormatError(f"Could not unpack header: {exc}") from exc
     if magic != MAGIC:
@@ -130,7 +150,12 @@ def _unpack_header(header: bytes) -> tuple[int, int]:
         raise SealedFormatError(
             f"Unsupported cipher_id {cipher_id} (only AES-256-GCM = {CIPHER_AES_256_GCM})"
         )
-    return version, cipher_id
+    if padding_length < 0 or padding_length > 1024 * 1024:
+        # Sanity bound: 1 MiB cap on padding length keeps a corrupt
+        # header from making us slice past the file's end with nothing
+        # actionable to do.
+        raise SealedFormatError(f"Implausible padding_length in header: {padding_length}")
+    return version, cipher_id, padding_length
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +195,7 @@ class SealedFile:
         key: bytes,
         *,
         aad: bytes = b"",
+        padding_bytes: int = 0,
     ) -> None:
         """Encrypt *plaintext* with *key* and write to *path* atomically.
         Args:
@@ -181,6 +207,15 @@ class SealedFile:
                 same AAD on read or :class:`InvalidTag` will be raised.
                 Recommended: ``key_id || file_relpath`` to prevent files
                 from being swapped between projects.
+            padding_bytes: v0.4.0 Item 4c — when ``> 0``, append a random
+                number of random bytes between ``0`` and ``padding_bytes``
+                (inclusive) AFTER the GCM tag. The exact length is
+                recorded in the file header so :meth:`read` can slice it
+                off before calling AESGCM.decrypt. Defeats the trivial
+                file-size leak (an observer otherwise infers plaintext
+                length within ±28 bytes from the on-disk size). Cost:
+                up to ``padding_bytes`` extra storage per file.
+
         The write is atomic — encrypted bytes are written to a sibling
         ``<name>.sealing`` file then renamed via :func:`os.replace` so a
         crash mid-write never leaves a half-sealed file at the live
@@ -192,11 +227,18 @@ class SealedFile:
         """
         if len(key) != 32:
             raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
+        if padding_bytes < 0:
+            raise ValueError("padding_bytes must be >= 0")
         path = Path(path)
         nonce = os.urandom(NONCE_LEN)
         # AESGCM.encrypt returns ciphertext || tag concatenated.
         ct_and_tag = AESGCM(key).encrypt(nonce, plaintext, aad if aad else None)
-        body = _pack_header() + nonce + ct_and_tag
+        # v0.4.0 Item 4c: random-length padding (0..padding_bytes inclusive).
+        # Length is the value that goes into the header; ``read`` uses it to
+        # know how many trailing bytes to discard.
+        pad_len = secrets.randbelow(padding_bytes + 1) if padding_bytes > 0 else 0
+        padding = secrets.token_bytes(pad_len) if pad_len else b""
+        body = _pack_header(padding_length=pad_len) + nonce + ct_and_tag + padding
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".sealing")
         tmp.write_bytes(body)
@@ -210,6 +252,7 @@ class SealedFile:
         *,
         aad: bytes = b"",
         chunk_size: int = STREAMING_CHUNK_SIZE,
+        padding_bytes: int = 0,
     ) -> None:
         """Encrypt *plaintext_iter* with *key* and write to *path* atomically.
 
@@ -252,6 +295,8 @@ class SealedFile:
             raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
         if chunk_size <= 0:
             raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        if padding_bytes < 0:
+            raise ValueError("padding_bytes must be >= 0")
         path = Path(path)
         nonce = os.urandom(NONCE_LEN)
         cipher = Cipher(algorithms.AES(key), modes.GCM(nonce))
@@ -261,13 +306,17 @@ class SealedFile:
             # the high-level AEAD API does this implicitly; the low-level
             # Cipher API surfaces the ordering requirement to the caller.
             encryptor.authenticate_additional_data(aad)
+        # v0.4.0 Item 4c: pre-roll the padding length so it can go into
+        # the header BEFORE we start streaming ciphertext. The header is
+        # written first because the file is built linearly.
+        pad_len = secrets.randbelow(padding_bytes + 1) if padding_bytes > 0 else 0
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".sealing")
         # Open BEFORE the loop so we can stream-write ciphertext chunks
         # as they're produced. Atomic os.replace at the end.
         try:
             with tmp.open("wb") as fh:
-                fh.write(_pack_header())
+                fh.write(_pack_header(padding_length=pad_len))
                 fh.write(nonce)
                 for chunk in plaintext_iter:
                     if not chunk:
@@ -283,6 +332,8 @@ class SealedFile:
                 if tail:
                     fh.write(tail)
                 fh.write(encryptor.tag)
+                if pad_len:
+                    fh.write(secrets.token_bytes(pad_len))
             os.replace(tmp, path)
         except BaseException:
             # Best-effort cleanup on any failure — never leave a partial
@@ -301,6 +352,7 @@ class SealedFile:
         *,
         aad: bytes = b"",
         chunk_size: int = STREAMING_CHUNK_SIZE,
+        padding_bytes: int = 0,
     ) -> None:
         """Convenience wrapper: read *src_path* in chunks, seal to *dst_path*.
 
@@ -308,6 +360,9 @@ class SealedFile:
         into :meth:`write_stream`. Used by the project-seal and
         hard-revoke paths so a multi-GB content file can be re-encrypted
         without ever materialising the whole plaintext.
+
+        ``padding_bytes`` is forwarded to :meth:`write_stream` — see
+        Item 4c semantics there.
         """
         if chunk_size <= 0:
             raise ValueError(f"chunk_size must be positive, got {chunk_size}")
@@ -321,7 +376,14 @@ class SealedFile:
                         break
                     yield buf
 
-        SealedFile.write_stream(dst_path, _reader(), key, aad=aad, chunk_size=chunk_size)
+        SealedFile.write_stream(
+            dst_path,
+            _reader(),
+            key,
+            aad=aad,
+            chunk_size=chunk_size,
+            padding_bytes=padding_bytes,
+        )
 
     @staticmethod
     def read(
@@ -345,7 +407,17 @@ class SealedFile:
         body = path.read_bytes()
         if len(body) < HEADER_LEN + NONCE_LEN + TAG_LEN:
             raise SealedFormatError(f"File too short to be a sealed AXSL file ({len(body)} bytes)")
-        _unpack_header(body[:HEADER_LEN])
+        _, _, padding_length = _unpack_header(body[:HEADER_LEN])
+        if padding_length:
+            # v0.4.0 Item 4c — slice off trailing random padding before
+            # AESGCM.decrypt. Without this, the GCM tag bytes are in the
+            # wrong place and decrypt raises InvalidTag.
+            if len(body) < HEADER_LEN + NONCE_LEN + TAG_LEN + padding_length:
+                raise SealedFormatError(
+                    f"Truncated sealed file: header claims {padding_length} bytes "
+                    f"of padding but body is only {len(body)} bytes"
+                )
+            body = body[: len(body) - padding_length]
         nonce = body[HEADER_LEN : HEADER_LEN + NONCE_LEN]
         ct_and_tag = body[HEADER_LEN + NONCE_LEN :]
         return AESGCM(key).decrypt(nonce, ct_and_tag, aad if aad else None)

--- a/src/axon/security/seal.py
+++ b/src/axon/security/seal.py
@@ -371,8 +371,13 @@ def project_seal(
         plaintext = src.read_bytes()
         aad = make_aad(seal_id, str(rel).replace("\\", "/"))
         tmp = src.with_suffix(src.suffix + ".sealing")
+        # v0.4.0 Item 4c: per-file random padding when configured. Pulled
+        # off the config object passed in by the caller (project_seal sig
+        # accepts ``config``); falls back to 0 when no config was passed
+        # (test paths and legacy callers).
+        _pad = int(getattr(config, "seal_padding_bytes", 0) or 0)
         try:
-            SealedFile.write(tmp, plaintext, dek, aad=aad)
+            SealedFile.write(tmp, plaintext, dek, aad=aad, padding_bytes=_pad)
             os.replace(tmp, src)
         except OSError as exc:
             # Clean up the failed tempfile before propagating.

--- a/src/axon/security/share.py
+++ b/src/axon/security/share.py
@@ -1674,9 +1674,18 @@ def _hard_revoke(
     # marker was only bumped by ingest, so a quiet rotation could go
     # undetected by mounted grantees).
     try:
+        from axon.projects import get_or_create_node_id
         from axon.version_marker import bump as _vm_bump
 
-        _vm_bump(project_dir)
+        # v0.4.0 Item 4a: stamp the marker with the store-scoped UUID
+        # rather than the hostname (the synced volume must not leak the
+        # owner's machine identity).
+        _node_id = ""
+        try:
+            _node_id = get_or_create_node_id(owner_user_dir)
+        except Exception:
+            pass
+        _vm_bump(project_dir, node_id=_node_id)
     except Exception as _vm_exc:  # pragma: no cover — defensive
         logger.debug("hard_revoke: version_marker bump raised: %s", _vm_exc)
     logger.info(

--- a/src/axon/version_marker.py
+++ b/src/axon/version_marker.py
@@ -11,7 +11,7 @@ Marker schema (v1)::
         "schema_version": 1,
         "seq": 42,                     # monotonic per-ingest counter
         "generated_at": "...ISO...",
-        "owner_host": "alice-laptop",  # informational
+        "owner_node_id": "8a3c…",      # store-scoped UUID4 (v0.4.0+)
         "hash_algo": "sha256",
         "artifacts": {
             "meta.json":                                "<hex digest>",
@@ -20,6 +20,16 @@ Marker schema (v1)::
             "bm25_index/.dynamic_graph.snapshot.json":  "<hex digest>",
         }
     }
+
+v0.4.0 Item 4a — privacy: the marker no longer carries the OS hostname
+(``socket.gethostname()``). Hostnames leak the owner's machine identity
+into a file that travels through cloud-sync. We replace it with a
+random UUID4 minted once per store at ``init_store`` time and cached
+in ``store_meta.json::node_id``. The UUID serves the same staleness-
+detection role (distinguishing markers written by different machines
+without doxxing the user) and is opaque to anyone watching the sync
+volume. Existing ``owner_host`` field is retained as ``""`` for
+schema compatibility; new ``owner_node_id`` field carries the UUID.
 
 We hash *manifest-level* files only — the small JSON / log files that
 each backend updates atomically when its data changes.  This stays
@@ -40,7 +50,6 @@ import hashlib
 import json
 import logging
 import os
-import socket
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -92,13 +101,6 @@ def _now_iso() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
-def _safe_hostname() -> str:
-    try:
-        return socket.gethostname() or ""
-    except Exception:
-        return ""
-
-
 def rollup_hashes(
     project_dir: Path | str,
     *,
@@ -133,8 +135,10 @@ def bump(
     *,
     seq: int | None = None,
     hash_algo: str = "sha256",
+    node_id: str | None = None,
 ) -> dict[str, Any]:
     """Compute and persist a fresh version marker.
+
     Args:
         project_dir: The project root (one level above ``bm25_index``
             and ``vector_store_data``).
@@ -142,8 +146,17 @@ def bump(
             tests.  Production callers should leave this ``None``.
         hash_algo: ``hashlib`` algorithm name.  Defaults to SHA-256;
             BLAKE3 (faster) is a future option once we add the dep.
+        node_id: v0.4.0 Item 4a — store-scoped UUID identifying which
+            machine wrote this marker. When ``None`` (test default or
+            legacy callers), the marker carries an empty
+            ``owner_node_id``. Production callers pass the cached
+            ``store_meta.json::node_id``. The legacy ``owner_host``
+            field is retained but always empty — no more hostname
+            leak through the cloud sync volume.
+
     Returns:
         The marker dict that was written to disk.
+
     The write is atomic: we serialise to ``version.json.tmp`` first
     and then ``os.replace`` over the live name, so concurrent readers
     never observe a half-written file.
@@ -157,7 +170,11 @@ def bump(
         "schema_version": SCHEMA_VERSION,
         "seq": int(seq),
         "generated_at": _now_iso(),
-        "owner_host": _safe_hostname(),
+        # ``owner_host`` retained as empty string for schema continuity
+        # with v0.3.x readers; v0.4.0+ writers no longer leak the OS
+        # hostname through cloud sync. Use ``owner_node_id`` instead.
+        "owner_host": "",
+        "owner_node_id": (node_id or ""),
         "hash_algo": hash_algo,
         "artifacts": rollup_hashes(project_dir, hash_algo=hash_algo),
     }

--- a/src/axon/version_marker.py
+++ b/src/axon/version_marker.py
@@ -11,6 +11,8 @@ Marker schema (v1)::
         "schema_version": 1,
         "seq": 42,                     # monotonic per-ingest counter
         "generated_at": "...ISO...",
+        "owner_host": "",              # always empty in v0.4.0+ writers;
+                                       # retained for v0.3.x reader compat
         "owner_node_id": "8a3c…",      # store-scoped UUID4 (v0.4.0+)
         "hash_algo": "sha256",
         "artifacts": {

--- a/tests/test_metadata_hardening.py
+++ b/tests/test_metadata_hardening.py
@@ -1,0 +1,260 @@
+"""Tests for v0.4.0 Item 4 — metadata leakage hardening.
+
+Coverage:
+
+4a. Hostname → store-scoped UUID node_id
+    - ``init_store`` writes a fresh ``node_id`` UUID into ``store_meta.json``.
+    - ``get_or_create_node_id`` returns the stored value, mints + persists
+      one for legacy stores (migration path).
+    - ``version_marker.bump`` accepts ``node_id`` and writes
+      ``owner_node_id`` + empty ``owner_host`` (no hostname leak).
+    - ``socket`` is no longer imported by ``version_marker``.
+
+4c. Random padding in sealed files (``security.seal_padding_bytes``)
+    - ``SealedFile.write`` round-trips with non-zero padding.
+    - ``write_stream`` round-trips with non-zero padding.
+    - File size grows by ``padding_length`` bytes; header carries the
+      length so ``read`` can slice it off.
+    - Two writes of the same plaintext with the same key produce
+      different on-disk lengths most of the time (defeats the size leak).
+    - ``AxonConfig.seal_padding_bytes`` round-trips through YAML.
+
+4b (hashed key_id filenames) is deferred to v0.5.0 — see PR description.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 4a — node_id replaces hostname
+# ---------------------------------------------------------------------------
+
+
+class TestNodeId:
+    def test_init_store_writes_node_id(self, tmp_path):
+        """A freshly initialised store must carry a UUID-shaped
+        ``node_id`` in ``store_meta.json`` — replacement for the
+        previous behaviour of letting bumps stamp the OS hostname into
+        each project's ``version.json``."""
+        from axon.projects import ensure_user_project
+
+        user_dir = tmp_path / "AxonStore" / "alice"
+        user_dir.mkdir(parents=True)
+        ensure_user_project(user_dir)
+        meta = json.loads((user_dir / "store_meta.json").read_text(encoding="utf-8"))
+        assert "node_id" in meta
+        nid = meta["node_id"]
+        # UUID4 string: 8-4-4-4-12 hex digits separated by dashes
+        parts = nid.split("-")
+        assert len(parts) == 5
+        assert [len(p) for p in parts] == [8, 4, 4, 4, 12]
+
+    def test_get_or_create_node_id_returns_existing(self, tmp_path):
+        from axon.projects import ensure_user_project, get_or_create_node_id
+
+        user_dir = tmp_path / "AxonStore" / "alice"
+        user_dir.mkdir(parents=True)
+        ensure_user_project(user_dir)
+        first = get_or_create_node_id(user_dir)
+        second = get_or_create_node_id(user_dir)
+        assert first == second
+        assert first  # non-empty
+
+    def test_get_or_create_node_id_migrates_legacy_store(self, tmp_path):
+        """A pre-v0.4.0 ``store_meta.json`` without a ``node_id`` field
+        must get one minted in-place on first read."""
+        from axon.projects import get_or_create_node_id
+
+        user_dir = tmp_path / "AxonStore" / "bob"
+        user_dir.mkdir(parents=True)
+        legacy = {"store_version": 2, "store_id": "store_legacy"}
+        (user_dir / "store_meta.json").write_text(json.dumps(legacy), encoding="utf-8")
+        nid = get_or_create_node_id(user_dir)
+        assert nid
+        # Persisted: a second call returns the same value
+        assert get_or_create_node_id(user_dir) == nid
+        # And ``store_meta.json`` now has the field
+        meta = json.loads((user_dir / "store_meta.json").read_text(encoding="utf-8"))
+        assert meta["node_id"] == nid
+
+    def test_get_or_create_node_id_missing_meta_returns_empty(self, tmp_path):
+        from axon.projects import get_or_create_node_id
+
+        user_dir = tmp_path / "AxonStore" / "ghost"
+        user_dir.mkdir(parents=True)
+        # No store_meta.json at all
+        assert get_or_create_node_id(user_dir) == ""
+
+    def test_version_marker_no_longer_writes_hostname(self, tmp_path):
+        """``bump`` must populate ``owner_node_id`` and leave
+        ``owner_host`` empty — no hostname leak through the synced
+        volume."""
+        from axon.version_marker import bump, read
+
+        marker = bump(tmp_path, node_id="my-uuid-1234")
+        assert marker["owner_host"] == ""
+        assert marker["owner_node_id"] == "my-uuid-1234"
+        # And it round-trips on disk
+        on_disk = read(tmp_path)
+        assert on_disk is not None
+        assert on_disk["owner_host"] == ""
+        assert on_disk["owner_node_id"] == "my-uuid-1234"
+
+    def test_version_marker_no_node_id_arg_writes_empty(self, tmp_path):
+        from axon.version_marker import bump
+
+        marker = bump(tmp_path)
+        assert marker["owner_host"] == ""
+        assert marker["owner_node_id"] == ""
+
+    def test_version_marker_does_not_import_socket(self):
+        """Defensive: a regression that re-introduces ``socket`` here
+        would re-introduce the hostname-leak surface area."""
+        import inspect
+
+        import axon.version_marker as vm
+
+        src = inspect.getsource(vm)
+        assert (
+            "import socket" not in src
+        ), "axon.version_marker must not import socket (Item 4a leak surface)"
+
+
+# ---------------------------------------------------------------------------
+# 4c — random padding in AXSL sealed files
+# ---------------------------------------------------------------------------
+
+
+pytest.importorskip("cryptography", reason="requires axon-rag[sealed] / cryptography")
+
+
+class TestSealPadding:
+    def test_round_trip_with_padding(self, tmp_path):
+        from axon.security.crypto import SealedFile, generate_dek
+
+        path = tmp_path / "secret.bin"
+        key = generate_dek()
+        SealedFile.write(path, b"hello world", key, padding_bytes=512)
+        out = SealedFile.read(path, key)
+        assert out == b"hello world"
+
+    def test_round_trip_no_padding_unchanged(self, tmp_path):
+        """Default ``padding_bytes=0`` must produce the same on-disk
+        layout as before Item 4c — backward compat."""
+        from axon.security.crypto import SealedFile, generate_dek
+
+        path = tmp_path / "no-pad.bin"
+        key = generate_dek()
+        SealedFile.write(path, b"unchanged", key)
+        # File size: 16 (header) + 12 (nonce) + 9 (plaintext) + 16 (tag) = 53
+        assert path.stat().st_size == 53
+        assert SealedFile.read(path, key) == b"unchanged"
+
+    def test_padding_grows_file_size(self, tmp_path):
+        """A non-zero ``padding_bytes`` budget gives at least SOME
+        write that grows the file beyond the no-pad baseline; over many
+        writes a meaningful fraction differ in size."""
+        from axon.security.crypto import SealedFile, generate_dek
+
+        key = generate_dek()
+        baseline = 16 + 12 + 5 + 16  # header + nonce + plaintext("hello") + tag
+        sizes: list[int] = []
+        for i in range(50):
+            p = tmp_path / f"f{i}.bin"
+            SealedFile.write(p, b"hello", key, padding_bytes=1024)
+            sizes.append(p.stat().st_size)
+        # Every file is at least the baseline; at least one is strictly bigger
+        assert all(s >= baseline for s in sizes)
+        assert max(sizes) > baseline
+        # Distribution check: at least 20 distinct sizes (would be ~50 if
+        # the RNG is healthy — but allow slack for very short bursts).
+        assert len(set(sizes)) >= 20
+
+    def test_padding_random_lengths_uniform_ish(self, tmp_path):
+        """The padding length samples from a 0..N uniform distribution
+        — no single length should dominate."""
+        from collections import Counter
+
+        from axon.security.crypto import SealedFile, generate_dek
+
+        key = generate_dek()
+        sizes: list[int] = []
+        for i in range(200):
+            p = tmp_path / f"u{i}.bin"
+            SealedFile.write(p, b"x" * 8, key, padding_bytes=256)
+            sizes.append(p.stat().st_size)
+        most = Counter(sizes).most_common(1)[0][1]
+        # No single padding length picked > 30% of the time
+        assert most < len(sizes) * 0.3
+
+    def test_streaming_write_supports_padding(self, tmp_path):
+        from axon.security.crypto import SealedFile, generate_dek
+
+        key = generate_dek()
+        path = tmp_path / "stream.bin"
+        chunks = [b"abc", b"def", b"ghi"]
+        SealedFile.write_stream(path, iter(chunks), key, padding_bytes=128)
+        assert SealedFile.read(path, key) == b"abcdefghi"
+
+    def test_negative_padding_rejected(self, tmp_path):
+        from axon.security.crypto import SealedFile, generate_dek
+
+        with pytest.raises(ValueError, match="padding_bytes"):
+            SealedFile.write(tmp_path / "x.bin", b"x", generate_dek(), padding_bytes=-1)
+
+    def test_truncated_padding_raises_format_error(self, tmp_path):
+        """If a header claims more padding than the file contains, read
+        must raise SealedFormatError — not silently misalign and produce
+        InvalidTag."""
+        from axon.security.crypto import SealedFile, SealedFormatError, generate_dek
+
+        path = tmp_path / "truncated.bin"
+        key = generate_dek()
+        SealedFile.write(path, b"hello", key, padding_bytes=64)
+        # Lop off some of the trailing padding bytes
+        body = path.read_bytes()
+        path.write_bytes(body[: len(body) - 10])
+        # The body claimed full padding length; now there isn't enough
+        # left to slice, so the format error fires before AESGCM.
+        # (If the original write picked padding_length=0 the test is
+        # vacuous — assert at least that we don't return wrong plaintext.)
+        try:
+            decrypted = SealedFile.read(path, key)
+        except (SealedFormatError, Exception):
+            return
+        assert decrypted != b"hello"
+
+
+# ---------------------------------------------------------------------------
+# Config field for 4c
+# ---------------------------------------------------------------------------
+
+
+class TestPaddingConfig:
+    def test_default_is_zero(self):
+        from axon.config import AxonConfig
+
+        cfg = AxonConfig()
+        assert cfg.seal_padding_bytes == 0
+
+    def test_yaml_round_trip(self, tmp_path):
+        from axon.config import AxonConfig
+
+        path = tmp_path / "config.yaml"
+        path.write_text("security:\n  seal_padding_bytes: 1024\n", encoding="utf-8")
+        cfg = AxonConfig.load(str(path))
+        assert cfg.seal_padding_bytes == 1024
+        cfg.seal_padding_bytes = 0
+        cfg.save(str(path))
+        cfg2 = AxonConfig.load(str(path))
+        assert cfg2.seal_padding_bytes == 0
+
+    def test_yaml_negative_rejected(self, tmp_path):
+        from axon.config import AxonConfig
+
+        path = tmp_path / "config.yaml"
+        path.write_text("security:\n  seal_padding_bytes: -5\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="seal_padding_bytes"):
+            AxonConfig.load(str(path))

--- a/tests/test_metadata_hardening.py
+++ b/tests/test_metadata_hardening.py
@@ -206,25 +206,32 @@ class TestSealPadding:
 
     def test_truncated_padding_raises_format_error(self, tmp_path):
         """If a header claims more padding than the file contains, read
-        must raise SealedFormatError — not silently misalign and produce
-        InvalidTag."""
-        from axon.security.crypto import SealedFile, SealedFormatError, generate_dek
+        must raise ``SealedFormatError`` (not silently misalign into
+        ``InvalidTag``). Build the scenario explicitly: write with
+        padding_bytes=0 (file has just header+nonce+ct+tag), then
+        re-stamp the header to claim padding_length=64. There are no
+        trailing pad bytes in the file, so read() will fail the
+        length-check before AESGCM and raise SealedFormatError."""
+        from axon.security.crypto import (
+            _HEADER_STRUCT,
+            HEADER_LEN,
+            SealedFile,
+            SealedFormatError,
+            generate_dek,
+        )
 
         path = tmp_path / "truncated.bin"
         key = generate_dek()
-        SealedFile.write(path, b"hello", key, padding_bytes=64)
-        # Lop off some of the trailing padding bytes
+        SealedFile.write(path, b"hello", key, padding_bytes=0)
+
         body = path.read_bytes()
-        path.write_bytes(body[: len(body) - 10])
-        # The body claimed full padding length; now there isn't enough
-        # left to slice, so the format error fires before AESGCM.
-        # (If the original write picked padding_length=0 the test is
-        # vacuous — assert at least that we don't return wrong plaintext.)
-        try:
-            decrypted = SealedFile.read(path, key)
-        except (SealedFormatError, Exception):
-            return
-        assert decrypted != b"hello"
+        magic, version, cipher_id, _ = _HEADER_STRUCT.unpack(body[:HEADER_LEN])
+        # Lie: claim padding_length=64 even though no pad bytes follow.
+        new_header = _HEADER_STRUCT.pack(magic, version, cipher_id, 64)
+        path.write_bytes(new_header + body[HEADER_LEN:])
+
+        with pytest.raises(SealedFormatError, match="padding"):
+            SealedFile.read(path, key)
 
 
 # ---------------------------------------------------------------------------
@@ -257,4 +264,16 @@ class TestPaddingConfig:
         path = tmp_path / "config.yaml"
         path.write_text("security:\n  seal_padding_bytes: -5\n", encoding="utf-8")
         with pytest.raises(ValueError, match="seal_padding_bytes"):
+            AxonConfig.load(str(path))
+
+    def test_yaml_above_reader_cap_rejected(self, tmp_path):
+        """Copilot finding on PR #109: a budget above the reader's
+        1 MiB sanity bound would emit files this build can't decrypt.
+        Reject at config-load instead of letting it become silent
+        data loss."""
+        from axon.config import AxonConfig
+
+        path = tmp_path / "config.yaml"
+        path.write_text(f"security:\n  seal_padding_bytes: {2 * 1024 * 1024}\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="1 MiB"):
             AxonConfig.load(str(path))

--- a/tests/test_version_marker.py
+++ b/tests/test_version_marker.py
@@ -347,11 +347,15 @@ class TestMarkerJsonShape:
         _seed_project(tmp_path)
         bump(tmp_path)
         raw = json.loads((tmp_path / VERSION_MARKER_FILENAME).read_text(encoding="utf-8"))
+        # v0.4.0 Item 4a: owner_node_id added (UUID4 — replaces the
+        # hostname leak); owner_host retained as empty string for
+        # schema continuity with v0.3.x readers.
         assert set(raw.keys()) == {
             "schema_version",
             "seq",
             "generated_at",
             "owner_host",
+            "owner_node_id",
             "hash_algo",
             "artifacts",
         }


### PR DESCRIPTION
## Summary

Plan Item 4. Two of three sub-items shipped; **4b (sha256-hashed key_id filenames) deferred to v0.5.0** — implementing it cleanly needs an encrypted share-index for owner-side enumeration.

## Changes

### 4a — Hostname → store-scoped UUID node_id

`version.json` markers no longer leak `socket.gethostname()`. Replaced with a per-store UUID4 (`owner_node_id`) minted once at store-init time and cached in `store_meta.json::node_id`. Legacy `owner_host` retained as empty string for v0.3.x reader schema continuity.

- `version_marker.py` no longer imports `socket`.
- `projects.get_or_create_node_id` migrates legacy stores in-place on first read.
- All `bump()` callers (`main.py`, `security/share.py`) pass the cached node_id.

### 4c — Random padding in AXSL sealed files (`security.seal_padding_bytes`)

New `AxonConfig.seal_padding_bytes: int = 0` (off by default, fully backward-compatible). When `> 0`, sealed writes append `0..N` random bytes after the GCM tag. Length stamped into 4 bytes of the previously-reserved AXSL header region (preserves the 16-byte header size). Reader slices off via header field; v0.3.x writers leave the field zero so old files unpack unchanged.

- Header struct: `>4sBBI6x` (was `>4sBB10x`).
- `SealedFile.write` / `write_stream` / `write_stream_from_path` accept `padding_bytes`.
- `project_seal` forwards `config.seal_padding_bytes` so the existing seal pipeline picks up the flag.

### 4b — DEFERRED

`.security/shares/<key_id>.wrapped` filenames still carry plaintext `key_id`s. Hashing them breaks `list_sealed_shares` / `hard_revoke` enumeration unless we add an encrypted index. Documented as known limitation in CHANGELOG.

## Tests

`tests/test_metadata_hardening.py` — 17 tests:
- 4a: node_id round-trip + legacy migration + missing-meta path; bump writes `owner_node_id` + empty `owner_host`; regression test asserts `import socket` is gone from `version_marker`.
- 4c: padding round-trip; baseline unchanged when `padding_bytes=0`; 50-write distribution check (≥20 distinct sizes); 200-write uniform-ish (no length > 30%); streaming write supports padding; negative rejected; truncated padding fails cleanly via `SealedFormatError`.
- Config: default 0, YAML round-trip, negative rejected.

Plus `test_version_marker.test_marker_keys_are_stable` updated to include the new `owner_node_id` key.

## Test plan
- [x] `pytest tests/test_metadata_hardening.py` — 17 passed
- [x] `pytest tests/test_sealed_crypto.py tests/test_version_marker.py tests/test_master_key_portability.py tests/test_project_seal.py` — 115 passed
- [x] Pre-commit hooks green (black + ruff + scope-aware pytest + evaluation smoke)
- [ ] CI green on PR
- [ ] Manual: enable `seal_padding_bytes=1024` in config, seal a project, verify file sizes vary

🤖 Generated with [Claude Code](https://claude.com/claude-code)