### PR TITLE
docs(quickref): add v0.4.0 REPL commands + refresh date

### DIFF
--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -140,6 +140,9 @@ Supported: `.txt`, `.md`, `.py`, `.json`, `.csv`, `.html`, `.docx`, `.pdf`, imag
 > For cloud drives (OneDrive, Dropbox, GDrive): use sealed mode — see [SHARING.md](SHARING.md#sealed-sharing-onedrive--dropbox--google-drive)
 | `/store whoami` | Show AxonStore identity and status |
 | `/store init <path>` | Change the store base path (e.g. to a shared drive) |
+| `/store keyring-mode [persistent\|session\|never]` | Show or set DEK storage mode for sealed projects (persistent = OS keyring; session = in-memory only; never = prompt every time) |
+| `/store wipe-cache` | Wipe the active sealed-project plaintext cache (forces re-decryption on next access) |
+| `/passphrase generate [N]` | Generate a Diceware passphrase from the bundled EFF wordlist (4–12 words; default 6 ≈ 77 bits of entropy) |
 | `/graph status` | Show GraphRAG community build status |
 | `/graph finalize` | Trigger explicit community rebuild (reports `not_applicable` on backends without a community step, e.g. `dynamic_graph`) |
 | `/graph conflicts` | List facts with `status='conflicted'` (dynamic_graph or federated backend); `graphrag` reports unsupported |
@@ -656,5 +659,5 @@ MIT License - See [LICENSE](../LICENSE) file.
 
 ---
 
-**Last Updated:** 2026-03-17
+**Last Updated:** 2026-05-04
 **Version:** see `axon --version`


### PR DESCRIPTION
## Summary
- Add three v0.4.0 REPL commands to the slash-command table in `docs/QUICKREF.md`:
  - `/passphrase generate [N]` — Diceware passphrase from the bundled EFF wordlist
  - `/store keyring-mode [persistent|session|never]` — show or set DEK storage mode
  - `/store wipe-cache` — wipe the active sealed-project plaintext cache
- Refresh the **Last Updated** footer from 2026-03-17 to 2026-05-04.

No other stale surface counts (MCP / REST / LM tool) were found in this file.

## Test plan
- [x] `pre-commit run --files docs/QUICKREF.md` passes (doc-only change; pytest skipped per scope rules).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>