### PR TITLE
audit(query): 4 bug fixes in query router

### DIFF
--- a/src/axon/query_router.py
+++ b/src/axon/query_router.py
@@ -1,6 +1,7 @@
 """Query routing, retrieval, context assembly and response generation (QueryRouterMixin)."""
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -62,11 +63,16 @@ _ROUTE_PROFILES: dict = {
 # Citation metadata helpers
 # ---------------------------------------------------------------------------
 
-# ``[Document N]`` is what _build_context emits and what we tell the LLM to
-# cite with. Some models drop the word "Document" and just write ``[N]``;
-# accept either form. We capture only 1- and 2-digit indices to avoid
-# matching arbitrary bracketed numbers in source-quoted code.
-_CITATION_MARKER_RE = re.compile(r"\[(?:Document\s+)?(\d{1,2})\]")
+# ``[Document N — label]`` is what _build_context emits and what we tell the
+# LLM to cite with. Models may reproduce variations:
+#   - bare digit form: ``[N]`` (Document word dropped)
+#   - full marker as shown in context: ``[Document N — label]``
+#   - system-prompt example form: ``[Document N (ID: ...)]``
+# To match all three, we accept any non-``]`` content after the digit, but
+# only when the ``Document`` prefix is present — the bare ``[N]`` form stays
+# strict to avoid matching unrelated bracketed snippets like ``[1 line]`` in
+# source-quoted code. We capture 1-3 digit indices to cover top_k up to 999.
+_CITATION_MARKER_RE = re.compile(r"\[(?:Document\s+(\d{1,3})(?:[^\]]*)?|(\d{1,3}))\]")
 _CITATION_TEXT_TRUNCATE = 500  # chars per source.text in the response payload
 
 
@@ -126,7 +132,12 @@ def _build_citation_metadata(response: str, citation_results: list[dict]) -> dic
     if not isinstance(response, str) or not response or not sources:
         return {"sources": sources, "citations": citations}
     for match in _CITATION_MARKER_RE.finditer(response):
-        marker_idx_one_based = int(match.group(1))
+        # Two alternative capture groups in the pattern:
+        #   group(1) = ``Document N…`` form
+        #   group(2) = bare ``N`` form
+        # Whichever matched carries the digit; the other is None.
+        digit = match.group(1) or match.group(2)
+        marker_idx_one_based = int(digit)
         # Reject out-of-range markers (LLM hallucinated a citation).
         # Index in the response is 1-based; sources is 0-based.
         if marker_idx_one_based < 1 or marker_idx_one_based > len(sources):
@@ -1516,12 +1527,18 @@ class QueryRouterMixin:
         )
 
     def _apply_overrides(self, overrides: dict | None) -> AxonConfig:
-        """Return a config copy with per-request overrides applied (thread-safe)."""
-        if not overrides:
-            return self.config
-        import copy
+        """Return a shallow copy of ``self.config`` with overrides applied.
 
+        Always returns a fresh copy — even when ``overrides`` is empty — so
+        callers that mutate the returned config (e.g. ``query()`` applying
+        route-profile flags via ``object.__setattr__``) cannot corrupt the
+        brain's shared ``self.config``. This is the contract every caller
+        depends on: per-request flag tweaks must NOT leak into subsequent
+        queries.
+        """
         cfg = copy.copy(self.config)
+        if not overrides:
+            return cfg
         for k, v in overrides.items():
             if v is not None and hasattr(cfg, k):
                 setattr(cfg, k, v)
@@ -1548,8 +1565,9 @@ class QueryRouterMixin:
         # Warn (don't block) if the embedding model has changed — retrieval
         # results will be degraded but the user can still access existing data.
         self._validate_embedding_meta(on_mismatch="warn")
-        # Clear citation metadata so a no-context fallback or cached hit
+        # Clear citation metadata so a no-context fallback or cache miss
         # doesn't leak the previous question's citations into this turn.
+        # On a cache hit the value is restored from the cached entry below.
         self._last_citations = {"sources": [], "citations": []}
         t0 = time.time()
         cfg = self._apply_overrides(overrides)
@@ -1574,11 +1592,22 @@ class QueryRouterMixin:
             with self._cache_lock:
                 cached = self._query_cache.get(cache_key)
                 if cached is not None:
-                    stored_time, stored_response = cached
+                    # Tuple layout: (stored_time, response, citations, provenance).
+                    # Legacy 2-tuples are still accepted for backwards
+                    # compatibility with externally-injected entries (tests).
+                    stored_time, stored_response, *rest = cached
+                    stored_citations = rest[0] if rest else {"sources": [], "citations": []}
+                    stored_provenance = rest[1] if len(rest) > 1 else {}
                     ttl = getattr(cfg, "query_cache_ttl", 1800)
                     if ttl <= 0 or time.monotonic() - stored_time < ttl:
                         logger.info(f"Cache hit for query: {query[:60]}")
                         self._query_cache.move_to_end(cache_key)
+                        # Restore brain-level state so callers reading
+                        # _last_citations / _last_provenance after a cache
+                        # hit see the cached query's data, not stale state
+                        # from a different prior call.
+                        self._last_citations = stored_citations
+                        self._last_provenance = stored_provenance
                         return stored_response
                     else:
                         del self._query_cache[cache_key]
@@ -1734,7 +1763,16 @@ class QueryRouterMixin:
                 # Evict least-recently-used entry when cache is at capacity
                 if len(self._query_cache) >= cfg.query_cache_size and self._query_cache:
                     self._query_cache.popitem(last=False)  # pop LRU (front of OrderedDict)
-                self._query_cache[cache_key] = (time.monotonic(), response)
+                # Store citations + provenance alongside the response so a
+                # subsequent cache hit can restore the brain-level state
+                # callers depend on (REST /query reads _last_citations and
+                # _last_provenance after brain.query() returns).
+                self._query_cache[cache_key] = (
+                    time.monotonic(),
+                    response,
+                    self._last_citations,
+                    self._last_provenance,
+                )
                 self._query_cache.move_to_end(cache_key)  # mark as most-recently-used
         return response
 
@@ -1751,6 +1789,11 @@ class QueryRouterMixin:
         Subsequent items are plain string chunks from the LLM stream.
         """
         self._validate_embedding_meta(on_mismatch="warn")
+        # Clear citation metadata for parity with query(). Streaming callers
+        # can't extract citations from individual tokens, but at minimum the
+        # sources list is populated once retrieval completes so a previous
+        # query's citations don't leak through.
+        self._last_citations = {"sources": [], "citations": []}
         cfg = self._apply_overrides(overrides)
         # --- System-level query router (mirrors query() routing logic) ---
         if cfg.query_router != "off":
@@ -1875,6 +1918,11 @@ class QueryRouterMixin:
             "retrieved_count": len(citation_results),
             "web_count": _web_count,
         }
+        # Populate _last_citations.sources before streaming begins so REST
+        # /query/stream and MCP-tool callers can read sources after the
+        # generator is consumed. The citations array stays empty because we
+        # never see the full response on the streaming path.
+        self._last_citations = _build_citation_metadata("", citation_results)
         # Yield a marker object so UI can optionally reconstruct sources
         yield {"type": "sources", "sources": results}
         yield from self.llm.stream(query, system_prompt, chat_history=chat_history)

--- a/src/axon/query_router.py
+++ b/src/axon/query_router.py
@@ -1592,22 +1592,30 @@ class QueryRouterMixin:
             with self._cache_lock:
                 cached = self._query_cache.get(cache_key)
                 if cached is not None:
-                    # Tuple layout: (stored_time, response, citations, provenance).
-                    # Legacy 2-tuples are still accepted for backwards
+                    # Tuple layout:
+                    #   (stored_time, response, citations, provenance, diagnostics)
+                    # Legacy shorter tuples are still accepted for backwards
                     # compatibility with externally-injected entries (tests).
                     stored_time, stored_response, *rest = cached
                     stored_citations = rest[0] if rest else {"sources": [], "citations": []}
                     stored_provenance = rest[1] if len(rest) > 1 else {}
+                    stored_diagnostics = rest[2] if len(rest) > 2 else None
                     ttl = getattr(cfg, "query_cache_ttl", 1800)
                     if ttl <= 0 or time.monotonic() - stored_time < ttl:
                         logger.info(f"Cache hit for query: {query[:60]}")
                         self._query_cache.move_to_end(cache_key)
                         # Restore brain-level state so callers reading
-                        # _last_citations / _last_provenance after a cache
-                        # hit see the cached query's data, not stale state
-                        # from a different prior call.
-                        self._last_citations = stored_citations
-                        self._last_provenance = stored_provenance
+                        # _last_citations / _last_provenance / _last_diagnostics
+                        # after a cache hit see the cached query's data, not
+                        # stale state from a different prior call. Deep-copy
+                        # everything we return so subsequent mutations of the
+                        # restored dicts can't corrupt the cached originals.
+                        import copy as _copy
+
+                        self._last_citations = _copy.deepcopy(stored_citations)
+                        self._last_provenance = _copy.deepcopy(stored_provenance)
+                        if stored_diagnostics is not None:
+                            self._last_diagnostics = _copy.deepcopy(stored_diagnostics)
                         return stored_response
                     else:
                         del self._query_cache[cache_key]
@@ -1763,15 +1771,22 @@ class QueryRouterMixin:
                 # Evict least-recently-used entry when cache is at capacity
                 if len(self._query_cache) >= cfg.query_cache_size and self._query_cache:
                     self._query_cache.popitem(last=False)  # pop LRU (front of OrderedDict)
-                # Store citations + provenance alongside the response so a
-                # subsequent cache hit can restore the brain-level state
-                # callers depend on (REST /query reads _last_citations and
-                # _last_provenance after brain.query() returns).
+                # Store citations + provenance + diagnostics alongside the
+                # response so a subsequent cache hit can restore the brain-
+                # level state callers depend on (REST /query reads
+                # _last_citations, _last_provenance, and _last_diagnostics
+                # after brain.query() returns). Deep-copy the mutable metadata
+                # before storing so later mutations of self._last_* by a
+                # subsequent query can't reach back and corrupt this cache
+                # entry.
+                import copy as _copy
+
                 self._query_cache[cache_key] = (
                     time.monotonic(),
                     response,
-                    self._last_citations,
-                    self._last_provenance,
+                    _copy.deepcopy(self._last_citations),
+                    _copy.deepcopy(self._last_provenance),
+                    _copy.deepcopy(self._last_diagnostics),
                 )
                 self._query_cache.move_to_end(cache_key)  # mark as most-recently-used
         return response

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10157,13 +10157,22 @@ class TestContextManager:
 
 
 class TestApplyOverrides:
-    def test_none_overrides_returns_config_unchanged(self, brain):
+    def test_none_overrides_returns_unmutated_copy(self, brain):
+        """``_apply_overrides`` always returns a fresh copy — even with no
+        overrides — so downstream route-profile mutations can't reach back
+        and corrupt ``brain.config`` across requests. The returned config
+        is value-equal to the original, just not the same instance."""
         result = brain._apply_overrides(None)
-        assert result is brain.config
+        assert result is not brain.config
+        assert result.top_k == brain.config.top_k
+        assert result.hyde == brain.config.hyde
 
-    def test_empty_overrides_returns_config_unchanged(self, brain):
+    def test_empty_overrides_returns_unmutated_copy(self, brain):
+        """Same contract for the empty-dict case as for ``None``."""
         result = brain._apply_overrides({})
-        assert result is brain.config
+        assert result is not brain.config
+        assert result.top_k == brain.config.top_k
+        assert result.hyde == brain.config.hyde
 
     def test_valid_override_creates_copy(self, brain):
         result = brain._apply_overrides({"top_k": 99})

--- a/tests/test_query_router_robustness.py
+++ b/tests/test_query_router_robustness.py
@@ -1564,15 +1564,23 @@ class TestGetMultiQueries:
 
 
 class TestApplyOverrides:
-    def test_none_overrides_returns_self_config(self):
+    def test_none_overrides_returns_distinct_copy(self):
+        """Even with no overrides, the returned config must NOT be the same
+        object as ``self.config`` — otherwise callers that mutate the returned
+        config (route profiles in ``query()``) corrupt the brain's shared
+        config across queries.
+        """
         stub = _make_full_stub()
         cfg = stub._apply_overrides(None)
-        assert cfg is stub.config
+        assert cfg is not stub.config
+        # Fields equal because no overrides applied
+        assert cfg.top_k == stub.config.top_k
 
-    def test_empty_overrides_returns_self_config(self):
+    def test_empty_overrides_returns_distinct_copy(self):
         stub = _make_full_stub()
         cfg = stub._apply_overrides({})
-        assert cfg is stub.config
+        assert cfg is not stub.config
+        assert cfg.top_k == stub.config.top_k
 
     def test_valid_override_applied(self):
         stub = _make_full_stub()
@@ -1590,6 +1598,34 @@ class TestApplyOverrides:
         stub = _make_full_stub(top_k=5)
         cfg = stub._apply_overrides({"top_k": None})
         assert cfg.top_k == 5
+
+    def test_route_profile_does_not_mutate_self_config(self):
+        """Regression: with no overrides, route profile must not leak through
+        to ``self.config``. Before the fix, the factual route flipped
+        ``self.config.hyde`` to False on the first query.
+        """
+        stub = _make_full_stub(
+            query_router="heuristic",
+            hyde=True,
+            similarity_threshold=0.0,
+        )
+        original_hyde = stub.config.hyde
+        # 'What is X?' classifies as factual; factual profile forces hyde=False.
+        stub.query("What is Python?")
+        # ``self.config.hyde`` must remain as the user set it.
+        assert stub.config.hyde == original_hyde
+
+    def test_route_profile_stream_does_not_mutate_self_config(self):
+        """query_stream() must also leave self.config alone."""
+        stub = _make_full_stub(
+            query_router="heuristic",
+            hyde=True,
+            similarity_threshold=0.0,
+        )
+        stub.llm.stream.return_value = iter(["chunk"])
+        original_hyde = stub.config.hyde
+        list(stub.query_stream("What is Python?"))
+        assert stub.config.hyde == original_hyde
 
 
 # ===========================================================================
@@ -1703,3 +1739,173 @@ class TestProfileIntegration:
         stub.query("What is Python?")  # short factual → factual route
         # After factual profile applied, hyde should be False
         assert calls[-1] is False
+
+
+# ===========================================================================
+# 25. Citation regex — extra forms emitted by the LLM
+# ===========================================================================
+
+
+class TestCitationMarkerRegex:
+    """The citation regex must match every form the LLM might emit:
+
+    - bare ``[N]``
+    - ``[Document N]``
+    - ``[Document N — label]`` (the exact marker shown in context)
+    - ``[Document N (ID: ...)]`` (the system-prompt example form)
+
+    It must NOT match unrelated bracketed-digit snippets like ``[1 line]``
+    that may appear in source-quoted code.
+    """
+
+    def _build_citations(self, response: str, n_sources: int):
+        from axon.query_router import _build_citation_metadata
+
+        rows = [
+            {
+                "id": f"doc_{i}",
+                "text": f"content {i}",
+                "score": 0.9,
+                "metadata": {"source": f"src_{i}.txt"},
+            }
+            for i in range(n_sources)
+        ]
+        return _build_citation_metadata(response, rows)
+
+    def test_bare_digit_form_matches(self):
+        meta = self._build_citations("Answer [1] cites first source.", 1)
+        assert len(meta["citations"]) == 1
+        assert meta["citations"][0]["document_index"] == 0
+
+    def test_document_prefix_form_matches(self):
+        meta = self._build_citations("Answer [Document 1] cites first.", 1)
+        assert len(meta["citations"]) == 1
+        assert meta["citations"][0]["document_index"] == 0
+
+    def test_document_form_with_label_matches(self):
+        """Regression: LLM copies the exact marker shown in _build_context."""
+        meta = self._build_citations(
+            "Answer [Document 1 — src_0.txt] cites first.",
+            1,
+        )
+        assert len(meta["citations"]) == 1
+        assert meta["citations"][0]["document_index"] == 0
+
+    def test_document_form_with_id_parens_matches(self):
+        """Regression: LLM follows the SYSTEM_PROMPT exact example form."""
+        meta = self._build_citations(
+            "Answer [Document 1 (ID: doc_0)] cites first.",
+            1,
+        )
+        assert len(meta["citations"]) == 1
+        assert meta["citations"][0]["document_index"] == 0
+
+    def test_bare_digit_strict_does_not_match_code_snippets(self):
+        """Bare ``[N]`` form stays strict — extra content after the digit
+        in the bare form must NOT match (avoids false positives in
+        source-quoted code like ``[1 line]``)."""
+        meta = self._build_citations("See [1 line of code] for example.", 1)
+        assert meta["citations"] == []
+
+    def test_three_digit_index_supported(self):
+        meta = self._build_citations("Answer [Document 100] cites it.", 100)
+        assert len(meta["citations"]) == 1
+        assert meta["citations"][0]["document_index"] == 99
+
+    def test_out_of_range_index_rejected(self):
+        """Index larger than number of sources is discarded."""
+        meta = self._build_citations("Answer [Document 99].", 1)
+        assert meta["citations"] == []
+        assert len(meta["sources"]) == 1
+
+    def test_multiple_citations_in_one_response(self):
+        meta = self._build_citations(
+            "Per [Document 1] and [2], the answer is X. Also [Document 1 — src_0.txt].",
+            2,
+        )
+        assert len(meta["citations"]) == 3
+        assert [c["document_index"] for c in meta["citations"]] == [0, 1, 0]
+
+
+# ===========================================================================
+# 26. Cache hit restores _last_citations and _last_provenance
+# ===========================================================================
+
+
+class TestQueryCacheCitationRestore:
+    """Regression: cache hits must restore _last_citations and
+    _last_provenance so REST /query callers reading those attributes see
+    the cached query's data, not stale state from a previous call.
+    """
+
+    def test_cache_hit_restores_citations(self):
+        stub = _make_full_stub(
+            query_cache=True,
+            query_cache_size=10,
+            similarity_threshold=0.0,
+        )
+        # First call (miss) — response cites Document 1
+        stub.llm.complete.return_value = "Answer [Document 1] explains."
+        stub.query("first query")
+        first_citations = dict(stub._last_citations)
+        first_provenance = dict(stub._last_provenance)
+        assert len(first_citations.get("sources", [])) >= 1
+        assert len(first_citations.get("citations", [])) >= 1
+
+        # Pollute the brain-level state with a different query's data.
+        stub._last_citations = {"sources": [], "citations": []}
+        stub._last_provenance = {"answer_source": "wrong_data"}
+
+        # Second call (hit) — must restore citations + provenance from cache.
+        result = stub.query("first query")
+        assert result == "Answer [Document 1] explains."
+        assert stub._last_citations == first_citations
+        assert stub._last_provenance == first_provenance
+
+    def test_cache_hit_supports_legacy_2tuple(self):
+        """Externally-injected 2-tuple cache entries (response only) must
+        still work — gracefully falls back to empty citations/provenance.
+        """
+        import time as _time
+
+        stub = _make_full_stub(
+            query_cache=True,
+            query_cache_size=10,
+            similarity_threshold=0.0,
+        )
+        cache_key = stub._make_cache_key("legacy query", None, stub.config)
+        # Pre-populate with a 2-tuple (legacy format)
+        stub._query_cache[cache_key] = (_time.monotonic(), "legacy answer")
+        result = stub.query("legacy query")
+        assert result == "legacy answer"
+        assert stub._last_citations == {"sources": [], "citations": []}
+        assert stub._last_provenance == {}
+
+
+# ===========================================================================
+# 27. query_stream populates _last_citations.sources
+# ===========================================================================
+
+
+class TestQueryStreamCitations:
+    def test_stream_resets_last_citations(self):
+        stub = _make_full_stub(similarity_threshold=0.0)
+        # Pre-populate citations to simulate state from a prior query.
+        stub._last_citations = {
+            "sources": [{"index": 0, "id": "stale", "title": "stale"}],
+            "citations": [{"marker": "[1]", "document_index": 0}],
+        }
+        stub.llm.stream.return_value = iter(["token"])
+        list(stub.query_stream("new query"))
+        # After streaming, sources reflect the new retrieval — NOT the stale
+        # prior state.
+        assert all(s["id"] != "stale" for s in stub._last_citations["sources"])
+
+    def test_stream_populates_sources_after_retrieval(self):
+        stub = _make_full_stub(similarity_threshold=0.0)
+        stub.llm.stream.return_value = iter(["token"])
+        list(stub.query_stream("query with retrieval"))
+        # _last_citations.sources is populated even though we can't extract
+        # citation markers from a stream (no full response to scan).
+        assert len(stub._last_citations["sources"]) >= 1
+        assert stub._last_citations["citations"] == []


### PR DESCRIPTION
## Summary

Audit of `src/axon/query_router.py` (and `surface_contract.py`) for unit 6 of the parallel bug audit. Four bugs found and fixed.

### Bug 1: `_apply_overrides` mutates `self.config`
When called with no overrides, the method returned `self.config` by reference. Route-profile logic in `query()` / `query_stream()` then mutated that shared config via `object.__setattr__`, silently corrupting the brain's global state. Reproducer:

```python
stub = make_brain(query_router='heuristic', hyde=True)
stub.query("What is Python?")  # factual route forces hyde=False
assert stub.config.hyde == True  # FAILS — was flipped to False
```

**Fix**: always return `copy.copy(self.config)`, even when overrides is empty.

### Bug 2: Cache hit drops `_last_citations` and `_last_provenance`
`query()` resets `_last_citations` at entry, then a cache hit returns the stored response without restoring those fields. The REST `/query` endpoint reads `brain._last_citations` after the call and returned empty sources for every cached query.

**Fix**: cache entries now carry citation + provenance state alongside the response; a hit restores them. Legacy 2-tuple entries still work for backwards compatibility with test fixtures.

### Bug 3: Citation regex misses common LLM formats
The pattern `\[(?:Document\s+)?(\d{1,2})\]` only matched `[N]` and `[Document N]`. It failed on:
- `[Document 1 — somefile.txt]` — the **exact marker** shown to the LLM by `_build_context`
- `[Document 1 (ID: ...)]` — the example form in the SYSTEM_PROMPT
- `[Document 100]` — three-digit indices (top_k > 99)

**Fix**: dual-alternation pattern `\[(?:Document\s+(\d{1,3})(?:[^\]]*)?|(\d{1,3}))\]` — Document-prefix form accepts any trailing non-`]` content; the bare `[N]` form stays strict to avoid false positives in source-quoted code (`[1 line]` etc.).

### Bug 4: `query_stream()` never resets/sets `_last_citations`
Stream callers reading the field saw stale citations from a previous `query()` call. Now reset at entry and populate `.sources` once retrieval completes.

## Test plan

- [x] 12 new regression tests across 3 new test classes (`TestCitationMarkerRegex`, `TestQueryCacheCitationRestore`, `TestQueryStreamCitations`)
- [x] 2 new mutation-leak regression tests in `TestApplyOverrides`
- [x] 2 existing `TestApplyOverrides` tests updated (they encoded the old buggy contract)
- [x] `python -m pytest tests/test_query_router_robustness.py -v --no-cov` — 139 passed
- [x] `python -m pytest tests/test_lint.py -v --no-cov` — 3 passed (black, ruff, mypy)
- [x] Pre-commit hooks all passing on local commit

## Patterns reviewed

Silent exception swallowing, `_apply_overrides` design, citation index lookup, context bloat / budgets, `_CITATION_TEXT_TRUNCATE`, route selection precedence, `_make_cache_key` correctness, query cache TTL, `getattr` on config, threading lock interaction, `chat_history` empty-list semantics, top_k validation, no-context fallback prompt, parent_doc retrieval semantics.

Patterns flagged but not addressed in this PR (low blast-radius, out of audit scope):
- `_make_cache_key` omits `query_router`, `mmr`, `code_lexical_boost`, `sparse_retrieval`, `code_top_k` flags — two semantically different queries can share a cache entry but only when the user toggles those flags between calls (rare).
- `_ROUTE_PROFILES` references `parent_doc` which is not an `AxonConfig` field (silently dropped by the `hasattr` guard) — dead code, harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)