### PR TITLE
audit(retrieval): 3 bug fixes

### DIFF
--- a/src/axon/rerank.py
+++ b/src/axon/rerank.py
@@ -43,6 +43,10 @@ class OpenReranker:
     def rerank(self, query: str, documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
         Rerank a list of documents based on a query.
+
+        Cross-encoder failures (OOM, model errors, malformed input) are caught
+        and the original document list is returned unchanged, so a transient
+        reranker error never crashes the surrounding query pipeline (audit P1).
         """
         if not self.config.rerank or (not self.model and not self.llm) or not documents:
             return documents
@@ -51,9 +55,13 @@ class OpenReranker:
             return self._llm_rerank(query, documents)
         # Cross-encoder pointwise scoring
         # Prepare pairs: (query, doc_text)
-        pairs = [[query, doc["text"]] for doc in documents]
-        # Get scores
-        scores = self.model.predict(pairs)
+        try:
+            pairs = [[query, doc.get("text", "")] for doc in documents]
+            # Get scores
+            scores = self.model.predict(pairs)
+        except Exception as exc:
+            logger.warning("Cross-encoder reranking failed; returning unranked documents: %s", exc)
+            return documents
         # Add scores to documents and sort
         for doc, score in zip(documents, scores):
             doc["rerank_score"] = float(score)

--- a/src/axon/sentence_window.py
+++ b/src/axon/sentence_window.py
@@ -355,6 +355,11 @@ class SentenceVectorStore:
         normed = self._vecs / norms
         scores: np.ndarray = normed @ q  # shape [N]
         k = min(top_k, len(self._ids))
+        # top_k <= 0 must short-circuit: np.argpartition(scores, -0)[-0:] is
+        # equivalent to scores[0:] and would return ALL rows sorted — the
+        # opposite of what the caller requested. (audit P1)
+        if k <= 0:
+            return []
         # argpartition is O(N) rather than O(N log N) — fast for large N
         top_indices = np.argpartition(scores, -k)[-k:]
         top_indices = top_indices[np.argsort(scores[top_indices])[::-1]]

--- a/src/axon/sparse_retrieval.py
+++ b/src/axon/sparse_retrieval.py
@@ -168,7 +168,16 @@ def fuse_sparse(
     except Exception as exc:
         logger.warning("sparse retrieval failed, falling back to dense-only: %s", exc)
         return dense_results
-    merged: dict[str, dict] = {r["id"]: dict(r) for r in dense_results}
+
+    # Deep-copy entries (and their metadata sub-dicts) before tagging with
+    # "sparse_score" so the caller's input lists are never mutated.
+    def _copy_entry(src: dict) -> dict:
+        copy = dict(src)
+        md = copy.get("metadata")
+        copy["metadata"] = dict(md) if isinstance(md, dict) else {}
+        return copy
+
+    merged: dict[str, dict] = {r["id"]: _copy_entry(r) for r in dense_results}
     dense_max = max((r["score"] for r in dense_results), default=1.0) or 1.0
     sparse_max = max((r["score"] for r in sparse_hits), default=1.0) or 1.0
     for hit in sparse_hits:
@@ -179,12 +188,10 @@ def fuse_sparse(
             merged[doc_id]["score"] = (
                 1.0 - sparse_weight
             ) * dense_norm + sparse_weight * sparse_norm
-            merged[doc_id]["metadata"] = merged[doc_id].get("metadata", {})
             merged[doc_id]["metadata"]["sparse_score"] = round(sparse_norm, 4)
         else:
-            entry = dict(hit)
+            entry = _copy_entry(hit)
             entry["score"] = sparse_weight * sparse_norm
-            entry.setdefault("metadata", {})
             entry["metadata"]["sparse_score"] = round(sparse_norm, 4)
             merged[doc_id] = entry
     return sorted(merged.values(), key=lambda d: d["score"], reverse=True)[:top_k]

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -155,3 +155,51 @@ def test_rerank_returns_input_unchanged_when_disabled():
     docs = [{"text": "doc", "id": "1"}]
     result = r.rerank("query", docs)
     assert result is docs
+
+
+def test_cross_encoder_predict_failure_returns_unranked_docs():
+    """Regression for audit/retrieval P1: a CrossEncoder predict() exception
+    (OOM, model loading error, malformed input) used to propagate out of
+    rerank() and crash the surrounding query pipeline. The contract is now
+    "best-effort": failures degrade to the unranked input list and the caller
+    still gets a usable result.
+    """
+    from axon.rerank import OpenReranker
+
+    r = OpenReranker.__new__(OpenReranker)
+    r.config = _make_cfg("cross-encoder")
+    r.llm = None
+
+    mock_model = MagicMock()
+    mock_model.predict.side_effect = RuntimeError("CUDA out of memory")
+    r.model = mock_model
+
+    docs = [{"text": "a", "id": "1"}, {"text": "b", "id": "2"}]
+    result = r.rerank("query", docs)
+    # Same number of docs returned, in original order, with no rerank_score.
+    assert len(result) == 2
+    assert [d["id"] for d in result] == ["1", "2"]
+    assert all("rerank_score" not in d for d in result)
+
+
+def test_cross_encoder_tolerates_doc_without_text_key():
+    """Regression: missing ``text`` keys should not blow up the cross-encoder
+    rerank path (audit/retrieval P2). We use ``doc.get("text", "")`` to keep
+    the predict call alive even if one doc was malformed upstream.
+    """
+    from axon.rerank import OpenReranker
+
+    r = OpenReranker.__new__(OpenReranker)
+    r.config = _make_cfg("cross-encoder")
+    r.llm = None
+
+    mock_model = MagicMock()
+    mock_model.predict.return_value = [0.1, 0.9]
+    r.model = mock_model
+
+    docs = [{"text": "good", "id": "g"}, {"id": "no_text"}]  # second doc lacks text
+    result = r.rerank("query", docs)
+    assert len(result) == 2
+    # Predict was called with empty string for the missing-text doc.
+    called_pairs = mock_model.predict.call_args[0][0]
+    assert called_pairs[1] == ["query", ""]

--- a/tests/test_sentence_window.py
+++ b/tests/test_sentence_window.py
@@ -131,3 +131,24 @@ def test_citation_integrity():
     for r in records:
         assert r.chunk_id == "stable_chunk_id"
         assert r.source == "important.txt"
+
+
+def test_sentence_vector_store_top_k_zero_returns_empty(tmp_path):
+    """Regression for audit/retrieval P1: top_k=0 used to return ALL rows.
+
+    Cause: ``np.argpartition(scores, -0)[-0:]`` is ``scores[0:]`` — i.e. the
+    entire array. The result was the full corpus sorted by descending score,
+    the opposite of what the caller asked for.
+    """
+    vs = SentenceVectorStore(tmp_path)
+    ids = [f"s{i}" for i in range(5)]
+    vecs = [[float(i), 0.0] for i in range(5)]
+    meta = [{"chunk_id": f"c{i}"} for i in range(5)]
+    vs.add(ids, vecs, meta)
+    assert len(vs) == 5
+    # top_k=0 must produce empty — not the entire index.
+    assert vs.search([1.0, 0.0], top_k=0) == []
+    # Negative top_k must also produce empty (defensive).
+    assert vs.search([1.0, 0.0], top_k=-3) == []
+    # Sanity: a positive top_k still works.
+    assert len(vs.search([1.0, 0.0], top_k=2)) == 2

--- a/tests/test_sparse_retrieval.py
+++ b/tests/test_sparse_retrieval.py
@@ -195,6 +195,33 @@ class TestFuseSparse:
         scores = [r["score"] for r in result]
         assert scores == sorted(scores, reverse=True)
 
+    def test_fuse_does_not_mutate_caller_metadata(self):
+        """Regression for audit/retrieval P2: fuse_sparse used to share the
+        same ``metadata`` dict reference between the caller's dense_results
+        and its merged output, so adding ``sparse_score`` leaked into the
+        original list. The fix deep-copies the metadata sub-dict.
+        """
+        original_meta = {"source": "doc1.txt", "chunk_idx": 0}
+        dense = [
+            {"id": "d1", "text": "text", "score": 0.5, "metadata": original_meta},
+        ]
+        sparse_hit = {"id": "d1", "text": "text", "score": 0.8, "metadata": {}}
+
+        class FixedSparse:
+            def encode_query(self, q):
+                return empty_sparse_vector()
+
+            def search(self, qv, top_k=10, filter_dict=None):
+                return [sparse_hit]
+
+        fuse_sparse(FixedSparse(), "q", dense, top_k=5)
+        # Caller's metadata dict must remain unchanged.
+        assert "sparse_score" not in original_meta
+        assert original_meta == {"source": "doc1.txt", "chunk_idx": 0}
+        # And the original dense entry must not have been mutated.
+        assert dense[0]["metadata"] is original_meta
+        assert dense[0]["score"] == 0.5
+
 
 # ---------------------------------------------------------------------------
 # SpladeSparseRetriever (Phase 1 backend)


### PR DESCRIPTION
## Summary
Three bug fixes from the parallel audit of `src/axon/` (unit 5: retrieval — vector store, retrievers, sparse retrieval, sentence window, rerank).

## Findings

**P1 — `SentenceVectorStore.search(top_k=0)` returned ALL rows** (`src/axon/sentence_window.py`)
- Cause: `np.argpartition(scores, -0)[-0:]` is equivalent to `scores[0:]`, returning the entire array. The caller asked for zero results and got the full sorted corpus.
- Fix: short-circuit `k <= 0` to `return []`.

**P1 — Cross-encoder rerank failures crashed the query pipeline** (`src/axon/rerank.py`)
- Cause: `self.model.predict(pairs)` and `doc["text"]` were unguarded. Any CrossEncoder failure (OOM, model load failure, malformed input) or a doc missing the `"text"` key propagated out to the caller.
- Fix: wrap predict-and-prepare in `try/except`, log a warning, return the unranked input. Use `doc.get("text", "")` so one malformed document does not poison the batch. Matches the existing graceful-degradation contract on the LLM rerank path.

**P2 — `fuse_sparse` mutated caller's metadata dicts** (`src/axon/sparse_retrieval.py`)
- Cause: `merged: dict[str, dict] = {r["id"]: dict(r) for r in dense_results}` is only a shallow copy — the `metadata` sub-dict was still a shared reference. Adding `"sparse_score"` to it leaked into the caller's input list.
- Fix: deep-copy each entry and its metadata sub-dict via a small inline `_copy_entry` helper.

## Test plan
- [x] `pytest tests/test_vector_store.py tests/test_retrievers.py tests/test_sparse_retrieval.py tests/test_sentence_window.py tests/test_rerank.py tests/test_embeddings_providers.py tests/test_vector_store_validation.py tests/test_lint.py --no-cov` — 340 passed, 1 skipped (SPLADE real-model marker)
- [x] Added one regression test per finding
- [x] black==23.12.1 + ruff clean
- [x] Pre-commit hooks (black, ruff, pytest scope-aware, evaluation-smoke) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)