### PR TITLE
audit(api): 8 bug fixes — secret leakage, traversal, DoS caps

### DIFF
--- a/src/axon/api_routes/config_routes.py
+++ b/src/axon/api_routes/config_routes.py
@@ -237,16 +237,23 @@ async def set_config_field(request: ConfigSetRequest):
                 f"Known dot-notation keys: {sorted(_DOT_TO_FLAT.keys())}"
             ),
         )
+    from axon.api_routes.projects import _mask_if_sensitive
+
     old_value = getattr(brain.config, flat_key)
     setattr(brain.config, flat_key, request.value)
     _reinitialize_runtime_components(brain, {flat_key})
     if request.persist:
         brain.config.save()
+    # Mask both old and new values when the field is a secret so the
+    # response cannot be used to exfiltrate API keys (the leaked
+    # ``old_value`` was an information-disclosure bug; ``new_value`` is
+    # an echo of the request body that an attacker controls but masking
+    # both keeps the response shape uniform for client UIs).
     return {
         "status": "success",
         "key": request.key,
         "flat_key": flat_key,
-        "old_value": old_value,
-        "new_value": request.value,
+        "old_value": _mask_if_sensitive(flat_key, old_value),
+        "new_value": _mask_if_sensitive(flat_key, request.value),
         "persisted": request.persist,
     }

--- a/src/axon/api_routes/maintenance.py
+++ b/src/axon/api_routes/maintenance.py
@@ -33,9 +33,14 @@ async def copilot_agent_handler(
     if not brain:
         raise HTTPException(status_code=503, detail="Brain not initialized")
     user_query = body.messages[-1].content if body.messages else ""
+    # ``not user_query`` doesn't catch whitespace-only input; split() on
+    # whitespace produces an empty list and ``parts[0]`` IndexErrors out
+    # of the route, leaking a 500 instead of the intended 400. Strip
+    # first so the empty-query check stays robust.
+    user_query = user_query.strip()
     if not user_query:
         return JSONResponse({"error": "Empty query"}, status_code=400)
-    parts = user_query.strip().split(maxsplit=1)
+    parts = user_query.split(maxsplit=1)
     command = parts[0].lower() if parts[0].startswith("/") else None
     args = parts[1] if len(parts) > 1 else ""
 

--- a/src/axon/api_routes/projects.py
+++ b/src/axon/api_routes/projects.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -49,6 +50,8 @@ def _require_local_turboquantdb(brain, action: str = "This action") -> None:
 _SENSITIVE_FIELDS = frozenset(
     {
         "api_key",
+        "openai_api_key",
+        "grok_api_key",
         "gemini_api_key",
         "ollama_cloud_key",
         "copilot_pat",
@@ -56,6 +59,23 @@ _SENSITIVE_FIELDS = frozenset(
         "qdrant_api_key",
     }
 )
+
+# Session IDs are interpolated directly into ``session_<id>.json`` by
+# ``axon.sessions._session_path`` — restrict to a filesystem-safe
+# alphabet to block traversal-style payloads at the route boundary.
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+def _mask_if_sensitive(flat_key: str, value):
+    """Return ``"***"`` for any known sensitive field with a truthy value.
+
+    Shared with :mod:`axon.api_routes.config_routes` so the masking set
+    stays in lock-step between the ``/config``, ``/config/update`` and
+    ``/config/set`` response shapes.
+    """
+    if flat_key in _SENSITIVE_FIELDS and value:
+        return "***"
+    return value
 
 
 @router.get("/config")
@@ -381,6 +401,13 @@ async def rotate_project_keys(request: ProjectRotateKeysRequest):
     brain = _api.brain
     if brain is None:
         raise HTTPException(status_code=503, detail="Brain not initialized")
+    # ``resolve_owned_sealed_project_path`` joins segments verbatim under
+    # ``user_dir``; without this check a ``..`` segment would let the
+    # caller probe arbitrary filesystem locations for sealed markers.
+    if not _VALID_PROJECT_NAME_RE.match(request.project_name):
+        raise HTTPException(
+            status_code=422, detail=f"Invalid project name: '{request.project_name}'"
+        )
     user_dir = Path(brain.config.projects_root).expanduser().resolve()
     try:
         project_root = _security.resolve_owned_sealed_project_path(request.project_name, user_dir)
@@ -404,6 +431,12 @@ async def seal_project(request: ProjectSealRequest):
     brain = _api.brain
     if brain is None:
         raise HTTPException(status_code=503, detail="Brain not initialized")
+    # ``project_seal`` resolves ``request.project_name`` to a directory
+    # inside the user store; reject ``..`` / backslash segments early.
+    if not _VALID_PROJECT_NAME_RE.match(request.project_name):
+        raise HTTPException(
+            status_code=422, detail=f"Invalid project name: '{request.project_name}'"
+        )
     _require_local_turboquantdb(brain, "Sealing a project")
     user_dir = Path(brain.config.projects_root).expanduser().resolve()
     previously_active = getattr(brain, "_active_project", None)
@@ -453,6 +486,8 @@ async def get_session(session_id: str):
     brain = _api.brain
     if not brain:
         raise HTTPException(status_code=503, detail="Brain not initialized")
+    if not _SESSION_ID_RE.match(session_id):
+        raise HTTPException(status_code=422, detail=f"Invalid session id: '{session_id}'")
     project = getattr(brain, "_active_project", None)
     session = _load_session(session_id, project=project)
     if not session:

--- a/src/axon/api_routes/security_routes.py
+++ b/src/axon/api_routes/security_routes.py
@@ -213,8 +213,13 @@ async def security_bootstrap(request: SecurityBootstrapRequest, req: Request):
 @router.post("/security/unlock")
 async def security_unlock(request: SecurityUnlockRequest, req: Request):
     from axon import security as _security
+    from axon.api_routes._rate_limit import _get_ip
 
-    client_ip = req.client.host if req.client else "unknown"
+    # Use the shared XFF-aware IP helper so the lockout key matches the
+    # client identity the per-IP rate limiter sees. Picking
+    # ``req.client.host`` directly was the proxy IP behind a reverse
+    # proxy, which collapsed every real user onto one shared bucket.
+    client_ip = _get_ip(req)
     now = time.time()
     _evict_stale_unlock_failures(now)
     # Clean up timestamps outside the lockout window

--- a/src/axon/api_routes/shares.py
+++ b/src/axon/api_routes/shares.py
@@ -360,6 +360,17 @@ async def share_revoke(request: ShareRevokeRequest, req: Request):
                     "field so the wrap file can be located."
                 ),
             )
+        # Reject project names that would escape the user directory.
+        # ``_resolve_owned_project_dir`` builds ``user_dir / segments[0] /
+        # subs / segments[1] ...`` without validating segments, so a
+        # ``..`` segment would walk outside the user's store. The
+        # ``share/generate`` route already gates on this regex; mirror
+        # that here so revoke can't be coerced into traversing.
+        if not _VALID_PROJECT_NAME_RE.match(request.project):
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid project name: '{request.project}'",
+            )
         try:
             result = _security.revoke_sealed_share(
                 owner_user_dir=user_dir,

--- a/src/axon/api_schemas.py
+++ b/src/axon/api_schemas.py
@@ -21,6 +21,17 @@ MAX_TEXT_FIELD_CHARS = (
     10_000_000  # characters — ~10 MB of ASCII text; /ingest/upload enforces a separate byte cap
 )
 MAX_URL_FIELD_CHARS = 2048  # characters — RFC 7230 practical maximum
+# A realistic sealed/open share envelope is a few hundred bytes; even
+# the largest SEALED2 form stays well under 4 KB. Cap at 16 KB so a
+# malformed payload can't trigger megabytes of base64 decode + JSON
+# parse work before the validator rejects it. Bumping the cap is
+# cheap if a future envelope shape needs more.
+MAX_SHARE_STRING_CHARS = 16_384
+# Passphrases feed straight into scrypt; a gigabyte input would burn
+# unbounded CPU even on a 401-Bad-Passphrase path. 4 KB is far above
+# any reasonable user-typed passphrase (~64 chars) but small enough
+# that scrypt's wall-clock stays bounded.
+MAX_PASSPHRASE_CHARS = 4096
 
 # ---------------------------------------------------------------------------
 
@@ -377,7 +388,11 @@ class ShareGenerateRequest(BaseModel):
 
 
 class ShareRedeemRequest(BaseModel):
-    share_string: str = Field(..., description="The base64 share string from the owner.")
+    share_string: str = Field(
+        ...,
+        max_length=MAX_SHARE_STRING_CHARS,
+        description="The base64 share string from the owner.",
+    )
 
 
 class ShareRevokeRequest(BaseModel):
@@ -482,17 +497,27 @@ class SecurityBootstrapRequest(BaseModel):
     # Route handlers must call ``.get_secret_value()`` to retrieve the
     # plain string before passing it to the security backend.
     passphrase: SecretStr = Field(
-        ..., description="Passphrase to bootstrap the security store with."
+        ...,
+        max_length=MAX_PASSPHRASE_CHARS,
+        description="Passphrase to bootstrap the security store with.",
     )
 
 
 class SecurityUnlockRequest(BaseModel):
-    passphrase: SecretStr = Field(..., description="Passphrase to unlock the security store.")
+    passphrase: SecretStr = Field(
+        ...,
+        max_length=MAX_PASSPHRASE_CHARS,
+        description="Passphrase to unlock the security store.",
+    )
 
 
 class SecurityChangePassphraseRequest(BaseModel):
-    old_passphrase: SecretStr = Field(..., description="Current passphrase.")
-    new_passphrase: SecretStr = Field(..., description="New passphrase to set.")
+    old_passphrase: SecretStr = Field(
+        ..., max_length=MAX_PASSPHRASE_CHARS, description="Current passphrase."
+    )
+    new_passphrase: SecretStr = Field(
+        ..., max_length=MAX_PASSPHRASE_CHARS, description="New passphrase to set."
+    )
 
 
 class ProjectRotateKeysRequest(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4211,3 +4211,148 @@ class TestShareRevoke:
             with patch("axon.shares.revoke_share_key", return_value={"status": "revoked"}):
                 resp = client.post("/share/revoke", json={"key_id": "k1"})
         assert resp.status_code == 200
+
+
+# ===========================================================================
+# audit/api-routes regression tests
+# ===========================================================================
+
+
+class TestPathTraversalGuards:
+    """Inputs that flow into filesystem paths must be regex-validated up front."""
+
+    def test_share_revoke_sealed_rejects_traversal_project(self):
+        """Sealed revoke uses ``request.project`` to locate the wrap file.
+        Without validation, ``..`` segments would let an attacker probe
+        outside the user store."""
+        with patch("axon.api._get_user_dir") as mock_user_dir:
+            mock_user_dir.return_value = MagicMock()
+            resp = client.post(
+                "/share/revoke",
+                json={"key_id": "ssk_abcd1234", "project": "../etc"},
+            )
+        assert resp.status_code == 422
+
+    def test_share_revoke_sealed_accepts_valid_project_name(self):
+        """Well-formed project names continue to reach the security backend."""
+        with patch("axon.api._get_user_dir") as mock_user_dir:
+            mock_user_dir.return_value = MagicMock()
+            with patch(
+                "axon.security.revoke_sealed_share",
+                return_value={"status": "soft_revoked", "key_id": "ssk_abcd1234"},
+            ):
+                resp = client.post(
+                    "/share/revoke",
+                    json={"key_id": "ssk_abcd1234", "project": "research/papers"},
+                )
+        assert resp.status_code == 200
+
+    def test_rotate_project_keys_rejects_traversal_name(self):
+        brain = _make_brain()
+        brain.config.projects_root = "/tmp/x"
+        api_module.brain = brain
+        resp = client.post("/project/rotate-keys", json={"project_name": "../escape"})
+        assert resp.status_code == 422
+
+    def test_seal_project_rejects_traversal_name(self):
+        brain = _make_brain()
+        brain.config.projects_root = "/tmp/x"
+        brain.config.vector_store = "turboquantdb"
+        brain.config.qdrant_url = ""
+        api_module.brain = brain
+        resp = client.post(
+            "/project/seal", json={"project_name": "..\\windows", "migration_mode": "snapshot"}
+        )
+        assert resp.status_code == 422
+
+    def test_get_session_rejects_traversal_id(self):
+        """Path-style session ids would resolve out of the sessions dir
+        and leak any JSON file the API process can read."""
+        brain = _make_brain()
+        api_module.brain = brain
+        # Starlette normalises ``..`` URL segments before dispatch, so the
+        # remaining vector is a single-segment id whose contents include
+        # path-like punctuation (``.`` is interpolated into the on-disk
+        # filename ``session_<id>.json`` verbatim by ``_session_path``).
+        # The new validator rejects any character outside [A-Za-z0-9_-].
+        for sid in ("foo.bar", "session..bar", "...", "abc/def"):
+            # ``abc/def`` doesn't even match the route pattern (slash is
+            # the segment separator) so it 404s — strictly out of scope
+            # for our handler but worth pinning in case Starlette ever
+            # relaxes its router.
+            resp = client.get(f"/session/{sid}")
+            assert resp.status_code in (404, 422), (sid, resp.status_code, resp.json())
+
+    def test_get_session_accepts_valid_id(self):
+        brain = _make_brain()
+        api_module.brain = brain
+        with patch("axon.sessions._load_session", return_value={"id": "abc123", "messages": []}):
+            resp = client.get("/session/abc123")
+        assert resp.status_code == 200
+
+
+class TestCopilotAgentWhitespaceQuery:
+    """audit/api-routes: whitespace-only Copilot queries used to IndexError."""
+
+    def test_whitespace_only_query_returns_400(self):
+        """maintenance.py: ``user_query=" "`` is truthy but ``strip().split()``
+        is empty; ``parts[0]`` IndexErrors. The fix strips before the
+        empty-check so the route returns the documented 400."""
+        brain = _make_brain()
+        api_module.brain = brain
+        body = {
+            "messages": [{"role": "user", "content": "   \t\n  "}],
+            "agent_request_id": "ws-001",
+        }
+        resp = client.post("/copilot/agent", json=body)
+        assert resp.status_code == 400
+
+
+class TestSecurityUnlockXffIp:
+    """audit/api-routes: /security/unlock lockouts must use the same IP
+    extraction as the per-IP rate limiter — otherwise reverse-proxy
+    deployments collapse every real user onto the LB IP and lockouts
+    bleed across tenants."""
+
+    def test_unlock_lockout_keyed_by_xff_first_hop(self):
+        """The lockout counter must increment for the X-Forwarded-For
+        client IP, not for the proxy's connecting IP."""
+        import axon.api_routes.security_routes as sr
+
+        sr._unlock_failures.clear()
+
+        from axon import security as _security
+
+        with patch(
+            "axon.security.unlock_store",
+            side_effect=_security.SecurityError("Wrong passphrase for store"),
+        ):
+            # All four requests are tagged with the same XFF IP but
+            # different connecting IPs. Pre-fix, this would have keyed
+            # off ``req.client.host``; after the fix it keys off XFF.
+            for _ in range(5):
+                resp = client.post(
+                    "/security/unlock",
+                    json={"passphrase": "wrong"},
+                    headers={"X-Forwarded-For": "203.0.113.42"},
+                )
+                assert resp.status_code == 401
+        # The 6th attempt with the same XFF IP must hit the lockout.
+        resp = client.post(
+            "/security/unlock",
+            json={"passphrase": "wrong"},
+            headers={"X-Forwarded-For": "203.0.113.42"},
+        )
+        assert resp.status_code == 429
+        # A different XFF IP is not locked out — bucket isolation holds.
+        with patch(
+            "axon.security.unlock_store",
+            side_effect=_security.SecurityError("Wrong passphrase for store"),
+        ):
+            resp = client.post(
+                "/security/unlock",
+                json={"passphrase": "wrong"},
+                headers={"X-Forwarded-For": "198.51.100.99"},
+            )
+        assert resp.status_code == 401
+        sr._unlock_failures.clear()

--- a/tests/test_api_schema_hardening.py
+++ b/tests/test_api_schema_hardening.py
@@ -256,3 +256,145 @@ def test_axon_config_exposes_upload_limits():
     field_names = {f.name for f in AxonConfig.__dataclass_fields__.values()}
     assert "max_upload_bytes" in field_names
     assert "max_files_per_request" in field_names
+
+
+# ---------------------------------------------------------------------------
+# audit/api-routes: max_length caps on free-form auth/share inputs
+# ---------------------------------------------------------------------------
+
+
+def test_share_redeem_oversized_share_string_returns_422():
+    """A pathologically large share_string must be rejected by Pydantic
+    before the route triggers base64-decode + JSON-parse work."""
+    from axon.api_schemas import MAX_SHARE_STRING_CHARS
+
+    api_module.brain = _make_brain()
+    payload = {"share_string": "A" * (MAX_SHARE_STRING_CHARS + 1)}
+    resp = client.post("/share/redeem", json=payload)
+    assert resp.status_code == 422
+
+
+def test_share_redeem_share_string_at_limit_passes_validation():
+    """A share_string at exactly the cap must reach the handler — it can
+    still fail downstream parsing, but never with a 422."""
+    from axon.api_schemas import MAX_SHARE_STRING_CHARS
+
+    api_module.brain = _make_brain()
+    payload = {"share_string": "A" * MAX_SHARE_STRING_CHARS}
+    resp = client.post("/share/redeem", json=payload)
+    assert resp.status_code != 422
+
+
+def test_security_bootstrap_oversized_passphrase_returns_422():
+    """An oversized passphrase must trip Pydantic, never feed scrypt."""
+    from axon.api_schemas import MAX_PASSPHRASE_CHARS
+
+    payload = {"passphrase": "x" * (MAX_PASSPHRASE_CHARS + 1)}
+    resp = client.post("/security/bootstrap", json=payload)
+    assert resp.status_code == 422
+
+
+def test_security_unlock_oversized_passphrase_returns_422():
+    from axon.api_schemas import MAX_PASSPHRASE_CHARS
+
+    payload = {"passphrase": "x" * (MAX_PASSPHRASE_CHARS + 1)}
+    resp = client.post("/security/unlock", json=payload)
+    assert resp.status_code == 422
+
+
+def test_security_change_passphrase_oversized_either_field_returns_422():
+    from axon.api_schemas import MAX_PASSPHRASE_CHARS
+
+    payload = {
+        "old_passphrase": "x" * (MAX_PASSPHRASE_CHARS + 1),
+        "new_passphrase": "ok-but-too-short-still-validates",
+    }
+    resp = client.post("/security/change-passphrase", json=payload)
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# audit/api-routes: /config/set sensitive-field masking
+# ---------------------------------------------------------------------------
+
+
+def test_config_set_masks_secret_in_response_old_and_new_value():
+    """``/config/set`` previously echoed the previous secret as ``old_value``
+    and the newly written secret as ``new_value``. Both must be masked
+    when the flat key is a known sensitive field."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class _FakeCfg:
+        openai_api_key: str = "prod-secret-do-not-leak"
+        qdrant_api_key: str = ""
+
+        def save(self) -> None:  # pragma: no cover — unused
+            return None
+
+    brain = MagicMock()
+    brain.config = _FakeCfg()
+    api_module.brain = brain
+
+    resp = client.post(
+        "/config/set",
+        json={"key": "llm.openai_api_key", "value": "rotated-secret-xyz", "persist": False},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # The mask must hide both the old and the new value.
+    assert body["old_value"] == "***"
+    assert body["new_value"] == "***"
+    # And the underlying config must actually be updated (mask is response-only).
+    assert brain.config.openai_api_key == "rotated-secret-xyz"
+
+
+def test_config_set_does_not_mask_non_sensitive_fields():
+    """Non-secret fields must continue to roundtrip values verbatim so UIs
+    can show before/after state."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class _FakeCfg:
+        hybrid_search: bool = True
+
+        def save(self) -> None:  # pragma: no cover
+            return None
+
+    brain = MagicMock()
+    brain.config = _FakeCfg()
+    api_module.brain = brain
+
+    resp = client.post(
+        "/config/set",
+        json={"key": "rag.hybrid_search", "value": False, "persist": False},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["old_value"] is True
+    assert body["new_value"] is False
+
+
+def test_config_get_masks_openai_and_grok_keys():
+    """``_SENSITIVE_FIELDS`` must include ``openai_api_key`` and
+    ``grok_api_key`` so ``/config`` does not leak them via the
+    asdict-dumped response."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class _FakeCfg:
+        openai_api_key: str = "openai-prod-key"
+        grok_api_key: str = "grok-prod-key"
+        gemini_api_key: str = "gemini-prod-key"
+        api_key: str = ""
+
+    brain = MagicMock()
+    brain.config = _FakeCfg()
+    api_module.brain = brain
+
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["openai_api_key"] == "***"
+    assert body["grok_api_key"] == "***"
+    assert body["gemini_api_key"] == "***"


### PR DESCRIPTION
## Summary

Parallel-audit unit 9 findings against the REST API route + validation
layer (`src/axon/api.py`, `src/axon/api_schemas.py`,
`src/axon/api_routes/`). Eight bugs fixed with minimum-blast-radius
patches, all backed by regression tests.

### Information disclosure

- `/config/set` echoed the previous and new values of any updated
  config key, including secrets like `openai_api_key`,
  `qdrant_api_key`, `gemini_api_key`. Masking is now applied to both
  via a shared `_mask_if_sensitive` helper.
- `_SENSITIVE_FIELDS` was missing `openai_api_key` and `grok_api_key`,
  so `/config` and `/config/update` responses leaked them.

### Path traversal

- `/share/revoke` (sealed shares) accepted unvalidated `project` field;
  `_resolve_owned_project_dir` joins segments verbatim and `..` could
  walk outside the user store.
- Same risk in `/project/rotate-keys` and `/project/seal`.
- `GET /session/{session_id}` interpolated the id into
  `session_<id>.json` — dotted ids could escape the sessions dir.
  Constrain to `[A-Za-z0-9_-]{1,128}`.

### Denial-of-service caps

- `ShareRedeemRequest.share_string` had no `max_length` so an arbitrary
  payload could feed base64-decode + JSON-parse. 16 KB cap.
- `SecurityBootstrapRequest`/`UnlockRequest`/`ChangePassphraseRequest`
  passphrases had no `max_length` so scrypt could be fed gigabyte
  inputs on the wrong-passphrase path. 4 KB cap.

### Robustness

- `/copilot/agent` IndexError on whitespace-only `user_query`: the
  empty-check ran on the unstripped value, then `strip().split()`
  returned `[]` and `parts[0]` raised. Strip before the check.
- `/security/unlock` lockout key used `req.client.host` while every
  other rate-limited route uses `_get_ip` (XFF-aware). Behind a
  reverse proxy this collapsed every real client onto one shared
  bucket. Switched to the shared helper.

## Test plan
- [x] `python -m pytest tests/test_api.py tests/test_api_config.py tests/test_api_rate_limits.py tests/test_api_health_metrics.py tests/test_api_schema_hardening.py tests/test_api_share_mount.py --no-cov` (372 passed, 1 skipped)
- [x] `python -m pytest tests/test_lint.py --no-cov` (3 passed)
- [x] `python -m black <files>` + `ruff check --fix <files>` (clean)
- [x] +14 new regression tests across the in-scope test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)