### PR TITLE
docs: comprehensive v0.4.0 staleness sweep + README hero redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 <div align="center">
-  <!-- Decorative — the wordmark below carries the brand name for screen readers -->
-  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/brand/axon-icon.svg" alt="" width="96" height="96" />
-</div>
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/brand/axon-wordmark.svg" alt="Axon" width="320" />
-</div>
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/repl-animation.gif" alt="Axon REPL — first-run wizard, ingest, and a cited query in action" width="400" />
+  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/brand/axon-wordmark.svg" alt="Axon" width="400" />
 
   <h3>Your documents, answerable. On your hardware.</h3>
 
@@ -23,25 +14,22 @@
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/jyunming/Axon/blob/main/LICENSE)
   [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-</div>
+  <br/>
 
----
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/repl-demo.png" alt="Axon REPL startup" width="820" />
+  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/repl-demo.png" alt="Axon REPL — startup banner, ingest, and a cited query" width="820" />
 </div>
 
 ---
 
 ## 🤔 Why Axon?
 
-Most RAG tools make you choose between **cloud power** and **data privacy**. Axon runs entirely on your hardware — full capability, zero egress.
+Most RAG tools make you choose between **cloud power** and **data privacy**. Axon is local-first — full capability with zero egress when you run on Ollama or vLLM; cloud providers (OpenAI, Gemini, Grok, GitHub Copilot, Ollama Cloud) stay optional.
 
 - 🔒 **Private by default** — all inference runs locally via Ollama or vLLM. No API key, no upload, no telemetry.
 - 📄 **Ingest anything** — 54 file formats (PDF, DOCX, Jupyter, code, images, URLs) in one command. SHA-256 dedup skips unchanged files.
 - 🤖 **Works in your tools** — `@axon` in Copilot Chat, MCP for Claude Code / Codex / Gemini CLI / Cursor, Graph panel in VS Code or your browser.
 - 🤝 **Built for teams** — share your knowledge base with signed, revocable read-only keys. Sealed (AES-256-GCM encrypted) sharing works safely through OneDrive, Dropbox, and Google Drive. Per-user permissions, full audit trail, no extra infrastructure. [Quick setup →](#sealed-sharing-quick-start)
-- 🕸️ **See your knowledge as a graph** — interactive 3D entity-relationship graph. Embedded webview in VS Code; opens in your browser everywhere else. Click any node to jump to the exact source line.
+- 🕸️ **See your knowledge as a graph** — interactive 3D entity-relationship graph. Embedded webview in VS Code; opens in your browser everywhere else. Click any node to inspect its supporting chunks and source excerpt.
 - 🔬 **Production-grade retrieval** — hybrid search, reranking, HyDE, multi-query expansion, and automatic web fallback. Zero manual tuning.
 
 ---
@@ -126,8 +114,8 @@ Files are ciphertext on disk — cloud providers see only encrypted bytes.
 ### 🛡️ Governance & Agents
 - **Governance Console** — full audit trail of every query
 - Graceful maintenance states: `normal → draining → readonly → offline`
-- **REST API** — 70 endpoints with Swagger docs at `/docs`
-- **MCP server** — 48 tools for Claude Code, Codex, Gemini, Cursor, Copilot
+- **REST API** — 73 endpoints with Swagger docs at `/docs`
+- **MCP server** — 51 tools for Claude Code, Codex, Gemini, Cursor, Copilot
 - **`@axon`** VS Code chat participant with Graph and Governance panels
 
 </td>
@@ -144,6 +132,15 @@ axon                              # First run auto-launches the setup wizard, th
 ```
 
 That's it. The wizard configures your LLM provider, embedding model, and retrieval defaults; subsequent runs go straight to the REPL.
+
+<details>
+<summary><b>See it run — first-run wizard, ingest, and a cited query</b></summary>
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/jyunming/Axon/main/docs/assets/repl-animation.gif" alt="Axon REPL — first-run wizard, ingest, and a cited query in action" width="640" />
+</div>
+
+</details>
 
 If something doesn't look right:
 
@@ -220,9 +217,9 @@ Extensions panel  →  "..."  →  Install from VSIX...
 →  run `axon-ext`  (or install from VSIX manually)
 ```
 
-Or connect via MCP for Copilot agent mode — point `.vscode/mcp.json` at `axon-mcp` and all 48 tools appear in the agent hammer menu automatically.
+Or connect via MCP for Copilot agent mode — point `.vscode/mcp.json` at `axon-mcp` and all 51 tools appear in the agent hammer menu automatically.
 
-> The VS Code extension surfaces **44 LM tools** to Copilot Chat, covering core RAG operations, sealed-store security, sharing, and governance.
+> The VS Code extension surfaces **39 LM tools** to Copilot Chat, covering core RAG operations, sealed-store security, sharing, and governance.
 
 **[Full setup guide →](https://github.com/jyunming/Axon/blob/main/docs/SETUP.md)**
 
@@ -272,7 +269,7 @@ Per-call overrides (e.g. force HyDE for one question): `retriever.with_overrides
 | 🔑 | **[Admin Reference](https://github.com/jyunming/Axon/blob/main/docs/ADMIN_REFERENCE.md)** | Every endpoint, REPL command, CLI flag, and config option |
 | ⚡ | **[Quick Reference](https://github.com/jyunming/Axon/blob/main/docs/QUICKREF.md)** | Commands and flags at a glance |
 | 📡 | **[API Reference](https://github.com/jyunming/Axon/blob/main/docs/API_REFERENCE.md)** | Full REST endpoint reference with request/response schemas |
-| 🔌 | **[MCP Tools](https://github.com/jyunming/Axon/blob/main/docs/MCP_TOOLS.md)** | All 48 MCP tool signatures with parameter defaults |
+| 🔌 | **[MCP Tools](https://github.com/jyunming/Axon/blob/main/docs/MCP_TOOLS.md)** | All 51 MCP tool signatures with parameter defaults |
 
 **Deep dives**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Most RAG tools make you choose between **cloud power** and **data privacy**. Axon is local-first — full capability with zero egress when you run on Ollama or vLLM; cloud providers (OpenAI, Gemini, Grok, GitHub Copilot, Ollama Cloud) stay optional.
 
-- 🔒 **Private by default** — all inference runs locally via Ollama or vLLM. No API key, no upload, no telemetry.
+- 🔒 **Private by default** — local inference via Ollama or vLLM is the recommended path; cloud providers (OpenAI, Gemini, Grok, GitHub Copilot, Ollama Cloud) remain opt-in. No telemetry. Strict offline / air-gap mode shuts every outbound call off entirely.
 - 📄 **Ingest anything** — 54 file formats (PDF, DOCX, Jupyter, code, images, URLs) in one command. SHA-256 dedup skips unchanged files.
 - 🤖 **Works in your tools** — `@axon` in Copilot Chat, MCP for Claude Code / Codex / Gemini CLI / Cursor, Graph panel in VS Code or your browser.
 - 🤝 **Built for teams** — share your knowledge base with signed, revocable read-only keys. Sealed (AES-256-GCM encrypted) sharing works safely through OneDrive, Dropbox, and Google Drive. Per-user permissions, full audit trail, no extra infrastructure. [Quick setup →](#sealed-sharing-quick-start)

--- a/docs/ADMIN_REFERENCE.md
+++ b/docs/ADMIN_REFERENCE.md
@@ -318,7 +318,7 @@ axon> Compare @report.pdf with @notes.docx
 
 ## 4. REST API Reference
 
-**68 endpoints** across 12 route files. Base URL: `http://localhost:8000` (default).
+**73 endpoints** across 12 route files. Base URL: `http://localhost:8000` (default).
 
 Interactive docs: `/docs` (Swagger UI), `/redoc`.
 
@@ -495,7 +495,7 @@ Exposed metrics: `axon_requests_total` (Counter, labels: `path/method/status`), 
 
 ## 5. MCP Tools Reference
 
-44 tools are registered when running `axon-mcp`.
+51 tools are registered when running `axon-mcp`.
 
 ### 5.1 Ingestion (6)
 
@@ -563,7 +563,7 @@ Returns: `ingest_path` / `ingest_url` → `{"job_id": "..."}`. `get_job_status` 
 | `list_shares` | — | List outgoing and incoming shares |
 | `refresh_mount` | — | Force-refresh a mounted shared project's handles |
 
-### 5.8 Security (Sealed Store) (6)
+### 5.8 Security (Sealed Store) (9)
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
@@ -573,6 +573,9 @@ Returns: `ingest_path` / `ingest_url` → `{"job_id": "..."}`. `get_job_status` 
 | `security_lock` | — | Lock the sealed-store (clear in-process key cache) |
 | `security_change_passphrase` | `old_passphrase` (str), `new_passphrase` (str) | Rotate the sealed-store passphrase |
 | `seal_project` | `project_name` (str), `migration_mode` (str, default `"in_place"`) | Encrypt all content files in a project at rest |
+| `suggest_passphrase` | `words` (int, optional, 4-12, default 6), `separator` (str, optional, default "-") | Diceware passphrase from EFF wordlist. v0.4.0 Item 1 |
+| `set_keyring_mode` | `mode` (str, required, "persistent"\|"session"\|"never") | Change DEK storage mode at runtime. v0.4.0 Item 2 |
+| `wipe_sealed_cache` | (no params) | Wipe the active sealed-project plaintext cache. Returns `{wiped: bool}`. v0.4.0 Item 3 |
 
 ### 5.9 Graph (4)
 

--- a/docs/AXON_STORE.md
+++ b/docs/AXON_STORE.md
@@ -105,10 +105,10 @@ The `username` is your OS username. `store_path` is the `AxonStore/` directory i
 
 ## 4. Sharing a Project
 
-Two share modes ship in v0.3.x:
+Two share modes ship in v0.4.0:
 
 - **Plaintext shares** (`sk_xxxxxxxx` key IDs) — HMAC-signed, used for unsealed projects on a shared filesystem
-- **Sealed shares** (`ssk_xxxxxxxx` key IDs, `SEALED1:`-prefixed envelope) — AES-256-GCM at rest with a per-grantee AES-KW wrap; safe through OneDrive / Dropbox / Google Drive (cloud sees ciphertext only)
+- **Sealed shares** (`ssk_xxxxxxxx` key IDs, `SEALED2:`-prefixed envelope) — AES-256-GCM at rest with a per-grantee AES-KW wrap, plus an embedded owner Ed25519 pubkey so the grantee can verify signed metadata sidecars (e.g. expiry) without an owner round-trip. Safe through OneDrive / Dropbox / Google Drive (cloud sees ciphertext only). The legacy `SEALED1:` envelope (v0.3.x; 6 fields, no embedded pubkey) is **never minted** by v0.4.0+ generators but is still accepted on redeem so old share strings keep working.
 
 `/share/generate` automatically picks the right mode based on whether the project is sealed (`axon --project-seal <project>`).
 
@@ -118,7 +118,7 @@ Two share modes ship in v0.3.x:
 |-----------|------|---------|-------------|
 | `project` | string | required | Name of the project to share |
 | `grantee` | string | required | OS username of the recipient |
-| `ttl_days` | int \| null | `null` | Positive integer days from creation until the share expires. `null` = no expiry. **v0.4.0:** honoured by both sealed (`ssk_`) and plaintext (`sk_`) shares. For sealed shares this writes an Ed25519-signed expiry sidecar next to the wrap; the grantee's mount fails with `ShareExpiredError` after expiry and auto-destroys the local DEK + cache + mount descriptor. `ttl_days <= 0` returns 422. |
+| `ttl_days` | int \| null | `null` | Positive integer days from creation until the share expires. `null` = no expiry. **v0.4.0:** honoured by **both** plaintext (`sk_`) and sealed (`ssk_`) shares — the v0.3.x plaintext-only restriction is gone. For sealed shares this writes an Ed25519-signed expiry sidecar next to the wrap (see [§4.1](#41-expiry-sidecar-shape)); the grantee's mount fails with `ShareExpiredError` after expiry and auto-destroys the local DEK + cache + mount descriptor (see [§4.2](#42-auto-destroy-lifecycle)). `ttl_days <= 0` returns 422. |
 
 > See [SHARING.md](SHARING.md) for the full sealed-share threat model, sync-folder prerequisites, and the `pip install "axon-rag[sealed]"` (or `[starter]`) extras.
 
@@ -148,10 +148,54 @@ curl -X POST http://localhost:8000/share/generate \
 
 The `share_string` is a base64 envelope:
 - Plaintext: base64 of an HMAC-signed payload
-- Sealed (v0.4.0+, default for all newly minted sealed shares): base64 of `SEALED2:<key_id>:<token_hex>:<owner>:<project>:<store_path>:<owner_pubkey_hex>` — the trailing field is the owner's Ed25519 signing pubkey so the grantee can verify the expiry sidecar (when present) without an owner round-trip
-- Sealed legacy (`SEALED1:` — 6 fields, no embedded pubkey): only emitted by pre-v0.4.0 builds. Still accepted on redeem for backward compatibility. Will not carry an expiry sidecar.
+- Sealed (v0.4.0+, default for every newly minted sealed share): base64 of 7 colon-separated fields — `SEALED2:<key_id>:<token_hex>:<owner>:<project>:<store_path>:<owner_pubkey_hex>`. The trailing field is the owner's Ed25519 signing pubkey (64 hex chars) so the grantee can verify the expiry sidecar (when present) without an owner round-trip.
+- Sealed legacy (`SEALED1:` — 6 fields, no embedded pubkey): never minted by v0.4.0+. Still accepted on redeem for backward compatibility, but mounts created from a `SEALED1:` string cannot enforce TTL (no recorded pubkey to verify the sidecar against). To get TTL gating on a legacy share, re-mint as `SEALED2:` and revoke the old key_id.
 
 Send it out-of-band (Signal, encrypted email — never the same channel as the data). All shares are **read-only** — there is no `write_access` capability.
+
+### 4.1 Expiry sidecar shape
+
+When `ttl_days` is set on a sealed share, the owner writes a signed sidecar to:
+
+```
+<owner-store>/<project>/.security/shares/<key_id>.expiry
+```
+
+The file is JSON with three fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key_id` | string | Echoes the share `key_id` (e.g. `ssk_a4f9c1d2`) — must match the filename |
+| `expires_at` | string | ISO 8601 UTC timestamp with trailing `Z` (e.g. `2026-06-03T01:00:00Z`); naive datetimes are rejected |
+| `sig` | string | base64url-encoded Ed25519 signature over `b"<key_id>:<expires_at>"` (the literal byte string formed by joining the two fields with a colon), signed with the owner's master-derived signing key. Verified by the grantee using the pubkey embedded in the `SEALED2:` envelope (recorded in the mount descriptor at redeem time). |
+
+Example sidecar:
+
+```json
+{
+  "key_id": "ssk_a4f9c1d2",
+  "expires_at": "2026-06-03T01:00:00Z",
+  "sig": "k4Pq...base64url..."
+}
+```
+
+The sidecar lives next to the wrap file (`<key_id>.wrapped`) and rides the same sync channel; OneDrive / Dropbox / Drive see opaque JSON bytes. It cannot be re-signed in place (the signing key never leaves the owner) — to extend a sealed share, mint a fresh one and revoke the old `key_id`.
+
+### 4.2 Auto-destroy lifecycle
+
+On every grantee mount of a sealed project, `get_grantee_dek` reads the expiry sidecar and:
+
+1. Verifies the Ed25519 signature with the owner pubkey recorded in the mount descriptor.
+2. Compares `expires_at` against `datetime.now(UTC)`.
+
+If the sidecar is missing the mount proceeds normally (TTL-less share). If the signature fails to verify, or `expires_at` has elapsed, `get_grantee_dek` raises `ShareExpiredError` and `_auto_destroy_expired_share` immediately wipes four pieces of local state:
+
+1. **DEK from the OS keyring** at `axon.share.<key_id>`.
+2. **DEK from the file fallback** at `<grantee-user-dir>/.security/shares/<key_id>.dek.wrapped` (used when the keyring is unavailable or in `keyring_mode=never`).
+3. **Active plaintext cache** for this project (`axon-sealed-*` temp dir) — covers the case where a previous mount staged files before the most recent expiry sidecar landed.
+4. **Mount descriptor** at `<grantee-user-dir>/mounts/<mount_name>/mount.json`, so the project disappears from `list_projects` immediately.
+
+**Encrypted source files on the synced filesystem are deliberately NOT touched.** Deleting them would propagate the deletion back to the owner's source folder via OneDrive / Dropbox / Drive sync — a catastrophically destructive failure mode. The owner manages their own bytes; auto-destroy only cleans up the grantee's local cached state.
 
 ### Extending an existing share
 
@@ -269,10 +313,10 @@ Revoked entries in `sharing` are shown with `"revoked": true`. Entries in `share
 
 - **Shared filesystem required for plaintext.** Sealed shares can ride OneDrive / Dropbox / Google Drive (cloud sees ciphertext only). Plaintext shares require both users to have filesystem access to the same `base_path` set during `store init`.
 
-- **Key security.** Sealed share strings begin (after base64-decode) with `SEALED1:<key_id>:<token_hex>:<owner>:<project>:<store_path>`; plaintext share strings are HMAC-signed payloads. Do not share them over untrusted channels (Signal / encrypted email recommended). Revocation is recorded in the owner's `.share_manifest.json` and validated lazily — at switch time, project-list, and share-list operations.
+- **Key security.** Sealed share strings begin (after base64-decode) with `SEALED2:<key_id>:<token_hex>:<owner>:<project>:<store_path>:<owner_pubkey_hex>` — 7 colon-separated fields. The legacy 6-field `SEALED1:` envelope is still accepted on redeem but is no longer minted. Plaintext share strings are HMAC-signed payloads. Do not share them over untrusted channels (Signal / encrypted email recommended). Revocation is recorded in the owner's `.share_manifest.json` and validated lazily — at switch time, project-list, and share-list operations.
 
 - **Project isolation and hierarchy.** Each user's projects live under `{base_path}/AxonStore/{username}/`. Users cannot read each other's data without an explicit share key. Project names are slash-separated and **nest up to 5 levels deep** (`research/papers/2024/q3/draft`); deeper paths are rejected at validation time (`_MAX_DEPTH` in `projects.py`).
 
 - **Mount layout.** When grantee bob redeems a share for `alice/research/papers`, it appears as `mounts/alice_research_papers` in bob's namespace (the `/` is replaced with `_` in the mount name).
 
-- **Expiry.** Share keys do not expire by default. Pass `ttl_days` at generate time (or extend later via `POST /share/extend`) to set a finite TTL, or revoke explicitly when access should end.
+- **Expiry.** Share keys do not expire by default. Pass `ttl_days` at generate time to set a finite TTL on either share mode (v0.4.0 covers both `sk_` and `ssk_`), or revoke explicitly when access should end. `POST /share/extend` works on plaintext shares only; renew a sealed share by minting a fresh key and revoking the old one. Sealed-share expiry is enforced lazily on the grantee — every mount verifies the signed sidecar and auto-destroys local state on expiry (see [§4.2](#42-auto-destroy-lifecycle)).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,7 +89,7 @@ Axon/
 ├── src/axon/          # Main package
 │   ├── main.py             # Core RAG engine
 │   ├── api.py              # FastAPI app factory and route registration
-│   ├── api_routes/         # Route handlers (68 endpoints across 12 files)
+│   ├── api_routes/         # Route handlers (73 endpoints across 12 files)
 │   ├── webapp.py           # Streamlit UI
 │   ├── loaders.py          # Document loaders
 │   ├── retrievers.py       # Search implementations

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -336,7 +336,7 @@ Open `http://localhost:8501` in your browser if it doesn't open automatically.
 
 ## Entry Point 5 — MCP Server (for AI coding agents)
 
-> **What is MCP?** Model Context Protocol is an open standard that lets AI coding agents call external tools programmatically. This is different from the VS Code extension (Entry Point 2): the extension gives you an `@axon` chat participant inside Copilot Chat; the MCP server gives any MCP-compatible agent direct access to all 48 Axon tools without a chat interface.
+> **What is MCP?** Model Context Protocol is an open standard that lets AI coding agents call external tools programmatically. This is different from the VS Code extension (Entry Point 2): the extension gives you an `@axon` chat participant inside Copilot Chat; the MCP server gives any MCP-compatible agent direct access to all 51 Axon tools without a chat interface.
 
 `axon-mcp` is a standard stdio server built on the open MCP protocol. It works with **Claude Code, Claude Desktop, OpenAI Codex CLI, OpenAI Codex Desktop, Google Gemini CLI, Cursor, VS Code Copilot agent mode**, and any other MCP-compatible tool.
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # Axon MCP Tools Reference
 
-Axon exposes a Model Context Protocol (MCP) server (`axon-mcp`) with **48 tools**.
+Axon exposes a Model Context Protocol (MCP) server (`axon-mcp`) with **51 tools**.
 
 > **Which integration should I use?**
 > - **`@axon` chat participant** — install the VS Code extension (VSIX). Gives you a conversational `@axon` inside Copilot Chat. No `.vscode/mcp.json` needed.
@@ -471,7 +471,7 @@ Trigger an audited graph community rebuild via the governance operator endpoint.
 
 ---
 
-## Sealed-Store Security (5)
+## Sealed-Store Security (8)
 
 ### `security_status`
 

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -140,6 +140,9 @@ Supported: `.txt`, `.md`, `.py`, `.json`, `.csv`, `.html`, `.docx`, `.pdf`, imag
 > For cloud drives (OneDrive, Dropbox, GDrive): use sealed mode — see [SHARING.md](SHARING.md#sealed-sharing-onedrive--dropbox--google-drive)
 | `/store whoami` | Show AxonStore identity and status |
 | `/store init <path>` | Change the store base path (e.g. to a shared drive) |
+| `/store keyring-mode [persistent\|session\|never]` | Show or set DEK storage mode for sealed projects (persistent = OS keyring; session = in-memory only; never = prompt every time) |
+| `/store wipe-cache` | Wipe the active sealed-project plaintext cache (forces re-decryption on next access) |
+| `/passphrase generate [N]` | Generate a Diceware passphrase from the bundled EFF wordlist (4–12 words; default 6 ≈ 77 bits of entropy) |
 | `/graph status` | Show GraphRAG community build status |
 | `/graph finalize` | Trigger explicit community rebuild (reports `not_applicable` on backends without a community step, e.g. `dynamic_graph`) |
 | `/graph conflicts` | List facts with `status='conflicted'` (dynamic_graph or federated backend); `graphrag` reports unsupported |
@@ -656,5 +659,5 @@ MIT License - See [LICENSE](../LICENSE) file.
 
 ---
 
-**Last Updated:** 2026-03-17
+**Last Updated:** 2026-05-04
 **Version:** see `axon --version`

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -955,7 +955,7 @@ Expected: `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",...}
 
 ### Available MCP tools
 
-For the full list of all 48 tools with parameter tables, see [MCP_TOOLS.md](MCP_TOOLS.md). v0.3.2 adds `graph_retrieve` (point-in-time), `graph_conflicts`, and capability-flagged `graph_finalize`.
+For the full list of all 51 tools with parameter tables, see [MCP_TOOLS.md](MCP_TOOLS.md). v0.3.2 adds `graph_retrieve` (point-in-time), `graph_conflicts`, and capability-flagged `graph_finalize`.
 
 > **Tip:** use `search_knowledge` (not `query_knowledge`) in agent mode — the agent's own LLM synthesises the answer from raw chunks, so no Ollama is required.
 
@@ -1073,7 +1073,7 @@ Copilot will call `list_knowledge` or `list_projects` automatically. You can als
 @axon search for information about neural networks
 ```
 
-### Available tools (44 total)
+### Available tools (39 VS Code LM tools)
 
 > v0.3.2 added `graph_retrieve` (point-in-time, with `--at TS`), `graph_conflicts`, and capability-flagged `graph_finalize` to this list. Run `axon-ext` (or open the Axon: Show Tools command in VS Code) to list everything live.
 

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -59,7 +59,7 @@ To set a time limit on the share:
 axon> /share generate research alice --ttl-days 30
 ```
 
-`--ttl-days` is honoured for both plaintext and sealed shares as of v0.4.0 (plaintext-only in v0.3.x). For plaintext shares, the expiry is recorded in the share manifest and enforced by the grantee's client on the next switch or query. To renew or clear a plaintext expiry without re-issuing the share, use `axon --share-extend <key_id> --ttl-days N` (or `--ttl-days 0` to clear). Sealed shares cannot be extended in place — see [Renewing a sealed share](#renewing-a-sealed-share) below.
+`--ttl-days` is honoured for both plaintext and sealed shares as of v0.4.0 (plaintext-only in v0.3.x). For plaintext shares, the expiry is recorded in the share manifest and enforced by the grantee's client on the next switch or query. To renew or clear a plaintext expiry without re-issuing the share, use `axon --share-extend <key_id> --share-ttl-days N` (renew) or `axon --share-extend <key_id>` (omit `--share-ttl-days` to clear); the REPL equivalent is `/share extend <key_id> --ttl-days N` or `/share extend <key_id> --clear`. `ttl_days <= 0` is rejected — there's no `--ttl-days 0` shortcut for clearing. Sealed shares cannot be extended in place — see [Renewing a sealed share](#renewing-a-sealed-share) below.
 
 Step 4 (grantee): Redeem the share
 
@@ -162,7 +162,7 @@ The end-to-end lifecycle:
        "sig": "<base64url-encoded Ed25519 signature over b'<key_id>:<expires_at>'>"
      }
      ```
-     The signature covers the bytes `b"{key_id}:{expires_at}"` exactly. The signing key is derived deterministically from the owner's master via `HKDF-SHA256(master, salt=b"", info=b"axon-share-signing-v1", length=32)`. Wait for **both** files to finish uploading before telling the grantee to redeem.
+     The signature covers the bytes `b"{key_id}:{expires_at}"` exactly. The signing key is derived deterministically from the owner's master via HKDF-SHA256 with `info=b"axon-share-signing-v1"` and a fixed non-empty salt — see `axon.security.signing._SIGNING_SALT` and `SIGNING_HKDF_INFO` for the canonical constants. Wait for **both** files to finish uploading before telling the grantee to redeem.
 2. **Redeem (grantee).** The SEALED2 envelope's 7th field carries the owner's signing pubkey. Axon stores the pubkey in the mount descriptor (`<user_dir>/mounts/<mount_name>/mount.json`) under `owner_pubkey_hex` so it survives across process restarts.
 3. **Mount (grantee).** On every `switch_project` to a sealed mount, Axon reads the mount descriptor's pubkey, fetches the latest `<key_id>.expiry` from the synced FS, verifies the Ed25519 signature against the recorded pubkey, parses `expires_at`, and compares against `datetime.now(timezone.utc)`. Any of these conditions raises `ShareExpiredError`:
    - sidecar JSON is malformed or missing required fields,

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -59,6 +59,8 @@ To set a time limit on the share:
 axon> /share generate research alice --ttl-days 30
 ```
 
+`--ttl-days` is honoured for both plaintext and sealed shares as of v0.4.0 (plaintext-only in v0.3.x). For plaintext shares, the expiry is recorded in the share manifest and enforced by the grantee's client on the next switch or query. To renew or clear a plaintext expiry without re-issuing the share, use `axon --share-extend <key_id> --ttl-days N` (or `--ttl-days 0` to clear). Sealed shares cannot be extended in place — see [Renewing a sealed share](#renewing-a-sealed-share) below.
+
 Step 4 (grantee): Redeem the share
 
 ```bash
@@ -131,15 +133,60 @@ Step 5: Generate a sealed share for the grantee
 axon --share-generate research alice
 ```
 
-Axon detects that the project is sealed and automatically generates a sealed share (key ID starts with `ssk_`). v0.4.0+ always emits a `SEALED2:` envelope carrying the owner's Ed25519 signing pubkey (used to verify the optional expiry sidecar). The legacy `SEALED1:` 6-field format is still accepted on redeem for backward compatibility with pre-v0.4.0 strings, but is no longer minted. Send the share string to the grantee out-of-band.
+Axon detects that the project is sealed and automatically generates a sealed share (key ID starts with `ssk_`). Send the share string to the grantee out-of-band.
 
-To add an expiry (v0.4.0):
+#### SEALED1 vs SEALED2 envelopes
+
+| Envelope | Decoded payload shape | Role in v0.4.0+ |
+|---|---|---|
+| `SEALED1:` | `SEALED1:<key_id>:<token_hex>:<owner>:<project>:<store_path>` (6 colon-separated fields including the prefix) | Legacy redeem-only — accepted for pre-v0.4.0 share strings, never minted by current generators. Mounts succeed but TTL cannot be enforced (no signing key bound to the envelope). |
+| `SEALED2:` | `SEALED2:<key_id>:<token_hex>:<owner>:<project>:<store_path>:<pubkey_hex_64>` (7 fields; the trailing pubkey is split first via `rpartition(":")` so a Windows `store_path` containing `C:\...` parses correctly) | Default in v0.4.0+. The 7th field carries the owner's Ed25519 signing pubkey, derived deterministically from the master via `HKDF-SHA256(master, info=b"axon-share-signing-v1")`. The grantee uses this pubkey to verify the expiry sidecar on every mount. |
+
+#### Sealed-share TTL flow (v0.4.0)
+
+To add an expiry, pass `--ttl-days` at generation time:
 
 ```
 axon> /share generate research alice --ttl-days 30
 ```
 
-This writes two files to the sync folder: the wrapped DEK (`.security/shares/<key_id>.wrapped`, ~40 bytes) and an Ed25519-signed expiry sidecar (`.security/shares/<key_id>.expiry`, ~250 bytes). Wait for both to upload before telling the grantee to redeem. Once the sidecar's `expires_at` passes, the grantee's next mount fails with `ShareExpiredError` and Axon auto-destroys the local DEK + cache + mount descriptor (encrypted source files on the synced FS are never touched).
+The end-to-end lifecycle:
+
+1. **Generate (owner).** Axon mints a SEALED2 envelope and writes two files to `<project>/.security/shares/`:
+   - `<key_id>.wrapped` — the wrapped DEK (~40 bytes).
+   - `<key_id>.expiry` — an Ed25519-signed JSON sidecar (~250 bytes) with the shape:
+     ```json
+     {
+       "key_id": "ssk_a1b2c3d4",
+       "expires_at": "2026-06-01T17:30:00Z",
+       "sig": "<base64url-encoded Ed25519 signature over b'<key_id>:<expires_at>'>"
+     }
+     ```
+     The signature covers the bytes `b"{key_id}:{expires_at}"` exactly. The signing key is derived deterministically from the owner's master via `HKDF-SHA256(master, salt=b"", info=b"axon-share-signing-v1", length=32)`. Wait for **both** files to finish uploading before telling the grantee to redeem.
+2. **Redeem (grantee).** The SEALED2 envelope's 7th field carries the owner's signing pubkey. Axon stores the pubkey in the mount descriptor (`<user_dir>/mounts/<mount_name>/mount.json`) under `owner_pubkey_hex` so it survives across process restarts.
+3. **Mount (grantee).** On every `switch_project` to a sealed mount, Axon reads the mount descriptor's pubkey, fetches the latest `<key_id>.expiry` from the synced FS, verifies the Ed25519 signature against the recorded pubkey, parses `expires_at`, and compares against `datetime.now(timezone.utc)`. Any of these conditions raises `ShareExpiredError`:
+   - sidecar JSON is malformed or missing required fields,
+   - signature verification fails (tampered or wrong key),
+   - `key_id` inside the sidecar doesn't match the share,
+   - `expires_at` is naive / not valid ISO 8601,
+   - `now > expires_at`,
+   - mount descriptor has no `owner_pubkey_hex` (legacy SEALED1 mount — TTL is unenforceable; the sidecar is treated as untrusted and the mount fails closed).
+4. **Auto-destroy (grantee).** When `ShareExpiredError` fires, Axon performs three local cleanups:
+   - **DEK** — deletes from the OS keyring (`axon.share.<key_id>`) and the file fallback at `<user_dir>/.security/shares/<key_id>.dek.wrapped`.
+   - **Plaintext cache** — wipes the active ephemeral cache directory (the temp dir staged for an earlier mount).
+   - **Mount descriptor** — removes `<user_dir>/mounts/<mount_name>/mount.json`, so the project disappears from `list_projects` immediately.
+
+   **Encrypted source files on the synced filesystem are NEVER touched.** Deleting them would propagate the deletion back to the owner via OneDrive/Dropbox/Drive sync — a destructive failure mode. The owner manages their own files; the grantee only manages local state.
+
+If the grantee's clock is behind the owner's by more than the TTL, expiry won't fire on the grantee yet — accept that the comparison is grantee-local. If the grantee's clock is ahead, expiry fires early; the grantee can re-redeem a fresh share to recover.
+
+#### Renewing a sealed share
+
+`POST /share/extend` (and the equivalent `axon --share-extend` / `/share extend` REPL command) only operates on the **plaintext** share manifest. Sealed shares (`ssk_*` key IDs) are not present in that manifest, so calling `/share/extend ssk_...` returns **404 Not Found** by design. To renew a sealed share:
+
+1. Generate a fresh sealed share with the new expiry: `/share generate <project> <grantee> --ttl-days N`.
+2. Send the new SEALED2 string to the grantee.
+3. After the grantee has redeemed and mounted successfully, revoke the old share: `/share revoke <old_key_id> --project <project>`. Use `--rotate` if the old grantee machine is compromised; soft revoke is sufficient if you simply want to retire the old key ID.
 
 ### Grantee setup (3 steps)
 
@@ -152,10 +199,10 @@ axon --store-init "/path/to/OneDrive/AxonStore"
 Step 2: Redeem the sealed share
 
 ```bash
-axon --share-redeem "SEALED1:..."
+axon --share-redeem "SEALED2:..."
 ```
 
-Axon reads the wrapped DEK from the shared folder, derives the decryption key from the share token, and stores the unwrapped DEK in the OS keyring. The share token is discarded from process memory immediately.
+Axon reads the wrapped DEK from the shared folder, derives the decryption key from the share token, and stores the unwrapped DEK in the OS keyring. The share token is discarded from process memory immediately. The redeem path also extracts the owner's Ed25519 signing pubkey from the SEALED2 envelope (7th field) and persists it in the mount descriptor so subsequent mounts can verify the expiry sidecar (see [TTL flow](#sealed-share-ttl-flow-v040) above). Pre-v0.4.0 `SEALED1:` strings still redeem successfully but mount without TTL enforcement — TTL gating requires a SEALED2 envelope to bind the signing key cryptographically to the share.
 
 Step 3: Query the sealed project
 
@@ -229,6 +276,9 @@ axon --share-list
 | `CacheCapacityError: Not enough disk space` | Temp dir needs at least 1.1× the project size free | Free space in OS temp dir or set `TMPDIR` to a larger volume |
 | `SecurityError: Wrapped DEK won't unwrap` / `InvalidTag` | Hard revoke was performed — grantee's cached DEK is stale | Owner must generate a new share; grantee redeems it |
 | `Sealed-share wrap file missing` | Owner revoked or the sync has not delivered the wrap file yet | Wait for sync to complete, then retry |
+| `ShareExpiredError: Sealed share <id> expired at <ts>` | The expiry sidecar's `expires_at` has passed | Owner generates a fresh share with a new `--ttl-days`; grantee redeems. Sealed shares cannot be extended in place — see [Renewing a sealed share](#renewing-a-sealed-share). |
+| `ShareExpiredError: ... signature verification failed` | Sidecar tampered, owner pubkey rotated, or wrong sidecar synced | Owner regenerates the share; grantee redeems. Local DEK + cache + mount descriptor are auto-destroyed; encrypted source files on the synced FS are untouched. |
+| `404 Not Found` from `POST /share/extend` on a sealed key | Sealed shares (`ssk_*`) are not in the plaintext manifest | Mint a fresh sealed share with `--ttl-days` and revoke the old one |
 | OneDrive shows "Files On-Demand" cloud icons on project files | Files are placeholders and will fail mid-query | Right-click the project folder → "Always keep on this device" |
 | Google Drive Stream mode evicts files | Stream mode removes cached files to free disk space | Switch to Mirror mode in Google Drive preferences |
 

--- a/index.html
+++ b/index.html
@@ -2169,7 +2169,7 @@
     <div class="axes-head">
         <div class="eyebrow reveal">— Why Axon —</div>
         <h2 class="reveal">Five axes <span class="ax-em">we refuse to compromise on.</span></h2>
-        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability local-first — zero egress when you run on Ollama or vLLM, cloud providers optional — and stacks four more constraints on top.</p>
+        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability, local-first — zero egress when you run on Ollama or vLLM; cloud providers optional — and stacks four more constraints on top.</p>
     </div>
 
     <div class="swipe-hint" aria-hidden="true">swipe<span class="arr">→</span>to explore the five axes</div>

--- a/index.html
+++ b/index.html
@@ -2169,7 +2169,7 @@
     <div class="axes-head">
         <div class="eyebrow reveal">— Why Axon —</div>
         <h2 class="reveal">Five axes <span class="ax-em">we refuse to compromise on.</span></h2>
-        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability with zero egress — and stacks four more constraints on top.</p>
+        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability local-first — zero egress when you run on Ollama or vLLM, cloud providers optional — and stacks four more constraints on top.</p>
     </div>
 
     <div class="swipe-hint" aria-hidden="true">swipe<span class="arr">→</span>to explore the five axes</div>
@@ -2311,9 +2311,9 @@
     <div class="pullquote-inner reveal">
         <div class="pullquote-mark">"</div>
         <p class="pullquote-text">
-            Cloud RAG sells <em>convenience</em>. Vanilla local RAG sells <em>control</em>. We refuse to choose — and we add <span class="pq-em">three constraints nobody else takes on</span>: the graph remembers when, the share survives without infrastructure, and the conflicts get surfaced instead of swept aside.
+            Cloud RAG sells <em>convenience</em>. Vanilla local RAG sells <em>control</em>. We get most of the convenience and all of the control — and we add <span class="pq-em">three constraints few local-first RAG engines combine</span>: the graph remembers when, the share survives without infrastructure, and the conflicts get surfaced instead of swept aside.
         </p>
-        <div class="pullquote-attr">— Axon design constraint · since v0.1</div>
+        <div class="pullquote-attr">— Axon design constraint</div>
     </div>
 </section>
 
@@ -2322,7 +2322,7 @@
     <div class="compare-head">
         <div class="eyebrow reveal">— Versus —</div>
         <h2 class="reveal">How it stacks up <span class="ax-em">against the alternatives.</span></h2>
-        <p class="reveal">Cloud sells convenience, local sells control. Axon refuses to choose.</p>
+        <p class="reveal">Cloud sells convenience, local sells control. Axon: most of the convenience, all of the control.</p>
     </div>
 
     <div class="reveal" style="overflow-x:auto">
@@ -2397,7 +2397,7 @@
             <div class="sc-tile-meta">
                 <span class="sc-tile-num">02</span>
                 <span class="sc-tile-name">VS Code · @axon</span>
-                <span class="sc-tile-tag">44 LM tools · 3D graph webview</span>
+                <span class="sc-tile-tag">39 LM tools · 3D graph webview</span>
             </div>
         </div>
         <div class="sc-tile reveal" style="transition-delay:0.1s">
@@ -2767,7 +2767,7 @@ results, diagnostics, trace = brain.<span class="cf">search_raw</span>(
     <div class="container">
         <div class="footer-eyebrow reveal">— pip install axon-rag —</div>
         <h2 class="footer-title reveal">Ready to index<br><span class="ax-em">your world?</span></h2>
-        <p class="footer-sub reveal">No cloud APIs. No telemetry. No subscription. Open source, MIT licensed. Runs on your laptop today.</p>
+        <p class="footer-sub reveal">Local-first. Cloud-optional. No telemetry. No subscription. Open source, MIT licensed. Runs on your laptop today.</p>
 
         <div class="reveal" style="margin-bottom:48px">
             <div class="footer-install">

--- a/index.template.html
+++ b/index.template.html
@@ -2169,7 +2169,7 @@
     <div class="axes-head">
         <div class="eyebrow reveal">— Why Axon —</div>
         <h2 class="reveal">Five axes <span class="ax-em">we refuse to compromise on.</span></h2>
-        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability local-first — zero egress when you run on Ollama or vLLM, cloud providers optional — and stacks four more constraints on top.</p>
+        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability, local-first — zero egress when you run on Ollama or vLLM; cloud providers optional — and stacks four more constraints on top.</p>
     </div>
 
     <div class="swipe-hint" aria-hidden="true">swipe<span class="arr">→</span>to explore the five axes</div>

--- a/index.template.html
+++ b/index.template.html
@@ -2169,7 +2169,7 @@
     <div class="axes-head">
         <div class="eyebrow reveal">— Why Axon —</div>
         <h2 class="reveal">Five axes <span class="ax-em">we refuse to compromise on.</span></h2>
-        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability with zero egress — and stacks four more constraints on top.</p>
+        <p class="reveal">Most RAG tools force a trade between cloud power and data privacy. Axon delivers full capability local-first — zero egress when you run on Ollama or vLLM, cloud providers optional — and stacks four more constraints on top.</p>
     </div>
 
     <div class="swipe-hint" aria-hidden="true">swipe<span class="arr">→</span>to explore the five axes</div>
@@ -2311,9 +2311,9 @@
     <div class="pullquote-inner reveal">
         <div class="pullquote-mark">"</div>
         <p class="pullquote-text">
-            Cloud RAG sells <em>convenience</em>. Vanilla local RAG sells <em>control</em>. We refuse to choose — and we add <span class="pq-em">three constraints nobody else takes on</span>: the graph remembers when, the share survives without infrastructure, and the conflicts get surfaced instead of swept aside.
+            Cloud RAG sells <em>convenience</em>. Vanilla local RAG sells <em>control</em>. We get most of the convenience and all of the control — and we add <span class="pq-em">three constraints few local-first RAG engines combine</span>: the graph remembers when, the share survives without infrastructure, and the conflicts get surfaced instead of swept aside.
         </p>
-        <div class="pullquote-attr">— Axon design constraint · since v0.1</div>
+        <div class="pullquote-attr">— Axon design constraint</div>
     </div>
 </section>
 
@@ -2322,7 +2322,7 @@
     <div class="compare-head">
         <div class="eyebrow reveal">— Versus —</div>
         <h2 class="reveal">How it stacks up <span class="ax-em">against the alternatives.</span></h2>
-        <p class="reveal">Cloud sells convenience, local sells control. Axon refuses to choose.</p>
+        <p class="reveal">Cloud sells convenience, local sells control. Axon: most of the convenience, all of the control.</p>
     </div>
 
     <div class="reveal" style="overflow-x:auto">
@@ -2397,7 +2397,7 @@
             <div class="sc-tile-meta">
                 <span class="sc-tile-num">02</span>
                 <span class="sc-tile-name">VS Code · @axon</span>
-                <span class="sc-tile-tag">44 LM tools · 3D graph webview</span>
+                <span class="sc-tile-tag">39 LM tools · 3D graph webview</span>
             </div>
         </div>
         <div class="sc-tile reveal" style="transition-delay:0.1s">
@@ -2767,7 +2767,7 @@ results, diagnostics, trace = brain.<span class="cf">search_raw</span>(
     <div class="container">
         <div class="footer-eyebrow reveal">— pip install axon-rag —</div>
         <h2 class="footer-title reveal">Ready to index<br><span class="ax-em">your world?</span></h2>
-        <p class="footer-sub reveal">No cloud APIs. No telemetry. No subscription. Open source, MIT licensed. Runs on your laptop today.</p>
+        <p class="footer-sub reveal">Local-first. Cloud-optional. No telemetry. No subscription. Open source, MIT licensed. Runs on your laptop today.</p>
 
         <div class="reveal" style="margin-bottom:48px">
             <div class="footer-install">


### PR DESCRIPTION
## Summary

Single PR consolidating a full pass of doc truth-checks across 8 user-facing docs + the README hero redesign + landing-page promotional copy fixes. Closes the 8 individual worker PRs (#112–#119) — superseded by this consolidation.

## What changed

**Doc count refreshes (v0.3.2 → v0.4.0)**
| File | Before | After |
|---|---|---|
| `README.md` | 70 endpoints / 48 MCP / 44 LM | 73 / **51** / **39** |
| `docs/SETUP.md` | 48 / 44 | 51 / 39 |
| `docs/GETTING_STARTED.md` | 48 | 51 |
| `docs/MCP_TOOLS.md` | 48 (header + Sealed-Store section sub-count 5→8) | 51 |
| `docs/ADMIN_REFERENCE.md` | 68 / 44 + missing 3 MCP rows | 73 / 51 + new rows for `suggest_passphrase`, `set_keyring_mode`, `wipe_sealed_cache` |
| `docs/QUICKREF.md` | "Last Updated: 2026-03-17" + missing v0.4.0 REPL commands | 2026-05-04 + new rows for `/passphrase generate`, `/store keyring-mode`, `/store wipe-cache` |
| `docs/DEVELOPMENT.md` | 68 endpoints | 73 |

**Sealed-TTL flow now documented end-to-end (`docs/AXON_STORE.md` + `docs/SHARING.md`)**
- SEALED2 envelope (7 fields, embedded owner pubkey) is now the default; SEALED1 is legacy-redeem-only.
- Expiry sidecar JSON shape: `{key_id, expires_at (ISO 8601 Z), sig (base64url Ed25519 over b"<key_id>:<expires_at>")}`.
- `ttl_days` honoured for both `sk_` and `ssk_` shares (was plaintext-only in v0.3.x).
- Auto-destroy lifecycle on grantee mount: wipes keyring DEK + file fallback + plaintext cache + mount descriptor; encrypted source files on synced FS NEVER touched.
- Renewal pattern for sealed: `/share/extend` returns 404; mint fresh + revoke old.

**README hero redesign**
- Drop the standalone 96×96 axon-icon block from the hero (wordmark already carries the brand).
- Move the REPL animation gif out of the hero into a `<details>` collapsible under Quick Start.
- Static `repl-demo.png` becomes the hero confidence shot.

**Landing-page truth fixes (`index.template.html` → re-rendered `index.html`)**
- Showcase tile "44 LM tools" → "39 LM tools".
- Footer "No cloud APIs" → "Cloud-optional" (Axon supports OpenAI/Gemini/Grok/Copilot/Ollama Cloud as optional providers).
- Five Axes intro: hedged from absolute "zero egress" to "local-first — zero egress when you run on Ollama or vLLM, cloud providers optional".
- Pull-quote: "three constraints nobody else takes on" → "few local-first RAG engines combine"; "since v0.1" attribution dropped (sealed sharing landed in #57/#58, not v0.1); "We refuse to choose" → "We get most of the convenience and all of the control".
- Compare-section subhead: matched same softening.

**README copy hedging**
- "Axon runs entirely on your hardware — full capability, zero egress" → hedged with "Axon is local-first — full capability with zero egress when you run on Ollama or vLLM; cloud providers (OpenAI, Gemini, Grok, GitHub Copilot, Ollama Cloud) stay optional".
- "Click any node to jump to the exact source line" → "Click any node to inspect its supporting chunks and source excerpt" (the JS viewer + VS Code panel surface chunks/excerpt but don't openTextDocument/revealRange).

## Verification
- `python scripts/audit_packaging.py` — PASSED, including the `index.html vs template: in sync` check
- `python scripts/render_index.py --check` — in sync at v0.4.0, 5 substitutions
- All 9 commits passed pre-commit hooks (trim-trailing-whitespace + check-yaml + check-merge-conflicts; doc-only so pytest/black/ruff skipped)

## Closes
Supersedes (will be closed after merge): #112, #113, #114, #115, #116, #117, #118, #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)