### PR TITLE
docs(development): refresh stale endpoint count for v0.4.0

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,7 +89,7 @@ Axon/
 ├── src/axon/          # Main package
 │   ├── main.py             # Core RAG engine
 │   ├── api.py              # FastAPI app factory and route registration
-│   ├── api_routes/         # Route handlers (68 endpoints across 12 files)
+│   ├── api_routes/         # Route handlers (73 endpoints across 12 files)
 │   ├── webapp.py           # Streamlit UI
 │   ├── loaders.py          # Document loaders
 │   ├── retrievers.py       # Search implementations


### PR DESCRIPTION
## Summary
- Update `docs/DEVELOPMENT.md` `api_routes/` count from 68 to 73 endpoints (v0.4.0 added 3 new REST endpoints: `GET /suggestions/passphrase`, `POST /security/keyring-mode`, `POST /security/wipe-sealed-cache`; baseline already-stale 68 reflects pre-v0.3.2 drift)

## Test plan
- [x] `pre-commit run --files docs/DEVELOPMENT.md` (doc-only)
- [x] No other stale counts (48 MCP / 70 / 44 LM / 68) found in this file