### PR TITLE
audit(core): 2 bug fixes

### DIFF
--- a/src/axon/main.py
+++ b/src/axon/main.py
@@ -695,12 +695,18 @@ Your primary goal is to help the user by answering questions based on the provid
             except Exception as exc:  # pragma: no cover — defensive
                 logger.debug("Persist executor shutdown raised: %s", exc)
             self._persist_executor_internal = None
-        # Close all unique store objects to avoid double-closure
+        # Close all unique store objects to avoid double-closure. Swallow
+        # per-store failures so a single misbehaving backend cannot abort
+        # the loop and skip the sealed-cache wipe below (which would leave
+        # decrypted plaintext on disk).
         seen_stores: set[int] = set()
         for attr in ("vector_store", "_own_vector_store", "bm25", "_own_bm25"):
             store = getattr(self, attr, None)
             if store and hasattr(store, "close") and id(store) not in seen_stores:
-                store.close()
+                try:
+                    store.close()
+                except Exception as exc:  # pragma: no cover — defensive
+                    logger.debug("Store %s close raised: %s", attr, exc)
                 seen_stores.add(id(store))
         # Force GC so Windows file handles into the sealed cache are
         # released BEFORE we try to overwrite + unlink the cache files.
@@ -875,6 +881,10 @@ Your primary goal is to help the user by answering questions based on the provid
         with self._traversal_cache_lock:
             self._traversal_cache.clear()
         self._ingested_hashes = set()
+        # Read-only scopes don't have a writeable doc-version store of their
+        # own, but leaving the previous project's data in memory would leak
+        # its sources through get_doc_versions(). Clear it here.
+        self._doc_versions = {}
         self._entity_graph = {}
         self._rebuild_entity_token_index()
         self._relation_graph = {}
@@ -1484,6 +1494,12 @@ Your primary goal is to help the user by answering questions based on the provid
         with self._traversal_cache_lock:
             self._traversal_cache.clear()
         self._ingested_hashes = self._load_hash_store()
+        # Doc-version tracking is keyed off the current project's bm25_path;
+        # rebind both the cached path and the in-memory dict so /tracked-docs
+        # and /ingest/refresh reflect the active project rather than the one
+        # active at brain construction time.
+        self._doc_versions_path = os.path.join(self.config.bm25_path, ".doc_versions.json")
+        self._load_doc_versions()
         self._graph_rag_cache = self._load_graph_rag_extraction_cache()
         self._graph_rag_cache_dirty = False
         self._code_graph = self._load_code_graph()

--- a/tests/test_brain_lifecycle.py
+++ b/tests/test_brain_lifecycle.py
@@ -111,3 +111,126 @@ class TestBrainLifecycle:
             mock_close_vs.assert_called_once()
             if mock_close_bm25:
                 mock_close_bm25.assert_called_once()
+
+    def test_close_wipes_sealed_cache_even_when_store_close_raises(
+        self, mock_dependencies, tmp_path
+    ):
+        """Regression: a misbehaving store.close() must not prevent the sealed
+        cache wipe from running. Pre-fix, an exception in the close loop
+        terminated the loop early and skipped the ``_sealed_cache`` cleanup,
+        leaving decrypted plaintext on disk.
+        """
+        config = AxonConfig(bm25_path=str(tmp_path), vector_store_path=str(tmp_path))
+        with patch.object(AxonBrain, "_load_hash_store", return_value=set()), patch.object(
+            AxonBrain, "_load_doc_versions"
+        ), patch.object(AxonBrain, "_load_entity_graph", return_value={}), patch.object(
+            AxonBrain, "_load_code_graph", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_relation_graph", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_community_levels", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_community_summaries", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_entity_embeddings", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_claims_graph", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_community_hierarchy", return_value={}
+        ):
+            brain = AxonBrain(config)
+            # Distinct objects so the close loop visits both arms.
+            vs = MagicMock()
+            vs.close = MagicMock(side_effect=OSError("file locked"))
+            bm = MagicMock()
+            bm.close = MagicMock()
+            brain.vector_store = vs
+            brain._own_vector_store = vs
+            brain.bm25 = bm
+            brain._own_bm25 = bm
+            # Plant a fake sealed cache and intercept release_cache.
+            fake_cache = MagicMock(path=str(tmp_path / "fake_cache"))
+            brain._sealed_cache = fake_cache
+
+            release_calls: list = []
+
+            def _fake_release(cache):
+                release_calls.append(cache)
+
+            fake_mount_mod = MagicMock()
+            fake_mount_mod.release_cache = _fake_release
+            with patch.dict("sys.modules", {"axon.security.mount": fake_mount_mod}, clear=False):
+                brain.close()
+
+            # The vector store raised, but the rest of the cleanup must
+            # still have happened: bm25 closed AND sealed cache released.
+            bm.close.assert_called_once()
+            assert release_calls == [fake_cache], (
+                "Sealed cache release must run even when a prior store.close() raised; "
+                f"got release_calls={release_calls!r}"
+            )
+            assert brain._sealed_cache is None
+
+    def test_switch_project_rebinds_doc_versions_path(self, mock_dependencies, tmp_path):
+        """Regression: switch_project must rebind ``_doc_versions_path`` and
+        reload ``_doc_versions``. Pre-fix, the path stayed pinned to the
+        project active at __init__, so ingests in the new project wrote
+        their version metadata into the previous project's directory and
+        ``get_doc_versions()`` returned stale cross-project data.
+        """
+        bm25_a = tmp_path / "proj_a" / "bm25"
+        bm25_a.mkdir(parents=True, exist_ok=True)
+        # Pre-stage a doc-versions file for project A so we can verify
+        # it's the one initially loaded.
+        (bm25_a / ".doc_versions.json").write_text(
+            '{"src_a": {"chunk_count": 1}}', encoding="utf-8"
+        )
+        bm25_b = tmp_path / "proj_b" / "bm25"
+        bm25_b.mkdir(parents=True, exist_ok=True)
+        (bm25_b / ".doc_versions.json").write_text(
+            '{"src_b": {"chunk_count": 7}}', encoding="utf-8"
+        )
+        config = AxonConfig(
+            bm25_path=str(bm25_a),
+            vector_store_path=str(tmp_path / "proj_a" / "vs"),
+        )
+        with patch.object(AxonBrain, "_load_hash_store", return_value=set()), patch.object(
+            AxonBrain, "_load_entity_graph", return_value={}
+        ), patch.object(AxonBrain, "_load_code_graph", return_value={}), patch.object(
+            AxonBrain, "_load_relation_graph", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_community_levels", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_community_summaries", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_entity_embeddings", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_claims_graph", return_value={}
+        ), patch.object(
+            AxonBrain, "_load_community_hierarchy", return_value={}
+        ):
+            brain = AxonBrain(config)
+            # After construction, doc-versions came from project A.
+            assert brain._doc_versions_path == str(bm25_a / ".doc_versions.json")
+            assert "src_a" in brain._doc_versions
+
+            proj_b_root = tmp_path / "proj_b_root"
+            proj_b_root.mkdir(parents=True, exist_ok=True)
+            (proj_b_root / "meta.json").write_text("{}", encoding="utf-8")
+            with patch("axon.projects.project_dir", return_value=proj_b_root), patch(
+                "axon.projects.project_vector_path",
+                return_value=str(tmp_path / "proj_b" / "vs"),
+            ), patch("axon.projects.project_bm25_path", return_value=str(bm25_b)), patch(
+                "axon.projects.set_active_project"
+            ), patch(
+                "axon.projects.list_descendants", return_value=[]
+            ), patch(
+                "axon.projects.is_reserved_top_level_name", return_value=False
+            ):
+                brain.switch_project("proj_b")
+
+            # After switch, both the path AND the loaded dict must reflect B.
+            assert brain._doc_versions_path == str(bm25_b / ".doc_versions.json")
+            assert "src_b" in brain._doc_versions
+            assert "src_a" not in brain._doc_versions
+            brain.close()


### PR DESCRIPTION
## Summary
Audit of `src/axon/main.py`, `src/axon/runtime.py`, `src/axon/sessions.py`, `src/axon/_ui_state.py` (Unit 1 of parallel `/batch` audit). Two real bugs fixed.

### Bug 1: `main.py:700-704` — `close()` skips sealed-cache wipe when store close raises
- **Root cause**: The store-close loop in `AxonBrain.close()` calls `store.close()` inline. If any store raises (e.g. turboquantdb on Windows with a stuck file lock), the loop terminates early and the subsequent `_sealed_cache` release block is bypassed entirely.
- **Impact**: Security-relevant. Decrypted plaintext from a sealed share could remain on disk after the brain shuts down, because `release_cache()` was never called.
- **Fix**: Wrap `store.close()` in a per-iteration `try/except`, log at debug level, and continue. The sealed-cache wipe now always runs.
- **Regression test**: `test_close_wipes_sealed_cache_even_when_store_close_raises` — installs a store whose `close` raises `OSError("file locked")`, asserts that both the other store's `close` AND a fake `release_cache` are still called.

### Bug 2: `main.py:1267 (switch_project)` — `_doc_versions_path` not rebound
- **Root cause**: `__init__` sets `self._doc_versions_path = os.path.join(self.config.bm25_path, ".doc_versions.json")` from the initial config. `switch_project()` changes `self.config.bm25_path` but never updates `_doc_versions_path` or reloads `_doc_versions`. Same omission in `_switch_to_scope()` (leaks previous project's data into the read-only scope view).
- **Impact**: After a project switch, ingest writes `.doc_versions.json` into the *previous* project's directory, and `get_doc_versions()` (used by `/tracked-docs` and `/ingest/refresh`) returns stale cross-project data.
- **Fix**: In `switch_project()`, rebind the path and call `_load_doc_versions()` next to the existing `_load_hash_store()` reload. In `_switch_to_scope()`, clear `self._doc_versions = {}` since scopes are read-only.
- **Regression test**: `test_switch_project_rebinds_doc_versions_path` — stages distinct `.doc_versions.json` files for projects A and B, constructs brain on A, switches to B, asserts both `_doc_versions_path` and `_doc_versions` reflect B.

### Patterns audited and clean
- `getattr(cfg, "field", default)` — every flag I saw is declared in `AxonConfig` (`config.py`); defaults serve as test-mock fallbacks.
- Threading locks (`_graph_lock_internal`, `_traversal_cache_lock_internal`) — eagerly initialised in `__init__` per CLAUDE.md guidance; no lazy-init race.
- `runtime.py` `LeaseRegistry` — lock ordering and epoch semantics are correct.
- `sessions.py` — `_sessions_dir` uses `exist_ok=True`; TOCTOU in `_load_session` is benign (FileNotFoundError caught).
- `_ui_state.py` — trivial, fine.
- `asyncio.run()` inside running loop — none in unit.
- Open() resource leaks — all use context managers.
- Bloom filter false positives — `_BloomHashStore` is dead code (`bloom_filter_hash_store` config flag is documented but never wired into `_load_hash_store`); not a runtime bug.

## Test plan
- [x] `python -m pytest tests/test_brain_lifecycle.py -v --no-cov` — 5/5 pass (3 existing + 2 new)
- [x] `python -m pytest tests/test_lint.py -v --no-cov` — 3/3 pass
- [x] `python -m pytest tests/test_main.py::TestSwitchProjectState tests/test_main.py::TestClose -v --no-cov` — 5/5 pass (existing close + switch_project coverage unchanged)
- [x] `python -m pytest tests/test_concurrency_hardened.py tests/test_sessions.py --no-cov` — 28/28 pass
- [x] Verified both regression tests FAIL on the unmodified `src/axon/main.py` and PASS with the fix