### PR TITLE
audit(surfaces): 2 bug fixes

### DIFF
--- a/src/axon/agent.py
+++ b/src/axon/agent.py
@@ -1088,13 +1088,38 @@ def _tool_create_project(brain, args: dict) -> str:
     return f"Project '{name}' created." + (f" Description: {description}" if description else "")
 
 
+# Config fields that contain credentials / API keys. ``_tool_get_config``
+# feeds its output back to the LLM driving the agent loop, so the raw
+# values must never appear there — even a cloud LLM provider would see
+# them otherwise. Keep this list in sync with the ``str`` fields in
+# :class:`axon.config.AxonConfig` that hold secrets (api_*, *_pat,
+# *_key, etc.).
+_SENSITIVE_CONFIG_FIELDS: frozenset[str] = frozenset(
+    {
+        "api_key",
+        "openai_api_key",
+        "grok_api_key",
+        "gemini_api_key",
+        "ollama_cloud_key",
+        "copilot_pat",
+        "brave_api_key",
+        "qdrant_api_key",
+    }
+)
+
+
 def _tool_get_config(brain) -> str:
     import dataclasses
 
     cfg = brain.config
     lines = [f"active_project: {brain._active_project}"]
     for field in dataclasses.fields(cfg):
-        lines.append(f"{field.name}: {getattr(cfg, field.name)}")
+        value = getattr(cfg, field.name)
+        if field.name in _SENSITIVE_CONFIG_FIELDS and value:
+            # Preserve "set vs unset" semantics so the agent can still
+            # answer "is OpenAI configured?" without seeing the key.
+            value = "***"
+        lines.append(f"{field.name}: {value}")
     return "\n".join(lines)
 
 
@@ -1279,7 +1304,12 @@ def _tool_refresh_ingest(brain, args: dict) -> str:
                 continue
             docs = loader_mgr.loaders[ext].load(source)
             combined = "".join(d.get("text", "") for d in docs)
-            current_hash = hashlib.sha256(combined.encode("utf-8", errors="replace")).hexdigest()
+            # Match the digest written by AxonBrain.ingest() to _doc_versions
+            # (see main.py: ``_hl.md5(...).hexdigest()``). Using SHA-256 here
+            # made the comparison mismatch for every file, so every refresh
+            # re-ingested everything — wasting embedding/LLM budget on
+            # unchanged content.
+            current_hash = hashlib.md5(combined.encode("utf-8", errors="replace")).hexdigest()
             if current_hash == stored_hash:
                 skipped += 1
                 continue

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -30,6 +30,7 @@ from axon.agent import (
     _tool_list_knowledge,
     _tool_list_projects,
     _tool_read_file,
+    _tool_refresh_ingest,
     _tool_search_knowledge,
     _tool_switch_project,
     _tool_update_settings,
@@ -368,6 +369,70 @@ class TestToolGetConfig:
         brain.config = _make_config(top_k=10)
         result = _tool_get_config(brain)
         assert "top_k: 10" in result
+
+    def test_get_config_redacts_sensitive_fields(self):
+        """Sensitive credentials must not appear in the LLM-facing output.
+
+        Regression for the agent.py:1091 secret leak — _tool_get_config
+        dumped every AxonConfig field via ``dataclasses.fields`` and
+        fed the result back to the LLM driving the agent loop, exposing
+        every populated API key / PAT to the model provider.
+        """
+        import dataclasses as _dc
+
+        @_dc.dataclass
+        class _CfgWithSecrets:
+            top_k: int = 5
+            openai_api_key: str = "sk-secret-OPENAI"
+            grok_api_key: str = "secret-GROK"
+            gemini_api_key: str = "secret-GEMINI"
+            ollama_cloud_key: str = "secret-OLLAMA"
+            copilot_pat: str = "ghp_secret_pat"
+            brave_api_key: str = "secret-BRAVE"
+            qdrant_api_key: str = "secret-QDRANT"
+            api_key: str = "secret-LEGACY"
+            llm_provider: str = "openai"  # non-sensitive sanity check
+
+        brain = _make_brain()
+        brain.config = _CfgWithSecrets()
+        result = _tool_get_config(brain)
+        # Sensitive values must be redacted...
+        for plaintext in (
+            "sk-secret-OPENAI",
+            "secret-GROK",
+            "secret-GEMINI",
+            "secret-OLLAMA",
+            "ghp_secret_pat",
+            "secret-BRAVE",
+            "secret-QDRANT",
+            "secret-LEGACY",
+        ):
+            assert plaintext not in result, f"leaked secret: {plaintext}"
+        # ...but the field NAMES are still visible so the agent can
+        # reason about whether a key is set.
+        assert "openai_api_key: ***" in result
+        assert "copilot_pat: ***" in result
+        # Non-sensitive fields pass through unchanged.
+        assert "llm_provider: openai" in result
+
+    def test_get_config_unset_secret_renders_as_empty(self):
+        """Empty / unset secret strings stay empty — only populated
+        values get the ``***`` mask so the agent can distinguish
+        "not configured" from "configured but redacted"."""
+        import dataclasses as _dc
+
+        @_dc.dataclass
+        class _CfgEmptySecrets:
+            openai_api_key: str = ""
+            top_k: int = 5
+
+        brain = _make_brain()
+        brain.config = _CfgEmptySecrets()
+        result = _tool_get_config(brain)
+        # Empty string must NOT be masked — the field reports as-is so
+        # the agent can tell "not configured" apart from "redacted".
+        assert "***" not in result
+        assert "openai_api_key: " in result.splitlines()
 
 
 # ---------------------------------------------------------------------------
@@ -772,3 +837,63 @@ class TestDestructiveConfirmMessages:
         assert (
             expected_fragment in captured[0]
         ), f"Expected '{expected_fragment}' in confirm message: {captured[0]!r}"
+
+
+# ---------------------------------------------------------------------------
+# _tool_refresh_ingest — hash-algorithm parity with AxonBrain.ingest()
+# ---------------------------------------------------------------------------
+
+
+class TestToolRefreshIngest:
+    """Refresh must use the same hash algorithm AxonBrain.ingest writes to
+    ``_doc_versions`` (``hashlib.md5``); otherwise every unchanged file is
+    needlessly re-ingested, burning embedding and LLM budget."""
+
+    def test_skips_unchanged_file_when_hash_matches(self, tmp_path):
+        import hashlib
+
+        # Match what AxonBrain.ingest() writes to _doc_versions (md5).
+        src = tmp_path / "doc.md"
+        src.write_text("hello world", encoding="utf-8")
+        expected_hash = hashlib.md5(b"hello world").hexdigest()
+
+        brain = _make_brain()
+        brain._doc_versions = {
+            str(src): {"content_hash": expected_hash, "chunk_count": 1},
+        }
+
+        loader = MagicMock()
+        loader.load.return_value = [{"text": "hello world"}]
+        with patch("axon.loaders.DirectoryLoader") as DL:
+            DL.return_value.loaders = {".md": loader}
+            result = _tool_refresh_ingest(brain, {})
+
+        # The file content matches the stored hash → must be skipped, not
+        # re-ingested. The bug pre-fix used sha256 here, so every file
+        # always fell into the re-ingest branch.
+        brain.ingest.assert_not_called()
+        assert "1 unchanged" in result, result
+
+    def test_reingests_when_content_changes(self, tmp_path):
+        import hashlib
+
+        src = tmp_path / "doc.md"
+        src.write_text("new content", encoding="utf-8")
+        # Stored hash matches an OLDER version of the file.
+        stale_hash = hashlib.md5(b"old content").hexdigest()
+
+        brain = _make_brain()
+        brain._doc_versions = {
+            str(src): {"content_hash": stale_hash, "chunk_count": 1},
+        }
+        brain.list_documents.return_value = []  # no existing chunks to purge
+
+        loader = MagicMock()
+        loader.load.return_value = [{"text": "new content"}]
+        with patch("axon.loaders.DirectoryLoader") as DL:
+            DL.return_value.loaders = {".md": loader}
+            result = _tool_refresh_ingest(brain, {})
+
+        # Hash mismatch → must call brain.ingest exactly once.
+        assert brain.ingest.call_count == 1
+        assert "1 file(s) re-ingested" in result, result


### PR DESCRIPTION
## Summary

Two bug fixes from the parallel bug audit of `src/axon/` (unit 10: REPL, CLI, MCP, agent, tools, doctor, webapp, integrations).

### 1. `_tool_get_config` leaked API keys to the LLM (HIGH)

`agent.py:_tool_get_config` dumped every `AxonConfig` field via `dataclasses.fields` and fed the result back to the LLM driving the agent loop. The tool result becomes part of conversation context, so a cloud LLM provider (OpenAI / Gemini / Grok / Ollama Cloud / GitHub Copilot) would see the user's API keys for **every other provider** on the next request.

Affected fields: `api_key`, `openai_api_key`, `grok_api_key`, `gemini_api_key`, `ollama_cloud_key`, `copilot_pat`, `brave_api_key`, `qdrant_api_key`.

Fix: introduce a local `_SENSITIVE_CONFIG_FIELDS` frozenset and mask populated values with `***` while preserving the field name (so the agent can still answer "is OpenAI configured?" without seeing the key). Empty/unset values pass through unchanged so the agent can distinguish "not configured" from "redacted".

### 2. `_tool_refresh_ingest` always re-ingested every file (MEDIUM)

`agent.py:_tool_refresh_ingest` computed file content hashes with `sha256`, but `AxonBrain.ingest()` writes **md5** hashes to `_doc_versions` (see `main.py:2681`). Every comparison failed → every refresh re-ingested every tracked file even when on-disk content was unchanged, wasting embedding + LLM budget on no-op refreshes. The REPL `/refresh` path (`repl.py:4061`) already uses md5 correctly.

Fix: switch to `hashlib.md5` to match the stored digest.

### Other patterns reviewed (no findings)

`asyncio.run` inside running loop, TOCTOU, `getattr(args, ...)` defaults, CLI argparse, REPL command parsing, MCP marshaling, agent tool argument validation, langchain/llama-index optional imports, type-narrowing falsy defaults, requests timeouts, Streamlit session state, exec/eval in user-controlled args, doctor.py urllib timeouts, ext_install subprocess, graph_render.py HTML escaping.

## Test plan

- [x] New regression tests in `tests/test_agent.py`:
  - `test_get_config_redacts_sensitive_fields` — verifies all 8 sensitive fields are masked
  - `test_get_config_unset_secret_renders_as_empty` — empty values stay empty (semantic preservation)
  - `test_skips_unchanged_file_when_hash_matches` — refresh skips when md5 matches
  - `test_reingests_when_content_changes` — refresh re-ingests when hashes diverge
- [x] Existing test_agent.py suite still passes (79 tests, 0.81s)
- [x] Broader suite passes: test_cli_advanced + test_cli_extra + test_mcp_server + test_repl_e2e + test_repl_commands + test_v032_integrations + test_v032_onboarding (489 passed, 8 skipped)
- [x] Lint suite passes: black, ruff, mypy

🤖 Generated with [Claude Code](https://claude.com/claude-code)