### PR TITLE
audit(config-llm): 2 bug fixes

### DIFF
--- a/src/axon/config_wizard.py
+++ b/src/axon/config_wizard.py
@@ -184,23 +184,33 @@ def run_wizard(brain: Any = None, config_path: str = "") -> dict[str, Any]:
         return getattr(cfg, field, default) if cfg else default
 
     # ── Core input helpers ────────────────────────────────────────────────────
-    def _pick(label: str, field: str, choices: list[str], default: Any) -> None:
+    def _pick(label: str, field: str, choices: list, default: Any) -> None:
         """Display a numbered menu and loop until the user picks a valid item.
         Accepts either the number (1-N) or the value string itself.
-        For boolean choices the value stored in *changes* is a Python bool.
+        *choices* may contain strings, ints, or bools; non-string entries are
+        compared via their stringified form but the original-typed value is
+        stored back into *changes*.
         """
+        # Normalise choices to (display_str, original_value) pairs so that
+        # bool/int choices (e.g. [False, True] or [4, 8]) don't blow up when
+        # the menu calls ``.lower()`` for case-insensitive matching.
+        choice_pairs = [(str(c), c) for c in choices]
+        choice_strs = [s for s, _ in choice_pairs]
         raw = _g(field, default)
-        cur_str = str(raw).lower() if isinstance(raw, bool) else str(raw)
-        # Find which menu item matches the current value
-        cur_idx = next((i for i, c in enumerate(choices) if c.lower() == cur_str.lower()), 0)
+        cur_str = str(raw)
+        # Find which menu item matches the current value (case-insensitive).
+        cur_idx = next(
+            (i for i, s in enumerate(choice_strs) if s.lower() == cur_str.lower()),
+            0,
+        )
         print(f"\n  {label}:")
-        for i, c in enumerate(choices, 1):
+        for i, s in enumerate(choice_strs, 1):
             marker = "  ◀ current" if i - 1 == cur_idx else ""
-            print(f"    {i}) {c}{marker}")
+            print(f"    {i}) {s}{marker}")
         while True:
             try:
                 ans = input(
-                    f"  Select [1–{len(choices)}, Enter = keep '{choices[cur_idx]}']: "
+                    f"  Select [1–{len(choice_strs)}, Enter = keep '{choice_strs[cur_idx]}']: "
                 ).strip()
             except EOFError:
                 print()
@@ -213,28 +223,32 @@ def run_wizard(brain: Any = None, config_path: str = "") -> dict[str, Any]:
             # Try as index number
             try:
                 idx = int(ans)
-                if 1 <= idx <= len(choices):
-                    selected = choices[idx - 1]
+                if 1 <= idx <= len(choice_strs):
+                    selected_str, selected_val = choice_pairs[idx - 1]
                     break
-                _err(f"  ✗ Enter a number between 1 and {len(choices)}.")
+                _err(f"  ✗ Enter a number between 1 and {len(choice_strs)}.")
                 continue
             except ValueError:
                 pass
             # Try as the literal value
-            match = next((c for c in choices if c.lower() == ans.lower()), None)
+            match = next(
+                ((s, v) for s, v in choice_pairs if s.lower() == ans.lower()),
+                None,
+            )
             if match:
-                selected = match
+                selected_str, selected_val = match
                 break
             _err(
                 f"  ✗ '{ans}' is not a valid option. "
-                f"Enter a number (1–{len(choices)}) or the value directly."
+                f"Enter a number (1–{len(choice_strs)}) or the value directly."
             )
-        # Store as Python bool for boolean-style menus
+        # Store as Python bool for boolean-style menus when choices are
+        # presented as the strings "true"/"false" (case-insensitive).
         _bool_choices = {"true", "false"}
-        if {c.lower() for c in choices} == _bool_choices:
-            val: Any = selected.lower() in ("true", "1", "yes")
+        if {s.lower() for s in choice_strs} == _bool_choices and not isinstance(selected_val, bool):
+            val: Any = selected_str.lower() in ("true", "1", "yes")
         else:
-            val = selected
+            val = selected_val
         if val != _g(field, default):
             changes[field] = val
 

--- a/src/axon/llm.py
+++ b/src/axon/llm.py
@@ -333,14 +333,19 @@ class OpenLLM:
         return contents
 
     def _get_openai_client(self, base_url: str = None, api_key: str = None):
-        """Return a cached OpenAI client. Pass base_url for vLLM or custom endpoints."""
-        cache_key = base_url or "default"
+        """Return a cached OpenAI client. Pass base_url for vLLM or custom endpoints.
+
+        The cache key includes both ``base_url`` and the resolved API key so that
+        runtime config changes (e.g. ``POST /config/update`` rotating
+        ``openai_api_key``) rebuild the client instead of silently reusing the
+        stale credential.
+        """
+        resolved_key = api_key or self.config.openai_api_key or self.config.api_key or "sk-dummy"
+        base_part = base_url or "default"
+        cache_key = f"{base_part}|{resolved_key}"
         if cache_key not in self._openai_clients:
             from openai import OpenAI
 
-            resolved_key = (
-                api_key or self.config.openai_api_key or self.config.api_key or "sk-dummy"
-            )
             kwargs = {"api_key": resolved_key}
             if base_url:
                 kwargs["base_url"] = base_url
@@ -348,16 +353,20 @@ class OpenLLM:
         return self._openai_clients[cache_key]
 
     def _get_grok_client(self):
-        """Return a cached OpenAI-compatible client for xAI Grok."""
-        cache_key = "_grok"
+        """Return a cached OpenAI-compatible client for xAI Grok.
+
+        The cache key includes the current ``grok_api_key`` so that runtime
+        rotations (e.g. ``POST /config/update``) rebuild the client.
+        """
+        if not self.config.grok_api_key:
+            raise ValueError(
+                "Grok API key not set. "
+                "Export XAI_API_KEY=<key> or set llm.grok_api_key in config.yaml."
+            )
+        cache_key = f"_grok|{self.config.grok_api_key}"
         if cache_key not in self._openai_clients:
             from openai import OpenAI
 
-            if not self.config.grok_api_key:
-                raise ValueError(
-                    "Grok API key not set. "
-                    "Export XAI_API_KEY=<key> or set llm.grok_api_key in config.yaml."
-                )
             self._openai_clients[cache_key] = OpenAI(
                 api_key=self.config.grok_api_key,
                 base_url="https://api.x.ai/v1",

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -10,6 +10,96 @@ def test_wizard_abort():
         assert res == {}
 
 
+def test_wizard_full_mode_tqdb_pick_does_not_crash():
+    """Regression: ``_pick`` previously called ``.lower()`` on bool/int choices
+    (``[False, True]``, ``[4, 8]``), so reaching the turboquantdb knobs in
+    ``full`` mode raised ``AttributeError: 'bool' object has no attribute
+    'lower'``. The fix preserves defaults without crashing.
+    """
+    inputs = [
+        "3",  # mode: full
+        "n",  # skip LLM
+        "n",  # skip Embedding
+        "y",  # enter Vector Store section (full-mode tqdb knobs live here)
+        "1",  # provider: turboquantdb (default — no change)
+        "",  # vector_store.path: keep default
+        "",  # qdrant.url: keep
+        "",  # qdrant.api_key: keep
+        # The tqdb knobs are passed bool/int choices in source; before the
+        # fix they crashed here. Press Enter to keep each default value.
+        "",  # tqdb_bits  (choices = [4, 8])
+        "",  # tqdb_fast_mode  (choices = [False, True])
+        "",  # tqdb_rerank  (choices = [True, False])
+        # Sections 4–16 (full-mode only) are all skipped to keep the test focused.
+        "n",  # skip Chunking
+        "n",  # skip Retrieval
+        "n",  # skip Sentence Window & CRAG-Lite
+        "n",  # skip Reranking
+        "n",  # skip Query Transformations
+        "n",  # skip RAPTOR
+        "n",  # skip GraphRAG
+        "n",  # skip Code Graph
+        "n",  # skip Output
+        "n",  # skip Performance
+        "n",  # skip REPL
+        "n",  # skip Offline
+        "n",  # skip Store & Paths
+    ]
+    with patch("builtins.input", side_effect=inputs):
+        res = run_wizard()
+    # No changes were entered — every section was either skipped or kept its
+    # default value. The point of the test is that this completes without
+    # raising AttributeError.
+    assert "tqdb_bits" not in res
+    assert "tqdb_fast_mode" not in res
+    assert "tqdb_rerank" not in res
+
+
+def test_wizard_full_mode_tqdb_records_typed_values():
+    """When the user picks a non-default tqdb choice the wizard must store
+    the original Python type (int / bool) — not the stringified form — so
+    downstream ``AxonConfig`` writes don't break dataclass invariants.
+    """
+    # With no brain, the wizard's `_pick` defaults are tqdb_bits=8,
+    # tqdb_fast_mode=False, tqdb_rerank=True. Pick the OTHER option for
+    # each so the changes are non-default and visible in `res`.
+    inputs = [
+        "3",  # mode: full
+        "n",  # skip LLM
+        "n",  # skip Embedding
+        "y",  # enter Vector Store
+        "1",  # provider: turboquantdb
+        "",  # path
+        "",  # qdrant.url
+        "",  # qdrant.api_key
+        "1",  # tqdb_bits: index 1 → 4 (wizard default 8 is at index 2)
+        "2",  # tqdb_fast_mode: index 2 → True (wizard default False at index 1)
+        "2",  # tqdb_rerank: index 2 → False (wizard default True at index 1)
+        "n",  # skip Chunking ... onward
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "n",
+        "y",  # save the changes
+    ]
+    with patch("builtins.input", side_effect=inputs), patch("axon.config.AxonConfig.save"):
+        res = run_wizard()
+    assert res.get("tqdb_bits") == 4
+    assert isinstance(res["tqdb_bits"], int) and not isinstance(res["tqdb_bits"], bool)
+    assert res.get("tqdb_fast_mode") is True
+    assert isinstance(res["tqdb_fast_mode"], bool)
+    assert res.get("tqdb_rerank") is False
+    assert isinstance(res["tqdb_rerank"], bool)
+
+
 def test_wizard_quick_mode_minimal():
     # To ensure it shows up in 'res', we must pick something DIFFERENT than default.
     # Default llm_model is 'llama3.1:8b'

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -2854,3 +2854,86 @@ def test_stream_yields_strings_for_provider(provider, extra_kwargs):
     assert len(result) >= 1
 
     assert all(isinstance(tok, str) for tok in result)
+
+
+# ---------------------------------------------------------------------------
+# Audit regression: client cache invalidation on api_key rotation
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIClientCacheKeyInvalidation:
+    """Regression: ``_get_openai_client`` / ``_get_grok_client`` previously
+    cached only by base_url, so a runtime rotation of the configured API key
+    (e.g. ``POST /config/update``) silently reused the stale client.
+    """
+
+    def test_openai_client_rebuilds_after_api_key_change(self):
+        from axon.llm import OpenLLM
+
+        cfg = _make_config(llm_provider="openai", llm_model="gpt-4o", openai_api_key="sk-old")
+
+        mock_openai = MagicMock()
+        mock_openai.OpenAI.side_effect = lambda **kw: MagicMock(_api_key=kw.get("api_key"))
+
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            llm = OpenLLM(cfg)
+            c1 = llm._get_openai_client()
+            assert c1._api_key == "sk-old"
+            # Rotate the key on the live config object — must invalidate cache.
+            llm.config.openai_api_key = "sk-new"
+            c2 = llm._get_openai_client()
+            assert c2._api_key == "sk-new"
+            assert c1 is not c2
+            assert mock_openai.OpenAI.call_count == 2
+
+    def test_openai_client_same_key_is_still_cached(self):
+        """Repeated calls with the same effective key must reuse the client."""
+        from axon.llm import OpenLLM
+
+        cfg = _make_config(llm_provider="openai", llm_model="gpt-4o", openai_api_key="sk-x")
+
+        mock_openai = MagicMock()
+        mock_openai.OpenAI.return_value = MagicMock()
+
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            llm = OpenLLM(cfg)
+            c1 = llm._get_openai_client()
+            c2 = llm._get_openai_client()
+            assert c1 is c2
+            assert mock_openai.OpenAI.call_count == 1
+
+    def test_grok_client_rebuilds_after_api_key_change(self):
+        from axon.llm import OpenLLM
+
+        cfg = _make_config(llm_provider="grok", llm_model="grok-2", grok_api_key="xai-old")
+
+        mock_openai = MagicMock()
+        mock_openai.OpenAI.side_effect = lambda **kw: MagicMock(_api_key=kw.get("api_key"))
+
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            llm = OpenLLM(cfg)
+            c1 = llm._get_grok_client()
+            assert c1._api_key == "xai-old"
+            llm.config.grok_api_key = "xai-new"
+            c2 = llm._get_grok_client()
+            assert c2._api_key == "xai-new"
+            assert c1 is not c2
+            assert mock_openai.OpenAI.call_count == 2
+
+    def test_openai_client_base_url_and_key_compose_in_cache(self):
+        """Cache must distinguish on base_url AND key independently."""
+        from axon.llm import OpenLLM
+
+        cfg = _make_config(llm_provider="openai", llm_model="gpt-4o", openai_api_key="sk-x")
+
+        mock_openai = MagicMock()
+        mock_openai.OpenAI.side_effect = lambda **kw: MagicMock(_kwargs=kw)
+
+        with patch.dict("sys.modules", {"openai": mock_openai}):
+            llm = OpenLLM(cfg)
+            c1 = llm._get_openai_client(base_url="http://a:1/v1")
+            c2 = llm._get_openai_client(base_url="http://b:1/v1")
+            c3 = llm._get_openai_client(base_url="http://a:1/v1")
+            assert c1 is c3
+            assert c1 is not c2
+            assert mock_openai.OpenAI.call_count == 2


### PR DESCRIPTION
## Summary

Parallel-audit unit 2 (Config & LLM Providers) of `src/axon/`. Two unrelated bugs in the LLM client cache and the interactive config wizard.

### 1. `_pick` crashes in `axon --setup` full mode (config_wizard.py)

`_pick(label, field, choices, default)` did `c.lower()` on every element of `choices` to do case-insensitive matching. The Vector Store section passes int/bool choices in full mode:

```python
_pick(\"vector_store.tqdb_bits\", \"tqdb_bits\", [4, 8], 8)
_pick(\"vector_store.tqdb_fast_mode\", \"tqdb_fast_mode\", [False, True], False)
_pick(\"vector_store.tqdb_rerank\", \"tqdb_rerank\", [True, False], True)
```

`(4).lower()` and `(False).lower()` raise `AttributeError: 'bool' object has no attribute 'lower'`. Anyone running `axon --setup` and choosing the **Full** mode crashed the moment the wizard reached the turboquantdb knobs.

**Fix:** normalise choices to `(display_str, original_value)` pairs internally. Display + matching use the strings; the stored value retains its Python type (`int` for `tqdb_bits`, `bool` for `tqdb_fast_mode` / `tqdb_rerank`).

### 2. OpenAI / Grok client cache misses API-key rotation (llm.py)

`_get_openai_client` cached the OpenAI client keyed by `base_url` only. If a user rotated `openai_api_key` at runtime (e.g. `POST /config/update`, or any test that mutates `cfg.openai_api_key`), the cached `OpenAI(api_key=old_key)` instance was reused silently. Same for `_get_grok_client` (single `_grok` cache slot, never invalidated). The Gemini path (line 273) already did this correctly.

**Fix:** include the resolved API key in the cache key so the client is rebuilt on rotation. Validation for missing `grok_api_key` moved out of the cache-miss branch so it always runs.

## Tests

6 new regression tests:

- `test_wizard_full_mode_tqdb_pick_does_not_crash` — full mode reaches tqdb knobs without `AttributeError`
- `test_wizard_full_mode_tqdb_records_typed_values` — selected `int`/`bool` round-trip through `_pick`
- `TestOpenAIClientCacheKeyInvalidation::test_openai_client_rebuilds_after_api_key_change`
- `TestOpenAIClientCacheKeyInvalidation::test_openai_client_same_key_is_still_cached`
- `TestOpenAIClientCacheKeyInvalidation::test_grok_client_rebuilds_after_api_key_change`
- `TestOpenAIClientCacheKeyInvalidation::test_openai_client_base_url_and_key_compose_in_cache`

## Test plan

- [x] `python -m pytest tests/test_config.py tests/test_config_validate.py tests/test_llm_providers.py tests/test_llm_copilot_flow.py tests/test_config_wizard.py tests/test_embeddings_providers.py -v --no-cov` → 246 passed
- [x] `python -m pytest tests/test_lint.py -v --no-cov` → 3 passed (black + ruff + mypy)
- [x] pre-commit hooks green (black 23.12.1, ruff, pytest scope-aware)

## Files

- `src/axon/config_wizard.py` — `_pick` choices normalised to (str, original) pairs
- `src/axon/llm.py` — `_get_openai_client` / `_get_grok_client` cache keys include API key
- `tests/test_config_wizard.py` — +2 regression tests
- `tests/test_llm_providers.py` — +4 regression tests

No version bump. No public-API change.