### PR TITLE
audit(security): 3 bug fixes

### DIFF
--- a/src/axon/security/cache.py
+++ b/src/axon/security/cache.py
@@ -69,6 +69,7 @@ __all__ = [
     "CACHE_HEADROOM_FRACTION",
     "CacheCapacityError",
     "SealedCache",
+    "SealedFileTamperError",
     "cleanup_orphans",
     "is_sealed_file",
 ]
@@ -88,6 +89,24 @@ class CacheCapacityError(RuntimeError):
     Surfaced with concrete numbers (project size, free space, deficit)
     so the user can either free up disk or move ``TMPDIR`` /
     ``TEMP`` to a roomier volume.
+    """
+
+
+class SealedFileTamperError(RuntimeError):
+    """Raised when a file in the seal policy's must-seal set lacks the
+    AXSL header at mount time.
+
+    AAD binding into the GCM tag prevents an attacker from forging
+    new ciphertext, but it does NOT prevent an attacker with write
+    access to the synced filesystem from REPLACING an encrypted file
+    with a plaintext one. Without an explicit check at materialise
+    time, the cache would copy that plaintext to a path the backend
+    later reads as authoritative — bypassing authenticated encryption.
+
+    This error surfaces the tamper to the caller (``materialize_for_read``)
+    which wraps it as :class:`SecurityError`. The partial cache is
+    wiped by the same ``except`` block that catches every other
+    materialisation failure.
     """
 
 
@@ -333,6 +352,11 @@ class SealedCache:
                 "roomier volume."
             )
         cache_dir = Path(tempfile.mkdtemp(prefix=CACHE_PREFIX, dir=str(cache_parent)))
+        # Defer the import of the seal policy to avoid a cache → seal →
+        # cache cycle at module load. The policy is a pure function over
+        # the relative path so calling it inside the loop adds no I/O.
+        from .seal import _should_seal  # noqa: PLC0415
+
         try:
             # PID sentinel — used by cleanup_orphans on next boot.
             (cache_dir / PID_SENTINEL_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
@@ -355,10 +379,27 @@ class SealedCache:
                     plaintext = SealedFile.read(src, dek, aad=aad)
                     dst.write_bytes(plaintext)
                 else:
-                    # Non-sealed file (e.g. version.json which is
-                    # deliberately plaintext). Copy as-is so the
-                    # cache is a faithful materialisation of the
-                    # project view.
+                    # The seal policy decides which files MUST be encrypted;
+                    # anything in the must-seal set that lacks the AXSL
+                    # header here is either tampering or a corrupted seal.
+                    # Refuse rather than silently materialise attacker-
+                    # controlled plaintext into the cache where backends
+                    # would consume it as authoritative — AAD binding
+                    # prevents ciphertext forgery, but does NOT prevent
+                    # an attacker with write access from REPLACING an
+                    # encrypted file with plaintext.
+                    if _should_seal(rel):
+                        raise SealedFileTamperError(
+                            f"Project file {rel} is in the must-seal set but "
+                            "lacks an AXSL header. The sealed project may "
+                            "have been tampered with on the synced filesystem "
+                            "(an attacker may have replaced an encrypted file "
+                            "with plaintext to bypass authenticated encryption). "
+                            "Refusing to materialise."
+                        )
+                    # Plaintext passthrough file (deliberately unsealed —
+                    # version.json, store_meta.json, etc.). Copy as-is so
+                    # the cache is a faithful view of the project.
                     shutil.copy2(src, dst)
         except Exception:
             # On any failure during materialisation, wipe the partial

--- a/src/axon/security/crypto.py
+++ b/src/axon/security/crypto.py
@@ -178,10 +178,12 @@ def _unpack_header(header: bytes) -> tuple[int, int, int]:
         raise SealedFormatError(
             f"Unsupported cipher_id {cipher_id} (only AES-256-GCM = {CIPHER_AES_256_GCM})"
         )
-    if padding_length < 0 or padding_length > 1024 * 1024:
-        # Sanity bound: 1 MiB cap on padding length keeps a corrupt
-        # header from making us slice past the file's end with nothing
-        # actionable to do.
+    if padding_length < 0 or padding_length > MAX_PADDING_BYTES:
+        # Sanity bound: the same MAX_PADDING_BYTES cap that the writer
+        # enforces via _validate_padding_bytes (see ~line 95). Sourcing
+        # both from the same constant keeps the read- and write-side
+        # bounds from drifting and re-introducing the original
+        # writer-accepts / reader-rejects data-loss mismatch.
         raise SealedFormatError(f"Implausible padding_length in header: {padding_length}")
     return version, cipher_id, padding_length
 

--- a/src/axon/security/crypto.py
+++ b/src/axon/security/crypto.py
@@ -57,6 +57,7 @@ __all__ = [
     "TAG_LEN",
     "DEK_LEN",
     "STREAMING_CHUNK_SIZE",
+    "MAX_PADDING_BYTES",
     "SealedFormatError",
     "SealedFile",
     "generate_dek",
@@ -83,6 +84,33 @@ DEK_LEN: int = 32  # 256-bit Data Encryption Key
 # and memory residency (larger chunks = more bytes pinned per worker).
 # Override via the ``chunk_size`` kwarg on :meth:`SealedFile.write_stream`.
 STREAMING_CHUNK_SIZE: int = 1024 * 1024
+
+# Hard cap on the ``padding_bytes`` parameter accepted by the writers.
+# Must stay <= the reader's ``_unpack_header`` sanity bound — otherwise
+# a writer could emit a file whose padding_length field falls above the
+# reader's threshold, producing SealedFormatError on read (silent data
+# loss until a future release bumps the reader bound). The config layer
+# (``AxonConfig.seal_padding_bytes``) enforces the same cap; this check
+# defends direct callers (tests, scripts) that bypass the config path.
+MAX_PADDING_BYTES: int = 1024 * 1024
+
+
+def _validate_padding_bytes(padding_bytes: int) -> None:
+    """Reject padding budgets outside ``[0, MAX_PADDING_BYTES]``.
+
+    Shared by :meth:`SealedFile.write` and :meth:`SealedFile.write_stream`
+    so the upper-bound check stays consistent with the reader's
+    ``_unpack_header`` sanity bound.
+    """
+    if padding_bytes < 0:
+        raise ValueError("padding_bytes must be >= 0")
+    if padding_bytes > MAX_PADDING_BYTES:
+        raise ValueError(
+            f"padding_bytes={padding_bytes} exceeds MAX_PADDING_BYTES "
+            f"({MAX_PADDING_BYTES}); files written with larger padding "
+            "would fail the reader's sanity check on the header field."
+        )
+
 
 # 4-byte magic | 1-byte version | 1-byte cipher_id | 10-byte reserved (zero)
 # Header layout (16 bytes, big-endian):
@@ -227,8 +255,7 @@ class SealedFile:
         """
         if len(key) != 32:
             raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
-        if padding_bytes < 0:
-            raise ValueError("padding_bytes must be >= 0")
+        _validate_padding_bytes(padding_bytes)
         path = Path(path)
         nonce = os.urandom(NONCE_LEN)
         # AESGCM.encrypt returns ciphertext || tag concatenated.
@@ -295,8 +322,7 @@ class SealedFile:
             raise ValueError(f"key must be 32 bytes (AES-256), got {len(key)}")
         if chunk_size <= 0:
             raise ValueError(f"chunk_size must be positive, got {chunk_size}")
-        if padding_bytes < 0:
-            raise ValueError("padding_bytes must be >= 0")
+        _validate_padding_bytes(padding_bytes)
         path = Path(path)
         nonce = os.urandom(NONCE_LEN)
         cipher = Cipher(algorithms.AES(key), modes.GCM(nonce))

--- a/src/axon/security/share.py
+++ b/src/axon/security/share.py
@@ -679,6 +679,23 @@ def generate_sealed_share(
 
         if isinstance(expires_at, datetime):
             expires_at_iso = expires_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    else:
+        # No TTL requested. Defense-in-depth: scrub any stale sidecar
+        # from a prior incarnation of this key_id so the new share is
+        # not silently TTL-gated by old metadata. (``_soft_revoke`` /
+        # ``_hard_revoke`` also clean up, but older builds may have
+        # left a sidecar behind.)
+        stale_sidecar = share_expiry_path(project_dir, key_id)
+        try:
+            stale_sidecar.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Could not remove stale expiry sidecar for key_id=%s at %s: %s. "
+                "Grantees may see unexpected TTL enforcement.",
+                key_id,
+                stale_sidecar,
+                exc,
+            )
     logger.info(
         "Generated sealed share key_id=%s project=%s grantee=%s wrapped_path=%s envelope=SEALED2 expires_at=%s",
         key_id,
@@ -1210,9 +1227,17 @@ def revoke_sealed_share(
 
 def _soft_revoke(project_dir: Path, key_id: str) -> dict[str, Any]:
     """Delete the wrap file for *key_id* — fresh redeem will fail.
-    Also deletes the persisted ``.kek`` sidecar (if present) so the
-    revoked share's KEK isn't kept around indefinitely. Best-effort:
-    a missing KEK file is fine.
+    Also deletes the persisted ``.kek`` sidecar and ``.expiry`` sidecar
+    (if present) so the revoked share's metadata isn't kept around
+    indefinitely. Best-effort: a missing sidecar file is fine.
+
+    Why ``.expiry`` cleanup matters: if the owner later re-issues a
+    share with the SAME key_id but WITHOUT a TTL, ``generate_sealed_share``
+    would not write a new sidecar — leaving the stale one in place.
+    Grantees would then see the OLD sidecar's TTL enforced on the NEW
+    share, defeating the owner's "no TTL" intent. Cleaning up here
+    closes that gap (and ``generate_sealed_share`` cleans up too as
+    defense-in-depth).
     """
     wrap = share_wrap_path(project_dir, key_id)
     if not wrap.is_file():
@@ -1231,6 +1256,14 @@ def _soft_revoke(project_dir: Path, key_id: str) -> dict[str, Any]:
             kek_path.unlink()
         except OSError as exc:
             logger.debug("Could not delete share KEK sidecar %s: %s", kek_path, exc)
+    # Best-effort: drop any signed expiry sidecar so a future
+    # re-issuance of the same key_id starts from a clean slate.
+    expiry_path = share_expiry_path(project_dir, key_id)
+    if expiry_path.is_file():
+        try:
+            expiry_path.unlink()
+        except OSError as exc:
+            logger.debug("Could not delete share expiry sidecar %s: %s", expiry_path, exc)
     logger.info("Soft-revoked sealed share key_id=%s under %s", key_id, project_dir)
     return {
         "status": "soft_revoked",
@@ -1633,9 +1666,15 @@ def _hard_revoke(
         delete_keyids.add(key_id)
     if shares_dir.is_dir():
         for delete_kid in delete_keyids:
+            # Delete the wrap, KEK, AND expiry sidecar so a future
+            # re-issuance of the same key_id starts from a clean slate.
+            # A stale expiry sidecar would otherwise be enforced on the
+            # new share if it was minted without an `expires_at` arg —
+            # defeating the owner's "no TTL" intent.
             for path in (
                 share_wrap_path(project_dir, delete_kid),
                 share_kek_path(project_dir, delete_kid),
+                share_expiry_path(project_dir, delete_kid),
             ):
                 if path.is_file():
                     try:

--- a/tests/test_sealed_cache.py
+++ b/tests/test_sealed_cache.py
@@ -28,6 +28,7 @@ from axon.security.cache import (  # noqa: E402
     PID_SENTINEL_FILENAME,
     CacheCapacityError,
     SealedCache,
+    SealedFileTamperError,
     _self_check,
     cleanup_orphans,
     is_sealed_file,
@@ -212,6 +213,125 @@ class TestCacheCreateFailures:
         ):
             with pytest.raises(CacheCapacityError, match="bytes free"):
                 SealedCache.create(sealed, dek, key_id="sk_a", cache_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Audit regression: tamper detection on must-seal files
+# ---------------------------------------------------------------------------
+
+
+class TestMustSealFileTamperDetection:
+    """Audit (security): SealedCache must refuse to materialise a sealed
+    project where a file in the must-seal set (per ``seal._should_seal``)
+    lacks the AXSL header.
+
+    Threat model: an attacker with write access to the synced filesystem
+    cannot forge new ciphertext (AAD-bound GCM tag), but COULD replace
+    an encrypted file with a plaintext file containing attacker-chosen
+    bytes. Without the tamper check, ``SealedCache.create`` would copy
+    the plaintext as-is and backends would consume it as authoritative —
+    bypassing authenticated encryption for that file. The check enforces
+    "if seal policy says it MUST be sealed, an unsealed copy is a tamper
+    and a hard error".
+    """
+
+    def test_plaintext_meta_json_replacement_rejected(self, tmp_path):
+        """``meta.json`` is in the must-seal root set. An attacker who
+        replaces the sealed copy with plaintext must trip the tamper
+        check, not silently materialise into the cache.
+        """
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_t1", files={"meta.json": b'{"v":1}'})
+
+        # Tamper: replace the encrypted meta.json with raw plaintext
+        # (i.e. simulate an attacker who can write but cannot encrypt).
+        (sealed / "meta.json").write_bytes(b'{"injected":true}')
+        assert not is_sealed_file(sealed / "meta.json"), "Setup: file is plaintext"
+
+        with pytest.raises(SealedFileTamperError, match="must-seal"):
+            SealedCache.create(sealed, dek, key_id="sk_t1", cache_root=tmp_path)
+
+    def test_plaintext_bm25_index_file_rejected(self, tmp_path):
+        """Files under ``bm25_index/`` are in the must-seal content set."""
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(
+            sealed,
+            dek,
+            key_id="sk_t2",
+            files={"bm25_index/.bm25_log.jsonl": b'{"d":"doc1"}\n'},
+        )
+
+        # Tamper a single bm25 file.
+        (sealed / "bm25_index" / ".bm25_log.jsonl").write_bytes(b"plain attacker text")
+
+        with pytest.raises(SealedFileTamperError, match="must-seal"):
+            SealedCache.create(sealed, dek, key_id="sk_t2", cache_root=tmp_path)
+
+    def test_plaintext_vector_store_file_rejected(self, tmp_path):
+        """Files under ``vector_store_data/`` are in the must-seal content set."""
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(
+            sealed,
+            dek,
+            key_id="sk_t3",
+            files={"vector_store_data/manifest.json": b'{"dim":768}'},
+        )
+
+        (sealed / "vector_store_data" / "manifest.json").write_bytes(b"plain")
+
+        with pytest.raises(SealedFileTamperError, match="must-seal"):
+            SealedCache.create(sealed, dek, key_id="sk_t3", cache_root=tmp_path)
+
+    def test_passthrough_files_still_allowed_plaintext(self, tmp_path):
+        """Tamper detection must NOT regress against legitimate plaintext
+        files (``version.json``, ``store_meta.json``, etc.) that are
+        deliberately unsealed by policy.
+        """
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        _seal_project(sealed, dek, key_id="sk_t4", files={"meta.json": b"{}"})
+        # version.json is in _NEVER_SEAL_NAMES — must remain plaintext
+        # and the cache must accept it.
+        (sealed / "version.json").write_text("{}", encoding="utf-8")
+
+        cache = SealedCache.create(sealed, dek, key_id="sk_t4", cache_root=tmp_path)
+        try:
+            assert (cache.path / "version.json").read_text() == "{}"
+        finally:
+            cache.wipe()
+
+    def test_partial_cache_wiped_on_tamper_detection(self, tmp_path):
+        """The tamper check must use the same partial-wipe path as other
+        materialisation failures — no plaintext leak in the temp dir
+        after a rejected mount."""
+        sealed = tmp_path / "proj"
+        dek = generate_dek()
+        # Two files; one sealed correctly, one tampered. The cache
+        # iteration order is filesystem-dependent so we exercise both
+        # possible orderings by ensuring no axon-sealed-* dir survives.
+        _seal_project(
+            sealed,
+            dek,
+            key_id="sk_t5",
+            files={
+                "meta.json": b'{"a":1}',
+                "vector_store_data/manifest.json": b'{"d":768}',
+            },
+        )
+        (sealed / "meta.json").write_bytes(b"injected")
+
+        before = {p.name for p in tmp_path.iterdir()}
+        with pytest.raises(SealedFileTamperError):
+            SealedCache.create(sealed, dek, key_id="sk_t5", cache_root=tmp_path)
+        after = {p.name for p in tmp_path.iterdir()}
+        new_caches = [n for n in (after - before) if n.startswith(CACHE_PREFIX)]
+        assert new_caches == [], (
+            "Partial cache survived tamper detection — plaintext bytes "
+            "may have leaked to the temp dir."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sealed_crypto.py
+++ b/tests/test_sealed_crypto.py
@@ -26,6 +26,7 @@ from axon.security.crypto import (  # noqa: E402
     DEK_LEN,
     HEADER_LEN,
     MAGIC,
+    MAX_PADDING_BYTES,
     NONCE_LEN,
     SCHEMA_VERSION,
     TAG_LEN,
@@ -334,6 +335,62 @@ class TestInputValidation:
         SealedFile.write(path, b"data", generate_dek())
         with pytest.raises(ValueError, match="32 bytes"):
             SealedFile.read(path, b"short")
+
+
+# ---------------------------------------------------------------------------
+# Audit regression: padding_bytes hard cap at write-time
+# ---------------------------------------------------------------------------
+
+
+class TestPaddingBytesMaxBound:
+    """Audit (security): SealedFile.write/write_stream must reject
+    ``padding_bytes`` above ``MAX_PADDING_BYTES``.
+
+    The reader's ``_unpack_header`` rejects any header whose
+    ``padding_length`` field exceeds 1 MiB (silent data loss otherwise).
+    Without a matching cap at the writer, a direct caller (test, script,
+    out-of-tree code) could mint a file the reader refuses — silent
+    failure mode hidden by the config layer's separate validation.
+    The hard cap defends direct callers that bypass the config path.
+    """
+
+    def test_max_padding_bytes_constant_is_1_mib(self):
+        assert MAX_PADDING_BYTES == 1024 * 1024
+
+    def test_write_rejects_padding_above_cap(self, tmp_path):
+        dek = generate_dek()
+        with pytest.raises(ValueError, match="MAX_PADDING_BYTES"):
+            SealedFile.write(
+                tmp_path / "oversized",
+                b"data",
+                dek,
+                padding_bytes=MAX_PADDING_BYTES + 1,
+            )
+
+    def test_write_accepts_padding_at_cap(self, tmp_path):
+        """Boundary: exactly MAX_PADDING_BYTES must be accepted."""
+        dek = generate_dek()
+        path = tmp_path / "atcap"
+        SealedFile.write(path, b"hello", dek, padding_bytes=MAX_PADDING_BYTES)
+        # File reads back fine — confirms the cap is consistent with
+        # the reader's bound.
+        assert SealedFile.read(path, dek) == b"hello"
+
+    def test_write_stream_rejects_padding_above_cap(self, tmp_path):
+        dek = generate_dek()
+        with pytest.raises(ValueError, match="MAX_PADDING_BYTES"):
+            SealedFile.write_stream(
+                tmp_path / "stream_oversized",
+                iter([b"data"]),
+                dek,
+                padding_bytes=MAX_PADDING_BYTES + 1,
+            )
+
+    def test_write_still_rejects_negative_padding(self, tmp_path):
+        """Pre-existing negative-padding rejection stays in place."""
+        dek = generate_dek()
+        with pytest.raises(ValueError, match="must be >= 0"):
+            SealedFile.write(tmp_path / "neg", b"data", dek, padding_bytes=-1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sealed_revoke.py
+++ b/tests/test_sealed_revoke.py
@@ -538,3 +538,115 @@ class TestRevokeWiredThroughSecurity:
         )
         assert result["status"] == "hard_revoked"
         assert result["files_resealed"] >= 4
+
+
+# ---------------------------------------------------------------------------
+# Audit regression: stale expiry sidecar cleanup on revoke + re-issue
+# ---------------------------------------------------------------------------
+
+
+class TestExpirySidecarCleanupOnRevoke:
+    """Audit (security): the v0.4.0 signed expiry sidecar (``<key_id>.expiry``)
+    must be deleted alongside the wrap on revoke. Otherwise a future re-issuance
+    of the SAME key_id WITHOUT ``expires_at`` would silently inherit the
+    stale sidecar — the grantee would see TTL enforcement the owner did
+    not intend (or worse, a past-expired sidecar denying access entirely).
+    """
+
+    def test_soft_revoke_deletes_expiry_sidecar(self, kr_backend, owner_user_dir):
+        from datetime import datetime, timedelta, timezone
+
+        from axon.security.share import share_expiry_path
+
+        proj = _populate_and_seal(owner_user_dir)
+        future = datetime.now(timezone.utc) + timedelta(days=30)
+        generate_sealed_share(
+            owner_user_dir, "research", "bob", key_id="ssk_exp_soft", expires_at=future
+        )
+        # Sanity: sidecar was written
+        assert share_expiry_path(proj, "ssk_exp_soft").is_file()
+
+        revoke_sealed_share(owner_user_dir, "research", "ssk_exp_soft")
+
+        # The sidecar must be gone — otherwise a re-issuance without
+        # expires_at would inherit the stale TTL.
+        assert not share_expiry_path(proj, "ssk_exp_soft").is_file()
+
+    def test_hard_revoke_deletes_expiry_sidecar(self, kr_backend, owner_user_dir):
+        from datetime import datetime, timedelta, timezone
+
+        from axon.security.share import share_expiry_path
+
+        proj = _populate_and_seal(owner_user_dir)
+        future = datetime.now(timezone.utc) + timedelta(days=30)
+        generate_sealed_share(
+            owner_user_dir, "research", "bob", key_id="ssk_exp_hard", expires_at=future
+        )
+        assert share_expiry_path(proj, "ssk_exp_hard").is_file()
+
+        revoke_sealed_share(owner_user_dir, "research", "ssk_exp_hard", rotate=True)
+        assert not share_expiry_path(proj, "ssk_exp_hard").is_file()
+
+    def test_reissue_without_expiry_does_not_inherit_stale_sidecar(
+        self, kr_backend, owner_user_dir
+    ):
+        """The owner's intent ("no TTL on re-issue") must win.
+
+        Even if a prior incarnation of the same key_id had a TTL, the
+        re-issued share must NOT carry that TTL — generate_sealed_share
+        must delete any stale sidecar when called without expires_at.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from axon.security.share import share_expiry_path
+
+        proj = _populate_and_seal(owner_user_dir)
+        future = datetime.now(timezone.utc) + timedelta(days=30)
+        generate_sealed_share(
+            owner_user_dir, "research", "bob", key_id="ssk_reissue", expires_at=future
+        )
+        sidecar = share_expiry_path(proj, "ssk_reissue")
+        assert sidecar.is_file()
+
+        # Soft revoke (closes a hypothetical bug where revoke leaves the
+        # sidecar, but also exercises the cleanup chain).
+        revoke_sealed_share(owner_user_dir, "research", "ssk_reissue")
+        assert not sidecar.is_file()
+
+        # Now re-issue with the SAME key_id but NO TTL. The fresh share
+        # must not have any sidecar on disk.
+        generate_sealed_share(owner_user_dir, "research", "bob", key_id="ssk_reissue")
+        assert not sidecar.is_file(), (
+            "Re-issued share without expires_at must not have an expiry sidecar; "
+            "stale sidecar would silently enforce TTL against owner intent."
+        )
+
+    def test_reissue_without_expiry_when_revoke_failed_to_clean_sidecar(
+        self, kr_backend, owner_user_dir
+    ):
+        """Defense-in-depth: even if a prior revoke didn't clean up the
+        sidecar (e.g. older release left it behind), a re-issue without
+        expires_at must scrub it.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from axon.security.share import share_expiry_path
+
+        proj = _populate_and_seal(owner_user_dir)
+        future = datetime.now(timezone.utc) + timedelta(days=30)
+        generate_sealed_share(
+            owner_user_dir, "research", "bob", key_id="ssk_defense", expires_at=future
+        )
+        sidecar = share_expiry_path(proj, "ssk_defense")
+        assert sidecar.is_file()
+
+        # Simulate an older-release soft revoke that deleted only the
+        # wrap, not the sidecar: manually unlink the wrap and KEK.
+        share_wrap_path(proj, "ssk_defense").unlink()
+        share_kek_path(proj, "ssk_defense").unlink()
+        assert sidecar.is_file(), "Setup: sidecar must still be present"
+
+        # Re-issue without TTL. The defense-in-depth cleanup in
+        # generate_sealed_share must scrub the orphan sidecar.
+        generate_sealed_share(owner_user_dir, "research", "bob", key_id="ssk_defense")
+        assert not sidecar.is_file()


### PR DESCRIPTION
## Summary

Unit 3 of the parallel bug audit — scoped to `src/axon/security/` (crypto, sealing, keys, cache). Three bugs found and fixed; +13 regression tests added.

### Bug 1: Stale `.expiry` sidecar after revoke

`_soft_revoke` and `_hard_revoke` deleted the `.wrapped` and `.kek` files but left the `.expiry` sidecar on disk. If the owner later re-issued the same `key_id` WITHOUT `expires_at`, `generate_sealed_share` did not write a new sidecar — the stale one stayed in place and was enforced on the new share. Two failure modes:

- Stale sidecar's `expires_at` in the future → grantee gets unexpected TTL the owner did not intend.
- Stale sidecar's `expires_at` already past → grantee gets `ShareExpiredError` against a freshly-issued share (DoS).

**Fix**: Both revoke paths now delete the `.expiry` sidecar alongside the wrap + KEK. As defense-in-depth, `generate_sealed_share` scrubs any pre-existing sidecar when called without `expires_at` (covers projects sealed by older builds that left orphans behind).

### Bug 2: `SealedFile.write` / `write_stream` accepted `padding_bytes` above reader bound

The reader's `_unpack_header` rejects any `padding_length` > 1 MiB (silent data-loss otherwise). The writers had no matching upper bound — only `padding_bytes < 0` was rejected. The `AxonConfig.seal_padding_bytes` validator caps at 1 MiB, but direct callers (tests, scripts, out-of-tree code) bypassed that path.

**Fix**: New `MAX_PADDING_BYTES` constant and shared `_validate_padding_bytes()` helper used by both writers. Boundary test (`padding_bytes == MAX_PADDING_BYTES`) confirms read/write stay aligned.

### Bug 3: `SealedCache` silently copied tampered plaintext as authoritative

AAD binding into the GCM tag prevents an attacker from forging new ciphertext, but does NOT prevent an attacker with write access to the synced filesystem from REPLACING an encrypted file (e.g. `meta.json`, `bm25_index/*`) with a plaintext file containing attacker-chosen bytes. `SealedCache.create` checked `is_sealed_file(src)` per file — non-AXSL files were copied as-is and backends consumed them as authoritative, bypassing authenticated encryption for that file.

**Fix**: `SealedCache.create` now consults `seal._should_seal(rel)` for each file. Files in the must-seal set that lack the AXSL header raise `SealedFileTamperError`; the existing partial-wipe path handles cleanup so no plaintext leaks to the temp dir. Passthrough files (`version.json`, `store_meta.json`, etc.) still flow through unchanged.

## Patterns reviewed (no findings)

- Pickle / yaml.load / eval / exec — none present in scoped files
- Timing attacks — passphrase / signature paths go through cryptographic constant-time primitives (scrypt + aes_key_unwrap, Ed25519.verify)
- Randomness — all paths use `secrets` / `os.urandom`, never `random.*`
- Nonce reuse — `os.urandom(12)` per AES-GCM call; no counters
- KDF parameter downgrade — scrypt params are constants; passphrase-min-length enforced
- Atomic file writes — sealed files, sidecars, mount descriptors all use `tmp + os.replace`
- Path traversal in mount paths — bearer-token threat model documented; non-fatal failure path
- DEK leakage in logs / errors — no key material in any error message
- Keyring fallback — `keyring_mode` is explicit; no silent downgrade
- Master key rotation atomicity — dual-write to keyring + fallback file documented
- Sealed format parsing — bounds checks on header, padding_length sanity bound

## Test plan

- [x] `python -m pytest tests/test_sealed_*.py tests/test_project_seal.py tests/test_keyring_modes.py tests/test_grantee_dek_fallback.py -v --no-cov` → 297 passed
- [x] `python -m pytest tests/test_lint.py -v --no-cov` → 3 passed (black + ruff + mypy)
- [x] +13 new regression tests cover the three fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)