### PR TITLE
docs(getting-started): refresh stale tool count for v0.4.0

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -336,7 +336,7 @@ Open `http://localhost:8501` in your browser if it doesn't open automatically.
 
 ## Entry Point 5 — MCP Server (for AI coding agents)
 
-> **What is MCP?** Model Context Protocol is an open standard that lets AI coding agents call external tools programmatically. This is different from the VS Code extension (Entry Point 2): the extension gives you an `@axon` chat participant inside Copilot Chat; the MCP server gives any MCP-compatible agent direct access to all 48 Axon tools without a chat interface.
+> **What is MCP?** Model Context Protocol is an open standard that lets AI coding agents call external tools programmatically. This is different from the VS Code extension (Entry Point 2): the extension gives you an `@axon` chat participant inside Copilot Chat; the MCP server gives any MCP-compatible agent direct access to all 51 Axon tools without a chat interface.
 
 `axon-mcp` is a standard stdio server built on the open MCP protocol. It works with **Claude Code, Claude Desktop, OpenAI Codex CLI, OpenAI Codex Desktop, Google Gemini CLI, Cursor, VS Code Copilot agent mode**, and any other MCP-compatible tool.
 


### PR DESCRIPTION
## Summary
- Update `docs/GETTING_STARTED.md` line 339 to reflect v0.4.0''s MCP tool count (48 -> 51).

v0.4.0 added 3 new MCP tools (`suggest_passphrase`, `set_keyring_mode`, `wipe_sealed_cache`).

## Test plan
- [x] Doc-only change; pre-commit passes.