### PR TITLE
audit(graph): 3 bug fixes

### DIFF
--- a/src/axon/code_graph.py
+++ b/src/axon/code_graph.py
@@ -9,6 +9,16 @@ logger = logging.getLogger("Axon")
 
 
 class CodeGraphMixin:
+    # NOTE: ``_load_code_graph`` and ``_save_code_graph`` are ALSO defined on
+    # :class:`axon.graph_rag.GraphRagMixin`. GraphRagMixin appears earlier in
+    # ``AxonBrain``'s MRO and therefore wins at runtime. The methods on this
+    # class exist so unit tests can exercise ``CodeGraphMixin`` in isolation
+    # without pulling in the full GraphRagMixin (~4 kLoC). Production goes
+    # through the GraphRagMixin version, which uses
+    # ``_gr_write_json_if_changed`` (atomic + cloud-sync-safe + skip-write-
+    # when-unchanged digest cache). Keep these two implementations in sync
+    # for shape (return type, defaults); divergence in atomic-write semantics
+    # is acceptable because only the GraphRagMixin path runs in production.
     def _load_code_graph(self) -> dict:
         """Load code graph from disk. Returns empty graph if not found."""
         import json

--- a/src/axon/graph_backends/dynamic_graph_backend.py
+++ b/src/axon/graph_backends/dynamic_graph_backend.py
@@ -497,6 +497,11 @@ class DynamicGraphBackend:
         Missing or unreadable snapshot is not an error: the grantee simply
         sees an empty graph and retrieve() returns nothing, which is the
         sensible default when the owner has never ingested.
+
+        Audit P1: validate ``snapshot_version`` and skip non-dict rows. A
+        future-version or attacker-shaped snapshot must not be silently
+        replayed against the (possibly stricter) v1 schema — load nothing
+        rather than partially insert junk that retrieve() then trips on.
         """
         if not self._snapshot_path.exists():
             return
@@ -511,11 +516,32 @@ class DynamicGraphBackend:
             return
         if not isinstance(data, dict):
             return
+        # Refuse snapshots written by a newer Axon that may carry fields the
+        # v1 SQLite schema cannot represent. Missing/non-int version is
+        # treated as v1 (legacy snapshots predating the field).
+        snap_ver = data.get("snapshot_version", 1)
+        if not isinstance(snap_ver, int) or snap_ver > SNAPSHOT_VERSION:
+            logger.warning(
+                "DynamicGraph snapshot at %s has unsupported snapshot_version=%r "
+                "(this build supports up to %d); refusing to load.",
+                self._snapshot_path,
+                snap_ver,
+                SNAPSHOT_VERSION,
+            )
+            return
         entities = data.get("entities") or []
         facts = data.get("facts") or []
+        if not isinstance(entities, list) or not isinstance(facts, list):
+            logger.warning(
+                "DynamicGraph snapshot at %s has non-list entities/facts; " "refusing to load.",
+                self._snapshot_path,
+            )
+            return
         with self._write_lock:
             try:
                 for ent in entities:
+                    if not isinstance(ent, dict):
+                        continue
                     self._conn.execute(
                         "INSERT OR IGNORE INTO entities "
                         "(entity_id, canonical_name, entity_type, description, "
@@ -530,6 +556,8 @@ class DynamicGraphBackend:
                         ),
                     )
                 for f in facts:
+                    if not isinstance(f, dict):
+                        continue
                     self._conn.execute(
                         "INSERT OR IGNORE INTO facts "
                         "(fact_id, subject, relation, object, valid_at, invalid_at, "

--- a/src/axon/graph_backends/federated_backend.py
+++ b/src/axon/graph_backends/federated_backend.py
@@ -16,6 +16,7 @@ backends are queried concurrently via ThreadPoolExecutor(max_workers=2).
 """
 from __future__ import annotations
 
+import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
@@ -29,6 +30,7 @@ from axon.graph_backends.base import (
 )
 
 BACKEND_ID = "federated"
+logger = logging.getLogger("Axon")
 
 
 def _weighted_rrf(
@@ -98,9 +100,6 @@ class FederatedGraphBackend:
     BACKEND_ID = BACKEND_ID
 
     def __init__(self, brain: Any) -> None:
-        import logging
-
-        _log = logging.getLogger("Axon")
         from axon.graph_backends.dynamic_graph_backend import DynamicGraphBackend
         from axon.graph_backends.graphrag_backend import GraphRagBackend
 
@@ -109,7 +108,7 @@ class FederatedGraphBackend:
             try:
                 self._backends.append(cls(brain))
             except Exception as exc:
-                _log.warning("FederatedGraphBackend: skipping %s — %s", cls.__name__, exc)
+                logger.warning("FederatedGraphBackend: skipping %s — %s", cls.__name__, exc)
 
         raw: dict = getattr(getattr(brain, "config", None), "graph_federation_weights", {}) or {}
         self._weights: dict[str, float] = {
@@ -149,11 +148,7 @@ class FederatedGraphBackend:
                 try:
                     per_backend[bid] = future.result()
                 except Exception as exc:
-                    import logging as _logging
-
-                    _logging.getLogger("Axon").warning(
-                        "FederatedGraphBackend: %s retrieve() failed — %s", bid, exc
-                    )
+                    logger.warning("FederatedGraphBackend: %s retrieve() failed — %s", bid, exc)
                     per_backend[bid] = []
         return _weighted_rrf(per_backend, weights)
 
@@ -161,6 +156,8 @@ class FederatedGraphBackend:
     # Ingest / finalize / clear / delete_documents (sequential delegation)
     # ------------------------------------------------------------------
     def ingest(self, chunks: list[dict]) -> IngestResult:
+        # Audit P1: sub-backend failures were previously silent; surface
+        # them so callers see partial-ingest state.
         total = IngestResult(backend_id=BACKEND_ID)
         for b in self._backends:
             try:
@@ -168,8 +165,12 @@ class FederatedGraphBackend:
                 total.entities_added += r.entities_added
                 total.relations_added += r.relations_added
                 total.chunks_processed = max(total.chunks_processed, r.chunks_processed)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(
+                    "FederatedGraphBackend: %s ingest() failed — %s",
+                    getattr(b, "BACKEND_ID", type(b).__name__),
+                    exc,
+                )
         return total
 
     def finalize(self, force: bool = False) -> FinalizationResult:
@@ -225,18 +226,29 @@ class FederatedGraphBackend:
         return out
 
     def clear(self) -> None:
+        # Audit P1: a silent clear() failure leaves stale state behind.
         for b in self._backends:
             try:
                 b.clear()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(
+                    "FederatedGraphBackend: %s clear() failed — %s",
+                    getattr(b, "BACKEND_ID", type(b).__name__),
+                    exc,
+                )
 
     def delete_documents(self, chunk_ids: list[str]) -> None:
+        # Audit P1: silent delete_documents() failures leave dangling
+        # entities/facts behind.
         for b in self._backends:
             try:
                 b.delete_documents(chunk_ids)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(
+                    "FederatedGraphBackend: %s delete_documents() failed — %s",
+                    getattr(b, "BACKEND_ID", type(b).__name__),
+                    exc,
+                )
 
     # ------------------------------------------------------------------
     # Status / graph_data

--- a/src/axon/graph_rag.py
+++ b/src/axon/graph_rag.py
@@ -13,6 +13,79 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("Axon")
 
+# ---------------------------------------------------------------------------
+# Pickle-cache HMAC helpers (audit P0: prevent untrusted pickle deserialization).
+#
+# The relation-graph pickle cache (.relation_graph.cache.pkl) is an opt-in perf
+# optimization (graph_rag_relation_pickle_cache, default False). pickle.load on
+# attacker-controlled bytes is RCE; when bm25_path is on a shared / cloud-synced
+# directory, an attacker who can write that file gets RCE on every load.
+#
+# Defense: bind the cache to the local machine via an HMAC keyed by a file
+# stored under ~/.axon/.relation_pickle_hmac.key (mode 0600, generated on first
+# use). On load, we verify the HMAC before unpickling; on failure we refuse to
+# load the pickle and fall through to the JSON shard path.
+# ---------------------------------------------------------------------------
+
+# The HMAC is stored in the existing ``.relation_graph.cache.meta.json``
+# sidecar (next to the ``key`` field), not appended to the pickle file, so
+# the pickle shape stays unchanged. The per-machine HMAC key lives under
+# ``~/.axon/`` (created mode 0600 on first use).
+_RELATION_PICKLE_HMAC_KEY_FILE = ".relation_pickle_hmac.key"
+
+
+def _relation_pickle_hmac_key_path():
+    """Return ``~/.axon/.relation_pickle_hmac.key`` as a :class:`pathlib.Path`."""
+    import pathlib as _pathlib
+
+    return _pathlib.Path.home() / ".axon" / _RELATION_PICKLE_HMAC_KEY_FILE
+
+
+def _get_or_create_relation_pickle_hmac_key() -> bytes:
+    """Return the 32-byte HMAC key, creating it (mode 0600) on first use.
+
+    The key lives at ``~/.axon/.relation_pickle_hmac.key`` and is local to the
+    machine; this binds the pickle cache to this host so a synced or attacker-
+    placed pickle file cannot be replayed against another machine.
+    """
+    import os as _os
+    import secrets as _secrets
+
+    key_path = _relation_pickle_hmac_key_path()
+    if key_path.exists():
+        try:
+            data = key_path.read_bytes()
+            if len(data) >= 32:
+                return data
+        except OSError:
+            pass
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key = _secrets.token_bytes(32)
+    tmp = key_path.with_suffix(key_path.suffix + ".tmp")
+    tmp.write_bytes(key)
+    try:
+        _os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    _os.replace(tmp, key_path)
+    return key
+
+
+def _compute_relation_pickle_hmac(payload: bytes, cache_key: str) -> str:
+    """Return hex-encoded HMAC-SHA256 over *payload* tagged by *cache_key*.
+
+    Tagging by ``cache_key`` (the shard-signature digest) ensures the HMAC
+    cannot be replayed against a different graph state on the same machine.
+    """
+    import hmac as _hmac
+
+    mac = _hmac.new(_get_or_create_relation_pickle_hmac_key(), digestmod="sha256")
+    mac.update(cache_key.encode("utf-8"))
+    mac.update(b"\x00")
+    mac.update(payload)
+    return mac.hexdigest()
+
+
 _GRAPHRAG_REDUCE_SYSTEM_PROMPT = (
     "You are a helpful assistant responding to questions about a dataset by synthesizing the "
     "perspectives from multiple data analysts.\n\n"
@@ -1089,10 +1162,31 @@ class GraphRagMixin:
                         try:
                             _meta = self._gr_json_load_path(shard_cache_meta_path)
                             if isinstance(_meta, dict) and _meta.get("key") == cache_key:
+                                # Audit P0: verify HMAC over the pickle bytes
+                                # BEFORE pickle.load(). pickle.load on attacker-
+                                # controlled bytes is RCE; the HMAC binds the
+                                # cache to this host (key under ~/.axon/, mode
+                                # 0600). On any HMAC failure, refuse and fall
+                                # through to the JSON shard path.
+                                import hmac as _hmac
                                 import pickle as _pickle
 
-                                with open(shard_cache_path, "rb") as _f:
-                                    _cached = _pickle.load(_f)
+                                _expected_mac = _meta.get("hmac")
+                                if not isinstance(_expected_mac, str) or not _expected_mac:
+                                    raise ValueError(
+                                        "relation pickle cache missing HMAC; refusing to load"
+                                    )
+                                _payload = shard_cache_path.read_bytes()
+                                _actual_mac = _compute_relation_pickle_hmac(_payload, cache_key)
+                                if not _hmac.compare_digest(_actual_mac, _expected_mac):
+                                    logger.warning(
+                                        "relation pickle cache HMAC mismatch at %s — "
+                                        "refusing to deserialize (possible tampering or "
+                                        "cache moved between machines)",
+                                        shard_cache_path,
+                                    )
+                                    raise ValueError("relation pickle cache HMAC mismatch")
+                                _cached = _pickle.loads(_payload)
                                 if isinstance(_cached, dict):
                                     return _cached
                         except Exception:
@@ -1182,14 +1276,24 @@ class GraphRagMixin:
                                 or 4
                             )
                             proto = min(max(1, proto), 5)
+                            # Audit P0: compute HMAC over the pickle bytes
+                            # and store it in the meta file so _load can
+                            # verify before unpickling. Without this, a
+                            # tampered pickle on a shared / synced path
+                            # would be RCE on load.
+                            _pickled = _pickle.dumps(merged, protocol=proto)
+                            _mac = _compute_relation_pickle_hmac(_pickled, cache_key)
                             _tmp = shard_cache_path.with_suffix(shard_cache_path.suffix + ".tmp")
                             with open(_tmp, "wb") as _f:
-                                _pickle.dump(merged, _f, protocol=proto)
+                                _f.write(_pickled)
                             _os.replace(_tmp, shard_cache_path)
                             _tmp_meta = shard_cache_meta_path.with_suffix(
                                 shard_cache_meta_path.suffix + ".tmp"
                             )
-                            _tmp_meta.write_text(_json.dumps({"key": cache_key}), encoding="utf-8")
+                            _tmp_meta.write_text(
+                                _json.dumps({"key": cache_key, "hmac": _mac}),
+                                encoding="utf-8",
+                            )
                             _os.replace(_tmp_meta, shard_cache_meta_path)
                         except Exception:
                             pass

--- a/tests/test_dynamic_graph_backend.py
+++ b/tests/test_dynamic_graph_backend.py
@@ -479,6 +479,82 @@ class TestDynamicGraphShareMountSafety:
         s = grantee.status()
         assert s["entities"] == 0
 
+    @staticmethod
+    def _make_grantee_with_snapshot(tmp_path, snapshot: dict):
+        """Write *snapshot* to bm25_path and return a freshly-built grantee."""
+        import json as _json
+
+        from axon.graph_backends.dynamic_graph_backend import (
+            SNAPSHOT_FILENAME,
+            DynamicGraphBackend,
+        )
+
+        (tmp_path / SNAPSHOT_FILENAME).write_text(_json.dumps(snapshot), encoding="utf-8")
+        grantee_brain = _make_brain(tmp_path)
+        grantee_brain._active_project = "mounts/shared"
+        return DynamicGraphBackend(grantee_brain)
+
+    @staticmethod
+    def _ent(eid: str, name: str, description: str = "") -> dict:
+        return {
+            "entity_id": eid,
+            "canonical_name": name,
+            "entity_type": "PERSON",
+            "description": description,
+            "first_seen_at": "2026-01-01T00:00:00+00:00",
+            "last_seen_at": "2026-01-01T00:00:00+00:00",
+        }
+
+    def test_grantee_refuses_future_snapshot_version(self, tmp_path):
+        """Audit P1: a snapshot from a NEWER Axon (snapshot_version > current)
+        must NOT be silently replayed against the v1 schema. The grantee
+        sees an empty graph instead of partially-populated junk.
+        """
+        from axon.graph_backends.dynamic_graph_backend import SNAPSHOT_VERSION
+
+        grantee = self._make_grantee_with_snapshot(
+            tmp_path,
+            {
+                "snapshot_version": SNAPSHOT_VERSION + 1,
+                "entities": [self._ent("e1", "alice", "future-only field shape")],
+                "facts": [],
+                "v2_only_field": {"some": "thing"},
+            },
+        )
+        s = grantee.status()
+        assert s["entities"] == 0
+        assert s["active_facts"] == 0
+
+    def test_grantee_skips_non_dict_rows_in_snapshot(self, tmp_path):
+        """Audit P1: a snapshot row that isn't a dict must be skipped, not
+        raise AttributeError and leave the DB half-populated.
+        """
+        grantee = self._make_grantee_with_snapshot(
+            tmp_path,
+            {
+                "snapshot_version": 1,
+                "entities": [
+                    self._ent("e1", "alice", "ok"),
+                    "not-a-dict",
+                    self._ent("e2", "bob", "also ok"),
+                ],
+                "facts": [],
+            },
+        )
+        assert grantee.status()["entities"] == 2
+
+    def test_grantee_refuses_non_list_entities(self, tmp_path):
+        """Audit P1: entities/facts that aren't lists are refused before iteration."""
+        grantee = self._make_grantee_with_snapshot(
+            tmp_path,
+            {
+                "snapshot_version": 1,
+                "entities": "not a list",
+                "facts": [],
+            },
+        )
+        assert grantee.status()["entities"] == 0
+
 
 class TestDynamicGraphDbRelocation:
     """When bm25_path is on a cloud-sync / network path, the owner DB is

--- a/tests/test_graph_rag_integrity.py
+++ b/tests/test_graph_rag_integrity.py
@@ -1,4 +1,5 @@
 import json
+import pickle
 
 import pytest
 
@@ -8,6 +9,14 @@ from axon.graph_rag import GraphRagMixin
 class MockConfig:
     def __init__(self, bm25_path: str):
         self.bm25_path = bm25_path
+        # Defaults that match AxonConfig for graph fields the loader inspects.
+        self.graph_rag_relation_msgpack_persist = True
+        self.graph_rag_relation_pickle_cache = False
+        self.graph_rag_relation_pickle_cache_protocol = 4
+        self.graph_rag_relation_shard_list_manifest = True
+        self.graph_rag_relation_shard_parallel_load = True
+        self.graph_rag_relation_shard_load_workers = 4
+        self.graph_rag_relation_shard_persist = False
 
 
 class TestGraphRagIntegrity:
@@ -108,3 +117,138 @@ class TestGraphRagIntegrity:
         loaded = brain_stub._load_entity_graph()
         assert len(loaded) == 10000
         assert loaded["entity_9999"]["frequency"] == 9999
+
+
+class TestRelationPickleCacheHmac:
+    """Audit P0: relation-graph pickle cache must verify HMAC before unpickling.
+
+    pickle.load on attacker-controlled bytes is RCE. When bm25_path is a
+    shared / cloud-synced directory, anyone with write access can drop a
+    malicious pickle there. The HMAC binds the cache to this host via a
+    key under ~/.axon/.
+    """
+
+    @pytest.fixture
+    def brain_stub(self, tmp_path, monkeypatch):
+        # Pin Path.home() so the HMAC key lands in tmp_path and the test
+        # doesn't pollute the developer's real ~/.axon.
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+
+        class Brain(GraphRagMixin):
+            def __init__(self, config):
+                self.config = config
+                self._entity_graph = {}
+                self._relation_graph = {}
+
+        cfg = MockConfig(str(tmp_path))
+        cfg.graph_rag_relation_pickle_cache = True
+        cfg.graph_rag_relation_msgpack_persist = False
+        return Brain(cfg)
+
+    def _seed_shards_with_cache(self, brain, tmp_path, payload):
+        """Write the minimum file set that triggers the pickle-cache fast-path."""
+        import hashlib
+
+        # Shards manifest + a single shard so _load_relation_graph reaches the
+        # cache-checking branch.
+        shard_payload = {"format": "rg_rel_v2", "g": payload}
+        shard_path = tmp_path / ".relation_graph.shard.000.json"
+        shard_path.write_text(json.dumps(shard_payload), encoding="utf-8")
+        (tmp_path / ".relation_graph.shards.json").write_text(
+            json.dumps({"format": "rg_rel_shard_v1", "shards": [".relation_graph.shard.000.json"]}),
+            encoding="utf-8",
+        )
+        # Shard state file with a deterministic signature so cache_key is computable.
+        sigs = ["deadbeef"]
+        (tmp_path / ".relation_graph.shard_state.json").write_text(
+            json.dumps({"format": "rg_rel_shard_state_v1", "signatures": sigs}),
+            encoding="utf-8",
+        )
+        # Compute cache_key the same way _load_relation_graph does.
+        return hashlib.sha1("|".join(sigs).encode("utf-8")).hexdigest()
+
+    def test_unsigned_pickle_cache_is_refused(self, brain_stub, tmp_path):
+        """A pickle file without a valid HMAC must NOT be unpickled.
+
+        Without this guard, an attacker who can write to bm25_path could
+        place a malicious pickle and achieve RCE on the next load.
+        """
+        cache_key = self._seed_shards_with_cache(
+            brain_stub,
+            tmp_path,
+            {"alice": [{"target": "shard_value", "relation": "knows", "chunk_id": "c1"}]},
+        )
+        # Plant an "evil" pickle bytes — but for safety in the test we just
+        # use a benign dict; the load path must not call pickle.load on it
+        # because the meta file has no HMAC.
+        evil = {"poisoned": [{"target": "rce", "relation": "rce", "chunk_id": "rce"}]}
+        (tmp_path / ".relation_graph.cache.pkl").write_bytes(pickle.dumps(evil))
+        # Meta without the "hmac" field — older format.
+        (tmp_path / ".relation_graph.cache.meta.json").write_text(
+            json.dumps({"key": cache_key}), encoding="utf-8"
+        )
+        loaded = brain_stub._load_relation_graph()
+        # The pickle MUST be rejected; we should fall through to the JSON
+        # shard load path and see the shard contents, not the planted dict.
+        assert "poisoned" not in loaded
+        assert "alice" in loaded
+
+    def test_tampered_pickle_cache_is_refused(self, brain_stub, tmp_path):
+        """A pickle file with an HMAC that doesn't match the bytes is refused."""
+        from axon.graph_rag import _compute_relation_pickle_hmac
+
+        cache_key = self._seed_shards_with_cache(
+            brain_stub,
+            tmp_path,
+            {"bob": [{"target": "shard_value", "relation": "knows", "chunk_id": "c2"}]},
+        )
+        # Compute a valid HMAC for one payload, then write a different payload.
+        good_payload = pickle.dumps({"legit": [{"target": "x", "relation": "y", "chunk_id": "z"}]})
+        good_mac = _compute_relation_pickle_hmac(good_payload, cache_key)
+        evil_payload = pickle.dumps(
+            {"tampered": [{"target": "rce", "relation": "rce", "chunk_id": "rce"}]}
+        )
+        (tmp_path / ".relation_graph.cache.pkl").write_bytes(evil_payload)
+        (tmp_path / ".relation_graph.cache.meta.json").write_text(
+            json.dumps({"key": cache_key, "hmac": good_mac}), encoding="utf-8"
+        )
+        loaded = brain_stub._load_relation_graph()
+        assert "tampered" not in loaded
+        assert "bob" in loaded
+
+    def test_signed_pickle_cache_is_loaded(self, brain_stub, tmp_path):
+        """The happy path: a pickle written by ``_load_relation_graph`` itself
+        carries a valid HMAC and is loaded on the next call."""
+        # Seed shards, run a first load — that writes the pickle cache.
+        self._seed_shards_with_cache(
+            brain_stub,
+            tmp_path,
+            {"carol": [{"target": "shard_value", "relation": "knows", "chunk_id": "c3"}]},
+        )
+        first = brain_stub._load_relation_graph()
+        assert "carol" in first
+        # The pickle and meta files should now exist with a valid HMAC.
+        assert (tmp_path / ".relation_graph.cache.pkl").exists()
+        meta = json.loads(
+            (tmp_path / ".relation_graph.cache.meta.json").read_text(encoding="utf-8")
+        )
+        assert "hmac" in meta and isinstance(meta["hmac"], str) and len(meta["hmac"]) == 64
+        # Delete the shard so the JSON fallback would return empty —
+        # this proves the second load came from the pickle cache.
+        (tmp_path / ".relation_graph.shard.000.json").write_text(
+            json.dumps({"format": "rg_rel_v2", "g": {}}), encoding="utf-8"
+        )
+        # Clear shard-names cache between loads
+        if hasattr(brain_stub, "_rel_shard_names_sig"):
+            delattr(brain_stub, "_rel_shard_names_sig")
+        second = brain_stub._load_relation_graph()
+        assert "carol" in second
+
+    def test_hmac_key_file_is_persistent(self, brain_stub, tmp_path):
+        """The HMAC key is created once and reused."""
+        from axon.graph_rag import _get_or_create_relation_pickle_hmac_key
+
+        key1 = _get_or_create_relation_pickle_hmac_key()
+        key2 = _get_or_create_relation_pickle_hmac_key()
+        assert key1 == key2
+        assert len(key1) >= 32

--- a/tests/test_v032_graph_surface.py
+++ b/tests/test_v032_graph_surface.py
@@ -395,6 +395,67 @@ class TestListConflicts:
 
 
 # ---------------------------------------------------------------------------
+# Audit P1: federated sub-backend failures must be logged, not silently
+# swallowed. Otherwise an operator who calls clear() / delete_documents() /
+# ingest() and gets no error believes the operation succeeded fully — but
+# stale state may remain in the backend that raised.
+# ---------------------------------------------------------------------------
+
+
+def _make_failing_backend(backend_id: str, method_name: str):
+    b = MagicMock()
+    b.BACKEND_ID = backend_id
+    getattr(b, method_name).side_effect = RuntimeError(f"{method_name} boom")
+    return b
+
+
+def _make_ok_backend(backend_id: str):
+    from axon.graph_backends.base import IngestResult
+
+    b = MagicMock()
+    b.BACKEND_ID = backend_id
+    b.ingest.return_value = IngestResult(
+        entities_added=1, relations_added=1, chunks_processed=1, backend_id=backend_id
+    )
+    return b
+
+
+class TestFederatedBackendFailureLogging:
+    @pytest.mark.parametrize(
+        "method_name,call",
+        [
+            ("ingest", lambda fed: fed.ingest([])),
+            ("clear", lambda fed: fed.clear()),
+            ("delete_documents", lambda fed: fed.delete_documents(["c1", "c2"])),
+        ],
+    )
+    def test_sub_backend_failure_is_logged(self, tmp_path, caplog, method_name, call):
+        import logging as _logging
+
+        brain = _make_brain(tmp_path, federation_weights={})
+
+        def _patched_init(self, _brain):
+            self._backends = [
+                _make_failing_backend("graphrag", method_name),
+                _make_ok_backend("dynamic_graph"),
+            ]
+            self._weights = {"graphrag": 1.0, "dynamic_graph": 1.0}
+
+        original_init = FederatedGraphBackend.__init__
+        try:
+            FederatedGraphBackend.__init__ = _patched_init  # type: ignore[assignment]
+            fed = FederatedGraphBackend(brain)
+            with caplog.at_level(_logging.WARNING, logger="Axon"):
+                call(fed)
+            expected = f"graphrag {method_name}() failed"
+            assert any(expected in rec.message for rec in caplog.records), [
+                rec.message for rec in caplog.records
+            ]
+        finally:
+            FederatedGraphBackend.__init__ = original_init  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
 # Item (8): point-in-time pass-through (already implemented; cover the
 # config plumbing so a regression in RetrievalConfig is caught early).
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Unit 7 of the parallel bug audit (Graph RAG & Backends). Three findings, all with regression tests.

### 1. P0 — `graph_rag.py:1095` pickle.load() with no integrity check

The opt-in relation-graph pickle cache (`.relation_graph.cache.pkl`, gated by `graph_rag_relation_pickle_cache=False`) called `pickle.load()` on the raw file bytes. When `bm25_path` is on a shared / cloud-synced directory (OneDrive, sealed-share grantee, multi-user FS), anyone with write access to that file gets RCE on the next load.

**Fix**: HMAC-SHA256 over the pickle bytes, keyed by `~/.axon/.relation_pickle_hmac.key` (32 random bytes, mode 0600, generated on first use). HMAC tag is stored in the existing `.relation_graph.cache.meta.json` sidecar. On load we verify the HMAC before `pickle.loads`; on any failure (missing field, tampered bytes, cache moved between machines) we refuse and fall through to the JSON shard path. HMAC is tagged by `cache_key` (shard-signature digest) so a valid pickle from one graph state cannot be replayed against another.

### 2. P1 — `dynamic_graph_backend.py:495` `_load_snapshot` did not validate `snapshot_version`

A snapshot written by a newer Axon (`snapshot_version > SNAPSHOT_VERSION`) was silently replayed against the v1 SQLite schema, leaving the grantee's in-memory DB in an undefined state. Also added:
- Per-row `isinstance(dict)` guard so a non-dict row from corruption / attacker shape is skipped rather than half-inserting then raising `AttributeError`.
- Up-front `isinstance(list)` check on `entities`/`facts` so a non-list (e.g. string) field is refused before iteration.

### 3. P1 — `federated_backend.py` silent failures on ingest / clear / delete_documents

These three methods caught every sub-backend exception with `except: pass`, so an operator could believe a `clear()` or `delete_documents()` succeeded fully when one backend actually failed and left stale entities / facts behind. Now logged at WARNING via the module-level `logger`; success path unchanged.

### Drive-by cleanups (simplify pass)

- `federated_backend.py`: consolidated four inline `import logging` calls into one module-level import + `logger`.
- `graph_rag.py`: removed unused `_RELATION_PICKLE_HMAC_SUFFIX` constant.
- `code_graph.py`: documented that `_load_code_graph` / `_save_code_graph` here are intentional test-isolation duplicates of the production methods on `GraphRagMixin` (which wins via MRO).

## Test plan

- [x] `python -m pytest tests/test_graph_rag_integrity.py tests/test_dynamic_graph_backend.py tests/test_v032_graph_surface.py -v --no-cov` — 67 passed
- [x] `python -m pytest tests/test_graph*.py tests/test_code_graph.py --no-cov` — 512 passed, 1 xfailed
- [x] `python -m pytest tests/test_lint.py -v --no-cov` — 3 passed
- [x] `python -m black src/axon/graph_rag.py src/axon/graph_backends/ src/axon/code_graph.py tests/test_*.py` — clean
- [x] `python -m ruff check ...` — All checks passed
- [ ] CI: full suite green

## Files changed (7)

- `src/axon/graph_rag.py` — HMAC helpers + verify/sign on pickle cache
- `src/axon/graph_backends/dynamic_graph_backend.py` — snapshot_version + per-row validation
- `src/axon/graph_backends/federated_backend.py` — log sub-backend failures
- `src/axon/code_graph.py` — comment-only (clarify intentional duplicate)
- `tests/test_graph_rag_integrity.py` — 4 new tests for HMAC (TestRelationPickleCacheHmac)
- `tests/test_dynamic_graph_backend.py` — 3 new tests for snapshot validation
- `tests/test_v032_graph_surface.py` — 1 parametrized test (3 cases) for federated logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)