### PR TITLE
audit(projects): 3 bug fixes

### DIFF
--- a/src/axon/access.py
+++ b/src/axon/access.py
@@ -6,7 +6,11 @@ that were previously ad-hoc methods on ``AxonBrain``.
 
 from __future__ import annotations
 
+import logging
+
 __all__ = ["check_write_allowed", "is_mounted_share_path"]
+
+logger = logging.getLogger(__name__)
 
 
 def is_mounted_share_path(project_name: str) -> bool:
@@ -56,5 +60,15 @@ def check_write_allowed(
                 )
         except PermissionError:
             raise
-        except Exception:
-            pass
+        except Exception as exc:
+            # get_maintenance_state already swallows its own JSON/OS errors,
+            # so reaching here means an unexpected failure (broken import,
+            # monkey-patched dep). Surface the fail-open at WARNING so the
+            # bypass is auditable instead of silent.
+            logger.warning(
+                "check_write_allowed: maintenance-state check failed for "
+                "project=%r operation=%r — allowing write (fail-open): %s",
+                active_project,
+                operation,
+                exc,
+            )

--- a/src/axon/governance.py
+++ b/src/axon/governance.py
@@ -316,7 +316,15 @@ class AuditStore:
                         continue
                     if since and d.get("timestamp", "") < since:
                         continue
-                    events.append(AuditEvent(**d))
+                    # Per-row failure must not poison the whole query — a
+                    # forward-compat row with an unknown key raises TypeError
+                    # in the dataclass ctor; previously the outer except
+                    # caught it and terminated iteration.
+                    try:
+                        events.append(AuditEvent(**d))
+                    except TypeError as exc:
+                        logger.debug("Governance JSONL row skipped: %s", exc)
+                        continue
         except Exception as exc:
             logger.debug("Governance JSONL query failed: %s", exc)
         return list(reversed(events))[:limit]

--- a/src/axon/shares.py
+++ b/src/axon/shares.py
@@ -407,35 +407,49 @@ def validate_received_shares(user_dir: Path) -> list[str]:
     """
     from axon.mounts import remove_mount_descriptor
 
-    keys = _read_json(_keys_path(user_dir))
-    received = keys.get("received", [])
-    removed = []
-    updated = False
-    for record in list(received):
-        manifest_path = Path(record.get("owner_manifest_path", ""))
-        if not manifest_path.exists():
-            continue  # Can't check — leave descriptor in place
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except Exception:
-            continue
-        key_id = record.get("key_id")
-        if not key_id:
-            continue  # skip malformed received record
-        manifest_record = next(
-            (r for r in manifest.get("issued", []) if r["key_id"] == key_id), None
-        )
-        if manifest_record and (
-            manifest_record.get("revoked") or _is_expired(manifest_record.get("expires_at"))
-        ):
-            mount_name = record["mount_name"]
-            # Primary: remove descriptor from mounts/
-            remove_mount_descriptor(user_dir, mount_name)
-            removed.append(mount_name)
-            received.remove(record)
-            updated = True
-    if updated:
-        with _lock:
+    # Hold the lock across the whole read-modify-write — otherwise a
+    # concurrent redeem_share_key() that appends a new received record
+    # between our read and write would be silently clobbered by the
+    # write below (lost-update TOCTOU).
+    with _lock:
+        keys = _read_json(_keys_path(user_dir))
+        received = keys.get("received", [])
+        removed: list[str] = []
+        updated = False
+        for record in list(received):
+            manifest_path = Path(record.get("owner_manifest_path", ""))
+            if not manifest_path.exists():
+                continue  # Can't check — leave descriptor in place
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            key_id = record.get("key_id")
+            if not key_id:
+                continue  # skip malformed received record
+            manifest_record = next(
+                (
+                    r
+                    for r in manifest.get("issued", [])
+                    if isinstance(r, dict) and r.get("key_id") == key_id
+                ),
+                None,
+            )
+            if manifest_record and (
+                manifest_record.get("revoked") or _is_expired(manifest_record.get("expires_at"))
+            ):
+                # .get() not [] — a corrupt record missing 'mount_name' must
+                # not crash the loop and abandon stale descriptors in place.
+                mount_name = record.get("mount_name")
+                if not mount_name:
+                    received.remove(record)
+                    updated = True
+                    continue
+                remove_mount_descriptor(user_dir, mount_name)
+                removed.append(mount_name)
+                received.remove(record)
+                updated = True
+        if updated:
             keys["received"] = received
             _write_json(_keys_path(user_dir), keys)
     return removed

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -90,6 +90,30 @@ class TestCheckWriteAllowed:
         """'default' never has a maintenance state — must not raise."""
         check_write_allowed("ingest", "default", read_only_scope=False, is_mounted=False)
 
+    def test_maintenance_check_failure_is_logged(self, caplog, monkeypatch):
+        """Unexpected errors in the maintenance-state lookup must emit a
+        WARNING (previously silently swallowed by ``except Exception: pass``,
+        hiding access-control bypass)."""
+        import logging
+
+        import axon.access as _access_mod
+        import axon.projects as _proj
+
+        def _boom(_name):
+            raise RuntimeError("simulated dependency failure")
+
+        monkeypatch.setattr(_proj, "get_maintenance_state", _boom)
+        caplog.set_level(logging.WARNING, logger=_access_mod.logger.name)
+
+        # Fail-open behaviour preserved.
+        _access_mod.check_write_allowed(
+            "ingest", "someproj", read_only_scope=False, is_mounted=False
+        )
+
+        assert any(
+            "maintenance-state check failed" in rec.message for rec in caplog.records
+        ), f"expected warning log; got {[r.message for r in caplog.records]}"
+
 
 # ---------------------------------------------------------------------------
 # maintenance module

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -267,6 +267,39 @@ class TestAuditStoreJSONL:
             store = AuditStore(tmp_path / "bad.db")
         assert store._use_jsonl
 
+    def test_query_jsonl_skips_malformed_row_not_terminates(self, tmp_path):
+        """A single malformed JSONL row (e.g. a forward-compat column the
+        dataclass doesn't recognise) must not terminate iteration and drop
+        every subsequent valid row."""
+        from dataclasses import asdict
+
+        store = self._jsonl_store(tmp_path)
+        good1 = _event(project="p1", action="ingest_started", target_id="1")
+        good2 = _event(project="p2", action="delete", target_id="2")
+        with store._jsonl_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(asdict(good1)) + "\n")
+            bad = asdict(_event(project="bad", target_id="bogus"))
+            bad["unknown_future_column"] = "x"
+            fh.write(json.dumps(bad) + "\n")
+            fh.write(json.dumps(asdict(good2)) + "\n")
+
+        ids = {r.event_id for r in store.query()}
+        assert good1.event_id in ids, "valid row before bad row was dropped"
+        assert good2.event_id in ids, "valid row after bad row was dropped"
+
+    def test_query_jsonl_skips_row_missing_required_field(self, tmp_path):
+        """A row missing a required AuditEvent field (e.g. action) must be
+        skipped rather than terminating the query."""
+        from dataclasses import asdict
+
+        store = self._jsonl_store(tmp_path)
+        good = _event(project="p1", target_id="ok")
+        with store._jsonl_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"target_type": "file", "project": "x"}) + "\n")
+            fh.write(json.dumps(asdict(good)) + "\n")
+
+        assert any(r.event_id == good.event_id for r in store.query())
+
 
 # ===========================================================================
 # CopilotSessionStore

--- a/tests/test_shares.py
+++ b/tests/test_shares.py
@@ -1037,3 +1037,140 @@ class TestGovernanceShareExtendedAction:
         assert len(results) == 1
         assert results[0].target_id == "sk_a"
         assert results[0].details["new_expires_at"] == "2099-01-01T00:00:00+00:00"
+
+
+# ===========================================================================
+# Audit-found regressions
+# ===========================================================================
+
+
+class TestValidateReceivedSharesTOCTOU:
+    """Regression: validate_received_shares() read-modify-write must be atomic
+    so a concurrent redeem_share_key() append is not silently dropped."""
+
+    def test_concurrent_redeem_during_validate_not_lost(self, tmp_path, monkeypatch):
+        """A redeem racing with validate's read must not be silently
+        overwritten by validate's later write.
+
+        Without the lock fix, validate reads outside the lock so a worker
+        redeem completes between the read and the write, and the write
+        clobbers the new record. With the fix, validate holds the lock
+        across both ops, so the worker either blocks or the write reflects
+        a consistent snapshot.
+        """
+        import threading
+
+        from axon import shares as _shares_mod
+
+        owner_dir = _make_user_dir(tmp_path, "alice")
+        grantee_dir = tmp_path / "AxonStore" / "bob"
+        grantee_dir.mkdir(parents=True)
+
+        gen1 = _shares_mod.generate_share_key(owner_dir, "myproject", "bob", ttl_days=30)
+        gen2 = _shares_mod.generate_share_key(owner_dir, "myproject", "bob")
+
+        red1 = _shares_mod.redeem_share_key(grantee_dir, gen1["share_string"])
+        first_mount = red1["mount_name"]
+        _shares_mod.revoke_share_key(owner_dir, gen1["key_id"])
+
+        worker_started = threading.Event()
+        validator_can_write = threading.Event()
+        gate_consumed = threading.Event()
+        original_read = _shares_mod._read_json
+
+        def gated_read_json(path):
+            data = original_read(path)
+            if (
+                str(path).endswith(".share_keys.json")
+                and "AxonStore" in str(path)
+                and "bob" in str(path)
+                and not gate_consumed.is_set()
+            ):
+                gate_consumed.set()
+                worker_started.set()
+                # Hold validate at this point so the worker has a window
+                # to complete its redeem. Timeout caps the test runtime
+                # when the fix is in place (worker blocks on the lock).
+                validator_can_write.wait(timeout=5)
+            return data
+
+        monkeypatch.setattr(_shares_mod, "_read_json", gated_read_json)
+
+        worker_err: list[BaseException] = []
+
+        def worker() -> None:
+            try:
+                worker_started.wait(timeout=5)
+                _shares_mod.redeem_share_key(grantee_dir, gen2["share_string"])
+            except BaseException as exc:  # noqa: BLE001
+                worker_err.append(exc)
+            finally:
+                validator_can_write.set()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        try:
+            removed = _shares_mod.validate_received_shares(grantee_dir)
+        finally:
+            validator_can_write.set()
+            t.join(timeout=10)
+
+        assert not worker_err, worker_err
+        assert first_mount in removed, "revoked first share should be pruned"
+
+        keys = json.loads((grantee_dir / ".shares" / ".share_keys.json").read_text())
+        received_mounts = [r.get("mount_name") for r in keys.get("received", [])]
+        assert any(
+            m and "myproject" in m for m in received_mounts
+        ), f"concurrently-redeemed mount was lost: received={received_mounts}"
+
+    def test_corrupt_received_record_does_not_crash(self, tmp_path):
+        """A record in received[] that's missing 'mount_name' must not crash
+        validate_received_shares with KeyError. Previously the code used
+        record["mount_name"] (no .get()) which crashed the loop and left
+        stale descriptors in place."""
+        from axon import shares
+
+        owner_dir = _make_user_dir(tmp_path, "alice")
+        grantee_dir = tmp_path / "AxonStore" / "bob"
+        grantee_dir.mkdir(parents=True)
+        (grantee_dir / ".shares").mkdir(parents=True, exist_ok=True)
+
+        # Generate then revoke a share so we have a removable record alongside
+        # the corrupted one.
+        gen = shares.generate_share_key(owner_dir, "myproject", "bob", ttl_days=30)
+        red = shares.redeem_share_key(grantee_dir, gen["share_string"])
+        good_mount = red["mount_name"]
+        shares.revoke_share_key(owner_dir, gen["key_id"])
+
+        # Inject a corrupt record (no mount_name) alongside the good one.
+        keys_path = grantee_dir / ".shares" / ".share_keys.json"
+        keys = json.loads(keys_path.read_text())
+        keys.setdefault("received", []).append(
+            {
+                "key_id": "sk_corrupt",
+                "owner": "alice",
+                "owner_manifest_path": str(owner_dir / ".shares" / ".share_manifest.json"),
+                "project": "myproject",
+                # Intentionally missing "mount_name"
+            }
+        )
+        # Also mark the corrupt one as revoked in the owner's manifest so the
+        # validator would *try* to delete the mount and trip the KeyError.
+        manifest_path = owner_dir / ".shares" / ".share_manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest.setdefault("issued", []).append(
+            {
+                "key_id": "sk_corrupt",
+                "project": "myproject",
+                "grantee": "bob",
+                "revoked": True,
+                "revoked_at": "2026-01-01T00:00:00+00:00",
+            }
+        )
+        manifest_path.write_text(json.dumps(manifest))
+        keys_path.write_text(json.dumps(keys))
+
+        # Must not crash; valid record should still be pruned.
+        removed = shares.validate_received_shares(grantee_dir)
+        assert good_mount in removed


### PR DESCRIPTION
## Summary
Audit pass over `src/axon/projects.py`, `governance.py`, `access.py`, `shares.py`, `mounts.py` (unit 4 of 10). Three confirmed bugs fixed; each ships with a regression test that fails on the pre-fix code.

### Bugs fixed

**1. `governance.py::_query_jsonl` — one bad row terminates the whole query.**
`AuditEvent(**d)` construction lived inside the outer `try/except`, so any row with an unknown column (e.g. a forward-compat field written by a newer Axon) raised `TypeError`, terminated iteration, and silently dropped every subsequent valid row from the result. Now caught per-row and skipped.

**2. `shares.py::validate_received_shares` — TOCTOU lost update + KeyError on corrupted state.**
- The read-modify-write straddled the module lock: `_read_json(...)` ran outside `_lock`, then the in-lock write at the end clobbered any record a concurrent `redeem_share_key()` had appended between the read and the write. Hold `_lock` for the whole sequence.
- Used `record["mount_name"]` directly; a corrupted received record without `mount_name` raised `KeyError`, terminated the loop, and abandoned stale descriptors. Switched to `.get()` and added a drop-malformed-record path.

**3. `access.py::check_write_allowed` — silent bypass of maintenance-state check.**
`except Exception: pass` swallowed every unexpected failure of the maintenance-state lookup. Any broken import or monkey-patched dependency would bypass `readonly`/`offline`/`draining` guards with no audit trail. Now logs at `WARNING`; behaviour preserved (fail-open) for backward compatibility.

### Patterns reviewed but no bug found
- `_parse_name` path-traversal: rejects `..` via segment regex; empty/Unicode segments fail validation.
- `mount_descriptor_dir` path-traversal: already uses `resolve()` + `is_relative_to` containment check (good).
- `redeem_share_key` project tampering: HMAC binds `(token, key_id, project, grantee, owner_store_path)` so cross-project replay fails verification.
- `list_descendants` symlink cycle: visited set on resolved paths; symlinks in `subs/` explicitly skipped.
- Atomic meta.json writes: bare `write_text` everywhere (not tmp+rename), but no inter-writer race observed because module lock + per-user namespacing serialises writers in practice. Flagged for future hardening.
- Governance SQL injection: all `query()` clauses use parameterised SQL, no f-string interpolation of user input.

## Test plan
- [x] `python -m pytest tests/test_projects.py tests/test_governance.py tests/test_governance_routes.py tests/test_access.py tests/test_shares.py tests/test_mounts.py tests/test_api_share_mount.py --no-cov` — 302 passed, 1 skipped
- [x] `python -m pytest tests/test_lint.py -v --no-cov` — 3 passed (ruff + black + mypy)
- [x] Verified each new regression test fails on the pre-fix code