### PR TITLE
docs(setup): refresh stale tool counts for v0.4.0

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -955,7 +955,7 @@ Expected: `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",...}
 
 ### Available MCP tools
 
-For the full list of all 48 tools with parameter tables, see [MCP_TOOLS.md](MCP_TOOLS.md). v0.3.2 adds `graph_retrieve` (point-in-time), `graph_conflicts`, and capability-flagged `graph_finalize`.
+For the full list of all 51 tools with parameter tables, see [MCP_TOOLS.md](MCP_TOOLS.md). v0.3.2 adds `graph_retrieve` (point-in-time), `graph_conflicts`, and capability-flagged `graph_finalize`.
 
 > **Tip:** use `search_knowledge` (not `query_knowledge`) in agent mode — the agent's own LLM synthesises the answer from raw chunks, so no Ollama is required.
 
@@ -1073,7 +1073,7 @@ Copilot will call `list_knowledge` or `list_projects` automatically. You can als
 @axon search for information about neural networks
 ```
 
-### Available tools (44 total)
+### Available tools (39 VS Code LM tools)
 
 > v0.3.2 added `graph_retrieve` (point-in-time, with `--at TS`), `graph_conflicts`, and capability-flagged `graph_finalize` to this list. Run `axon-ext` (or open the Axon: Show Tools command in VS Code) to list everything live.
 


### PR DESCRIPTION
## Summary
- `docs/SETUP.md` line 958: "all 48 tools" -> "all 51 tools" (v0.4.0 added `suggest_passphrase`, `set_keyring_mode`, `wipe_sealed_cache`)
- `docs/SETUP.md` line 1076: "Available tools (44 total)" -> "Available tools (39 VS Code LM tools)" (legacy mistake; actual count from `integrations/vscode-axon/package.json::contributes.languageModelTools`)

## Test plan
- [x] `pre-commit run --files docs/SETUP.md` passes (trim-trailing-whitespace + check-yaml)
- [x] Doc-only change; no code paths affected