### PR TITLE
docs(mcp-tools): refresh tool count header to 51

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # Axon MCP Tools Reference
 
-Axon exposes a Model Context Protocol (MCP) server (`axon-mcp`) with **48 tools**.
+Axon exposes a Model Context Protocol (MCP) server (`axon-mcp`) with **51 tools**.
 
 > **Which integration should I use?**
 > - **`@axon` chat participant** — install the VS Code extension (VSIX). Gives you a conversational `@axon` inside Copilot Chat. No `.vscode/mcp.json` needed.
@@ -471,7 +471,7 @@ Trigger an audited graph community rebuild via the governance operator endpoint.
 
 ---
 
-## Sealed-Store Security (5)
+## Sealed-Store Security (8)
 
 ### `security_status`
 


### PR DESCRIPTION
## Summary
- Update MCP_TOOLS.md tool count header from 48 to 51 to reflect v0.4.0 additions
- Update Sealed-Store Security section header from (5) to (8) — section already lists `wipe_sealed_cache`, `set_keyring_mode`, and `suggest_passphrase` from previous v0.4.0 PRs but the count was stale

## Test plan
- [x] `pre-commit run --files docs/MCP_TOOLS.md` passes
- [x] No source/test changes — doc-only refresh