### PR TITLE
fix(pages): mirror docs/ path so image references resolve

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,9 +32,13 @@ jobs:
 
       - name: Prepare publish directory
         run: |
-          mkdir -p public
+          # index.html references images via "docs/assets/..." paths
+          # (relative to the repo root). Pages serves from this publish
+          # dir, so we must mirror the source layout — otherwise every
+          # `<img src="docs/assets/...">` 404s on the live site.
+          mkdir -p public/docs
           [ -f index.html ] && cp index.html public/ || true
-          cp -r docs/assets public/ 2>/dev/null || true
+          cp -r docs/assets public/docs/ 2>/dev/null || true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## The bug

`index.html` references all assets via `docs/assets/...`:
- `<link rel="icon" href="docs/assets/brand/axon-favicon.svg">`
- `<img src="docs/assets/repl-animation.gif">`
- `<img src="docs/assets/vscode-graph-panel.png">`
- `<img src="docs/assets/AxonCopilot.gif">`
- `<link rel="icon" href="docs/assets/axon-mark.png">`

The Pages workflow copied `docs/assets` directly into `public/`, flattening to `public/assets/...`. Pages serves from `public/`, so every reference resolved to `<site>/docs/assets/<file>` → 404. Live landing page showed broken image icons.

## Fix

```diff
-          mkdir -p public
+          mkdir -p public/docs
           [ -f index.html ] && cp index.html public/ || true
-          cp -r docs/assets public/ 2>/dev/null || true
+          cp -r docs/assets public/docs/ 2>/dev/null || true
```

Now `public/` mirrors the source repo layout — the same paths the local file:// preview already used.

## Test plan
- [x] Reviewed all `<img src=` and `<link href=` in index.html — all use `docs/assets/...`
- [x] Verified all 5 referenced files exist under `docs/assets/` in the repo
- [ ] CI green on this PR
- [ ] After merge, Pages rebuilds — confirm landing page images load on the live URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)