### PR TITLE
docs(audit): 8 staleness/drift fixes after the 10-PR audit cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,10 +95,6 @@ Cross-interface parity:
 - 32 tests in `tests/test_passphrase.py` covering wordlist parse, entropy, format, edge cases, no-duplicate-in-1000-runs, and REST contract.
 - Default separator is space (4 EFF entries are themselves hyphenated, so `-` would be visually ambiguous as a word delimiter). REST endpoint defaults to `-` for URL-friendliness.
 
----
-
-## [0.4.0] - 2026-05-04
-
 ### 🔒 Security — TTL-gated sealed shares with auto-destruction
 
 Closes the v0.3.x security gap where a redeemed sealed-share DEK lived in the grantee's OS keyring **indefinitely**. v0.4.0 adds:
@@ -185,7 +181,7 @@ The dataclass default for the vector store has been `turboquantdb` since v0.2.1,
 
 ### 🛠️ Developer Experience
 
-- **Pre-commit pytest now uses pytest-testmon** — selective test runs based on per-file coverage tracking. Typical local commit drops from ~45 min to ~30 s for doc-only changes; source edits to widely-imported modules still take a few minutes. CI is unaffected (full suite still runs on every push). Cache file `.testmondata` is gitignored. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#pre-commit-pytest-testmon-accelerated) for cache-recovery commands when the selection is wrong.
+- **Pre-commit pytest now uses pytest-testmon** — selective test runs based on per-file coverage tracking. Typical local commit drops from ~45 min to ~30 s for doc-only changes; source edits to widely-imported modules still take a few minutes. CI is unaffected (full suite still runs on every push). Cache file `.testmondata` is gitignored. (Superseded by `scripts/precommit_pytest_scoped.py` in v0.4.0 — see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#pre-commit-pytest-scope-aware-selector).)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ python -m pytest -k test_basic_split --no-cov
 
 > **Note:** VS Code extension e2e tests (`tests/e2e/test_vscode_extension_*.py`) require a live VS Code instance and are excluded from the standard run via `-m "not extension"`. The pre-commit hook runs the full non-extension suite automatically on every commit (black + ruff + pytest).
 
-> **Pre-commit pytest is testmon-accelerated.** The hook uses `pytest-testmon` to skip tests whose dependent code hasn't changed since the last green run. First commit on a fresh clone runs the full suite (~45 min) to populate `.testmondata` (gitignored); subsequent commits typically take ~30 s for doc-only changes and a few minutes for source edits. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#pre-commit-pytest-testmon-accelerated) for cache-recovery commands.
+> **Pre-commit pytest is scope-aware.** The hook (`scripts/precommit_pytest_scoped.py`) maps each staged file to a small, predictable set of test files via path-prefix rules — `axon/security/*` → sealed-share tests, `axon/api_routes/*` → API tests, etc. Doc / HTML / SVG / Markdown / scripts-only commits skip the hook entirely via the trigger regex. CI runs the full suite on every push as the safety net. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#pre-commit-pytest-scope-aware-selector) for details and how to force a full local run.
 
 ### Code Quality
 
@@ -74,18 +74,20 @@ pre-commit run --all-files  # Run manually
 Axon/
 ├── src/
 │   └── axon/          # Main package
-│       ├── main.py         # Core RAG engine
-│       ├── api.py          # FastAPI endpoints
+│       ├── main.py         # Core RAG engine (AxonBrain)
+│       ├── api.py          # FastAPI app factory
+│       ├── api_routes/     # REST route handlers (split by domain)
 │       ├── webapp.py       # Streamlit UI
 │       ├── loaders.py      # Document loaders
 │       ├── retrievers.py   # BM25 and fusion
 │       ├── splitters.py    # Text chunking
-│       └── tools.py        # Agent tool definitions
+│       ├── tools.py        # Agent tool definitions
+│       ├── mcp_server.py   # MCP stdio server
+│       └── security/       # Sealed-store crypto, sharing, signing
 ├── tests/                  # Test suite
 ├── examples/               # Example scripts
-├── pyproject.toml         # Package metadata and tool config
-├── requirements.txt        # Dependencies
-└── setup.py               # Package setup (legacy)
+├── pyproject.toml          # Package metadata + tool config (dynamic version from src/axon/Cargo.toml)
+└── requirements.txt        # Optional pinned dependency list (`pip install -e ".[dev]"` is preferred)
 ```
 
 ## Coding Standards

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ retriever = AxonLlamaRetriever(brain=brain, top_k=5)
 nodes = retriever.retrieve("what does the project do?")  # list[NodeWithScore]
 ```
 
-Per-call overrides (e.g. force HyDE for one question): `retriever.with_overrides({"hyde": True}).invoke(query)`.
+Per-call overrides (e.g. force HyDE for one question): `retriever.with_overrides({"hyde": True}).invoke(query)`. From async code, `await retriever.aretrieve(query, hyde=True, top_k=8)` accepts the same flags as kwargs without rebuilding the retriever (v0.4.1).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,14 @@
 
 ## Supported Versions
 
-Currently supported versions:
+Security fixes are applied to the latest minor release line on PyPI (`axon-rag`).
+Older releases do not receive backports — upgrade to the current line before
+filing a security report.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.9.x   | :white_check_mark: |
-| < 0.9   | :x:                |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/ADMIN_REFERENCE.md
+++ b/docs/ADMIN_REFERENCE.md
@@ -320,7 +320,7 @@ axon> Compare @report.pdf with @notes.docx
 
 **73 endpoints** across 12 route files. Base URL: `http://localhost:8000` (default).
 
-Interactive docs: `/docs` (Swagger UI), `/redoc`.
+Interactive docs: `/docs` (Swagger UI), `/redoc` — both branded with the Axon favicon. `/favicon.ico` redirects (302) to `/brand/axon-favicon.svg`; `/brand/*` is a static mount of `src/axon/brand/`. These paths (plus `/gui/`, `/health/live`, `/metrics`) bypass the optional `X-API-Key` middleware so browsers can fetch the docs UI without credentials.
 
 ### 4.1 Health
 
@@ -413,7 +413,7 @@ Interactive docs: `/docs` (Swagger UI), `/redoc`.
 | `GET` | `/store/status` | Show sealed-store init/unlock state and cipher suite |
 | `GET` | `/store/whoami` | Return current AxonStore identity and store path |
 | `POST` | `/share/generate` | Generate an HMAC-SHA256 read-only share key |
-| `POST` | `/share/redeem` | Mount a shared project (read-only) |
+| `POST` | `/share/redeem` | Mount a shared project (read-only). `share_string` is capped at 16 KB; oversized payloads return 422 before decode |
 | `POST` | `/share/revoke` | Revoke an outgoing share key |
 | `POST` | `/share/extend` | Extend the expiry of an existing share key |
 | `GET` | `/share/list` | List outgoing and incoming shares with revocation status |
@@ -427,6 +427,8 @@ Interactive docs: `/docs` (Swagger UI), `/redoc`.
 | `POST` | `/security/unlock` | Unlock the sealed-store for sealed-project operations |
 | `POST` | `/security/lock` | Lock the sealed-store (clear in-process key cache) |
 | `POST` | `/security/change-passphrase` | Rotate the sealed-store passphrase |
+
+> **DoS guard.** Every passphrase body field (`/security/bootstrap`, `/security/unlock`, `/security/change-passphrase`) is capped at 4 KB (4096 chars). Oversized inputs return 422 before scrypt runs. `/security/unlock` rate-limits failed attempts per client IP (honours `X-Forwarded-For` behind a reverse proxy).
 
 ### 4.7 Graph
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -3,7 +3,11 @@
 Full endpoint reference for the Axon FastAPI server (`axon-api`, default port 8000).
 
 For interactive exploration, open `http://localhost:8000/docs` (Swagger UI) or
-`http://localhost:8000/redoc` after starting the server.
+`http://localhost:8000/redoc` after starting the server. Both pages serve a
+branded favicon and wordmark from `/brand/*` (static mount of
+`src/axon/brand/`); `/favicon.ico` redirects (302) to `/brand/axon-favicon.svg`.
+These auxiliary paths bypass the X-API-Key middleware (`/brand/`, `/gui/`,
+`/health/live`, `/metrics`) and are intentionally excluded from the schema.
 
 > Every endpoint below is also reachable under `/v1/...` (every router is dual-mounted at the root and the `/v1` prefix). The `/v1` mount is the recommended path for clients that pin to a major API version.
 
@@ -422,6 +426,8 @@ Requires the `[sealed]` extra (already bundled in `[starter]`).
 | `POST` | `/security/keyring-mode` | **v0.4.0 Item 2** — change DEK storage mode at runtime. Body `{"mode": "persistent"\|"session"\|"never"}`. 422 on invalid mode. Caveat: previously stored secrets are NOT migrated. For permanent change, set `security.keyring_mode` in config.yaml and restart. `GET /security/status` now also returns `keyring_mode` + `session_cache_size`. |
 | `POST` | `/security/wipe-sealed-cache` | **v0.4.0 Item 3** — manually wipe the active sealed-project plaintext cache. Returns `{wiped: bool}` (false when no cache or no brain). Idempotent. Cache re-materialises on next sealed-project query. Pair with `security.seal_cache_ephemeral` for per-query auto-wipe. |
 
+> **DoS guard:** `/security/bootstrap`, `/security/unlock`, and `/security/change-passphrase` cap each passphrase field at 4 KB (4096 chars). Oversized inputs return 422 before scrypt runs, so a malicious caller cannot trigger gigabyte scrypt work on the wrong-passphrase path. `/security/unlock` rate-limits failed attempts per client IP (honours `X-Forwarded-For` behind a reverse proxy).
+
 > Sealed-mount admin routes (`/project/seal`, `/project/rotate-keys`) live in the **Projects** section but require an unlocked store — call `/security/unlock` first if your shell or process restarted. See [SHARING.md](SHARING.md) for the full owner/grantee flow.
 
 ---
@@ -462,7 +468,9 @@ Response carries `key_id` (`sk_` for plaintext, `ssk_` for sealed), `share_strin
 **`POST /share/redeem` body:**
 ```json
 {
-  "share_string": "axon-share:v1:..."  // required — full share string from /share/generate
+  "share_string": "axon-share:v1:..."  // required — full share string from /share/generate.
+                                       // Capped at 16 KB (16384 chars); larger payloads return 422 before any
+                                       // base64-decode or JSON-parse work happens.
 }
 ```
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -28,34 +28,35 @@ python -m pytest -k test_name --no-cov                # match by name
 
 > VS Code extension e2e tests (`tests/e2e/test_vscode_extension_*.py`) require a live VS Code instance. Exclude them with `-m "not extension"` if running headlessly. The pre-commit hook does this automatically.
 
-#### Pre-commit pytest (testmon-accelerated)
+#### Pre-commit pytest (scope-aware selector)
 
-The pre-commit pytest hook uses [pytest-testmon](https://testmon.org/) to run only tests whose dependent code changed since the last green run. Cache lives in `.testmondata` (gitignored) and is per-developer.
+The pre-commit pytest hook (`scripts/precommit_pytest_scoped.py`, wired in
+`.pre-commit-config.yaml`) maps each staged file to a small, predictable set of
+test files via path-prefix rules — e.g. `axon/security/*` → sealed-share tests,
+`axon/api_routes/*` → API tests. This replaced the prior `pytest-testmon` hook
+in v0.4.0; testmon's transitive-coverage analysis pulled in essentially the
+whole 4500-test suite when foundational modules (e.g. `axon/security/share.py`)
+changed — a 30+ minute commit on every source edit.
 
 | Commit shape | Approx. local hook time |
 |---|---|
-| First commit on a fresh clone (cache empty) | ~45 min — populates the cache |
-| Doc-only commit | ~30 s |
-| Single-source-file edit | ~1–3 min |
-| Edit to a widely-imported module (e.g. `cli.py`, `config.py`) | ~5–10 min |
-| Branch hop / cross-cutting refactor | testmon may rebuild → ~45 min once, then back to fast |
+| Doc / HTML / SVG / Markdown / scripts-only commit | hook skipped entirely (trigger regex excludes them) |
+| Single edit under `axon/security/*` | seconds — runs sealed-share tests only |
+| Single edit under `axon/api_routes/*` | seconds — runs API tests only |
+| Edit to a widely-imported module (e.g. `cli.py`, `config.py`) | ~1–5 min — broader subset |
+| Cross-cutting refactor touching many areas | longer — union of matched subsets |
 
-**Forcing a full run** (when testmon's selection feels wrong):
-
-```bash
-rm .testmondata .testmondata-journal      # nuke the cache
-# next commit's hook does a full rebuild
-```
-
-Or run pytest manually without `--testmon`:
+**Forcing a full run** (when the scoped selector feels too narrow):
 
 ```bash
-python -m pytest tests/ --no-cov
+python -m pytest tests/ --no-cov          # full suite, ignores the hook entirely
 ```
 
-**CI is unaffected** — `.github/workflows/ci.yml` runs the full suite on every push. testmon is purely a local-dev accelerator (fresh runners have no cache).
+The path-prefix mapping is heuristic; CI runs the full suite on every push as
+the safety net, so a too-narrow local subset never lands on `main` unchecked.
 
-**Editable install required.** Pre-commit invokes the host Python's pytest, so `pytest-testmon` must be installed in the same env:
+**Editable install required.** Pre-commit invokes the host Python's pytest, so
+the dev dependencies must be installed in the same env:
 
 ```bash
 pip install -e ".[dev]"


### PR DESCRIPTION
## Summary

Follow-up audit after the 10 parallel codebase-audit PRs (#122–#131) merged to main on 2026-05-19. Scope was docs only — no source changes. Eight factual / staleness fixes across 7 files.

## Findings & fixes

| # | File:line | What was wrong | What it now reads |
|---|---|---|---|
| 1 | `SECURITY.md:7-12` | Supported Versions table claimed 0.9.x supported / <0.9 unsupported (current shipped version is 0.4.1) | `0.4.x` supported / `<0.4` unsupported + one-line backport policy |
| 2 | `CHANGELOG.md:98-100` | Duplicate `## [0.4.0] - 2026-05-04` header split the 0.4.0 release into two siblings (PR I + Items 1-4 above, TTL-gated sealed shares below) | Single 0.4.0 section; the duplicate `---` + header removed |
| 3 | `CHANGELOG.md:184` (historical v0.3.2) | Linked to anchor `#pre-commit-pytest-testmon-accelerated` that no longer exists | Link redirected to `#pre-commit-pytest-scope-aware-selector`; added "superseded by …" note. Descriptive text kept verbatim per the historical-attribution convention. |
| 4 | `CONTRIBUTING.md:43` + `:74-89` | Claimed pre-commit hook uses `pytest-testmon`; v0.4.0 replaced it with `scripts/precommit_pytest_scoped.py`. Also project-structure tree listed nonexistent `setup.py` and missed `api_routes/`, `mcp_server.py`, `security/`. | Rewrote the note as "scope-aware". Updated tree to match `ls src/axon`; dropped the `setup.py` legacy mention. |
| 5 | `docs/DEVELOPMENT.md:31-62` | Same testmon mismatch — full section described the old hook | Full rewrite: new heading "Pre-commit pytest (scope-aware selector)" + updated timing table + simpler force-full-run command |
| 6 | `docs/API_REFERENCE.md:425-429` + `docs/ADMIN_REFERENCE.md:431` | PR #124 added caller-visible DoS guards (share_string ≤ 16 KB, passphrase ≤ 4 KB) — undocumented | Added a "DoS guard" callout next to the `/share/redeem` and `/security/*` endpoints describing the 422 behaviour and the `X-Forwarded-For`-aware rate limiter on `/security/unlock` |
| 7 | `docs/API_REFERENCE.md:5-11` + `docs/ADMIN_REFERENCE.md:323` | PR #126 added branded `/docs`, `/redoc`, `/favicon.ico`, `/brand/*` routes; the auth-bypass prefix list grew — undocumented | One-liner under each "Interactive docs" intro noting the static mount, the 302 redirect, and the auth-bypass prefix list so operators know not to block them at a reverse proxy |
| 8 | `README.md:251` | LangChain section documented only `with_overrides({...}).invoke(query)`; PR #121 (v0.4.1) added `aretrieve(query, **overrides)` as a first-class async-with-overrides API | Extended the per-call-overrides sentence to mention `aretrieve(query, hyde=True, top_k=8)` for async callers |

## Surface-count audit

Verified against current `main`:
- **51 MCP tools** (`@mcp.tool()` decorators in `src/axon/mcp_server.py`) — matches `README.md`, `docs/MCP_TOOLS.md`, `docs/SETUP.md`, `docs/ADMIN_REFERENCE.md`
- **73 REST endpoints** (74 `@router.{verb}` minus the one docstring example in `_rate_limit.py`) — matches `README.md`, `docs/ADMIN_REFERENCE.md`, `docs/DEVELOPMENT.md`
- **39 VS Code LM tools** (`languageModelTools` array length in `integrations/vscode-axon/package.json`) — matches `README.md`, `docs/SETUP.md`
- **8 LLM providers** in `Literal[...]` at `config.py:330-332`

No drift in any of the counts.

## What I did NOT change
- `CLAUDE.md` (root): removed from the repo at commit `21ca913`; lives only in the user's local copy. Out of scope for a tracked PR.
- Architecture / roadmap docs under `docs/architecture/`: historical roadmap content; intentional verbatim historical attribution.
- Source code under `src/`: out of scope per the audit brief.

## Test plan

- [x] `python -m pytest tests/test_lint.py -v --no-cov` — passes (ruff + black + mypy, 3/3)
- [x] Grep sweep for `testmon`, `0.9.x`, `setup.py` in docs — no remaining stale refs
- [x] Verified surface counts (51 / 73 / 39 / 8) against current main
- [x] Verified all touched markdown tables / blockquote placements still render correctly (DoS-guard callouts moved below table boundaries on first pass)
- [ ] Ensure Copilot review and CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)